### PR TITLE
Fix navigation to /discover after successful publish

### DIFF
--- a/app/upload/[address]/UploadPageClient.tsx
+++ b/app/upload/[address]/UploadPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient, useSignerStatus } from "@account-kit/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { isAddress } from "viem";
 import { logger } from '@/lib/utils/logger';
@@ -19,29 +19,28 @@ interface UploadPageClientProps {
  */
 export function UploadPageClient({ urlAddress, children }: UploadPageClientProps) {
   const router = useRouter();
-  const { address: scaAddress } = useSmartAccountClient({});
+  const { address: scaAddress, isLoadingClient } = useSmartAccountClient({});
   const { account } = useModularAccount();
   const user = useUser();
+  const { isInitializing, isAuthenticating } = useSignerStatus();
   const eoaAddress = user?.address;
 
   // Use the Smart Account address from useModularAccount as primary source
   const smartAccountAddress = account?.address || scaAddress;
 
   useEffect(() => {
-    // Normalize addresses for comparison (case-insensitive)
-    const normalizeAddress = (addr: string | undefined) => 
-      addr ? addr.toLowerCase() : null;
-
-    const urlAddr = normalizeAddress(urlAddress);
-    const smartAddr = normalizeAddress(smartAccountAddress);
-    const eoaAddr = normalizeAddress(eoaAddress);
+    // Block redirect while account state is transient. Smart account state can
+    // briefly drop to undefined during background work (e.g. content-coin deploy
+    // right after publish), and a redirect here would cancel an in-flight
+    // router.push to /discover.
+    if (isLoadingClient || isInitializing || isAuthenticating) return;
 
     // Validate URL address format
     if (urlAddress && !isAddress(urlAddress)) {
       logger.warn("Invalid address format in URL, redirecting...");
-      if (smartAddr) {
+      if (smartAccountAddress) {
         router.replace(`/upload/${smartAccountAddress}`);
-      } else if (eoaAddr) {
+      } else if (eoaAddress) {
         router.replace(`/upload/${eoaAddress}`);
       } else {
         router.replace("/upload");
@@ -49,28 +48,34 @@ export function UploadPageClient({ urlAddress, children }: UploadPageClientProps
       return;
     }
 
+    const normalizeAddress = (addr: string | undefined) =>
+      addr ? addr.toLowerCase() : null;
+
+    const urlAddr = normalizeAddress(urlAddress);
+    const smartAddr = normalizeAddress(smartAccountAddress);
+    const eoaAddr = normalizeAddress(eoaAddress);
+
     // If we have a smart account address, use that as the primary address
     if (smartAddr) {
       if (urlAddr !== smartAddr) {
         logger.debug("URL address mismatch, redirecting to Smart Account upload:", smartAccountAddress);
         router.replace(`/upload/${smartAccountAddress}`);
-        return;
       }
-    } 
+      return;
+    }
+
     // Fallback to EOA address if no smart account
-    else if (eoaAddr) {
+    if (eoaAddr) {
       if (urlAddr !== eoaAddr) {
         logger.debug("URL address mismatch, redirecting to EOA upload:", eoaAddress);
         router.replace(`/upload/${eoaAddress}`);
-        return;
       }
-    }
-    // If no address is available, redirect to base upload page
-    else {
-      router.replace("/upload");
       return;
     }
-  }, [urlAddress, smartAccountAddress, eoaAddress, router, account?.address, scaAddress]);
+
+    // Truly disconnected (no smart account, no EOA, not loading) — bounce to base upload
+    router.replace("/upload");
+  }, [urlAddress, smartAccountAddress, eoaAddress, isLoadingClient, isInitializing, isAuthenticating, router]);
 
   return <>{children}</>;
 }

--- a/components/Videos/Upload/index.tsx
+++ b/components/Videos/Upload/index.tsx
@@ -304,7 +304,7 @@ const HookMultiStepForm = () => {
 
             // Navigate to Discover so the user can see their published video
             logger.debug("Redirecting to discover page...");
-            router.push("/discover");
+            router.replace("/discover");
 
             // --- STORY PROTOCOL IP REGISTRATION ---
             if (data.storyConfig?.registerIP && address) {
@@ -458,25 +458,18 @@ const HookMultiStepForm = () => {
             }
 
             // --- AUTO DEPLOY CONTENT COIN ---
+            // Fire-and-forget so navigation to /discover isn't blocked by the deploy transaction.
+            // handleUploadSuccess swallows its own errors; .catch is a safety net.
             if (finalMeTokenId && address && metadata?.ticker) {
               toast.info("Deploying Content Coin Market...");
-              try {
-                // 15s timeout for content coin
-                await withTimeout(
-                  handleUploadSuccess(
-                    metadata.title,
-                    metadata.ticker,
-                    finalMeTokenId,
-                    address
-                  ),
-                  15000
-                );
-                // The hook handles its own toasts usually, but we ensure we don't hang
-                // Note: handleUploadSuccess logs success
-              } catch (ccError) {
+              handleUploadSuccess(
+                metadata.title,
+                metadata.ticker,
+                finalMeTokenId,
+                address
+              ).catch((ccError) => {
                 logger.error("Content Coin deployment error:", ccError);
-                // Swallowed; user already redirected to Discover
-              }
+              });
             }
           }}
         />

--- a/components/Videos/Upload/index.tsx
+++ b/components/Videos/Upload/index.tsx
@@ -466,7 +466,8 @@ const HookMultiStepForm = () => {
                 metadata.title,
                 metadata.ticker,
                 finalMeTokenId,
-                address
+                address,
+                livepeerAsset.playbackId
               ).catch((ccError) => {
                 logger.error("Content Coin deployment error:", ccError);
               });


### PR DESCRIPTION
## Summary
- Publishing a video appeared successful (DB updated, success toast shown) but the page never navigated to `/discover`.
- Root cause was a race between the publish handler and the upload page's auth guard. The Content Coin deploy was `await`ed for up to 15s after `router.push`, keeping the upload component mounted while smart-account state churned. `UploadPageClient`'s `useEffect` re-fired on those transient states and called `router.replace` back to `/upload/` (or `/upload`), canceling the in-flight `/discover` navigation.

## Changes
- **`components/Videos/Upload/index.tsx`** — Content Coin deploy is now fire-and-forget (no `await`, no `withTimeout`), and the redirect uses `router.replace("/discover")` so the back button doesn't return to a completed publish flow. Also now passes `livepeerAsset.playbackId` to `handleUploadSuccess` so the background deploy persists the new Content Coin ID to the video row's `attributes.content_coin_id` (addresses gemini-code-assist review).
- **`app/upload/[address]/UploadPageClient.tsx`** — Effect now reads `isLoadingClient` from `useSmartAccountClient` and `isInitializing` / `isAuthenticating` from `useSignerStatus`, and bails early during transient states. URL-format validation and address-mismatch redirect logic preserved for stable states.

## Test plan
- [ ] Publish a video end-to-end and confirm the page lands on `/discover` immediately after the success toast.
- [ ] Confirm the "Deploying Content Coin Market…" toast still appears and the deploy completes (or fails silently) in the background after navigation.
- [ ] After the background deploy completes, query the video row and confirm `attributes.content_coin_id` is populated with the deployed Content Coin ID.
- [ ] Visit `/upload/` while logged in and confirm the address-mismatch redirect to your own upload page still works.
- [ ] Visit `/upload/not-an-address` and confirm the invalid-address redirect still works.
- [ ] Sign out and visit `/upload/` to confirm the disconnected user is bounced to `/upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)