### PR TITLE
Add viewer-created clips with derivative NFT minting

### DIFF
--- a/app/api/livepeer/clips/route.ts
+++ b/app/api/livepeer/clips/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { createClip } from "@/services/livepeer-clips";
+import { getStreamByPlaybackId } from "@/services/streams";
+import { serverLogger } from "@/lib/utils/logger";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const MAX_CLIP_SPAN_MS = 120_000;
+
+export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const rl = await rateLimiters.strict(request);
+  if (rl) return rl;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { playbackId, sessionId, startTime, endTime, name, clipperAddress } = body ?? {};
+
+  if (!playbackId || !sessionId || startTime == null || endTime == null || !clipperAddress) {
+    return NextResponse.json(
+      {
+        error: "Missing required fields",
+        hint: "playbackId, sessionId, startTime, endTime, clipperAddress are required",
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!ADDRESS_REGEX.test(clipperAddress)) {
+    return NextResponse.json({ error: "Invalid clipperAddress format" }, { status: 400 });
+  }
+
+  const start = Number(startTime);
+  const end = Number(endTime);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    return NextResponse.json(
+      { error: "startTime and endTime must be numbers with endTime > startTime" },
+      { status: 400 }
+    );
+  }
+
+  if (end - start > MAX_CLIP_SPAN_MS) {
+    return NextResponse.json(
+      { error: `Clip span must be ≤ ${MAX_CLIP_SPAN_MS / 1000} seconds` },
+      { status: 400 }
+    );
+  }
+
+  const stream = await getStreamByPlaybackId(playbackId);
+  if (!stream) {
+    return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+  }
+  if (stream.allow_clipping === false) {
+    return NextResponse.json(
+      { error: "The broadcaster has disabled clipping on this stream" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const result = await createClip({
+      playbackId,
+      sessionId,
+      startTime: start,
+      endTime: end,
+      name: typeof name === "string" ? name.slice(0, 120) : undefined,
+    });
+
+    if (result.error) {
+      return NextResponse.json({ error: result.error }, { status: 502 });
+    }
+
+    return NextResponse.json({
+      playbackUrl: result.playbackUrl,
+      assetId: result.assetId,
+      newPlaybackId: result.newPlaybackId,
+      parentPlaybackId: playbackId,
+      parentStoryIpId: stream.story_ip_id ?? null,
+      parentStoryLicenseTermsId: stream.story_license_terms_id ?? null,
+      parentCreatorId: stream.creator_id ?? null,
+      parentCommercialRevShare: stream.story_commercial_rev_share ?? null,
+    });
+  } catch (e: any) {
+    serverLogger.error("Clip creation failed:", e);
+    return NextResponse.json(
+      { error: e?.message || "Failed to create clip" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/story/mint-derivative/route.ts
+++ b/app/api/story/mint-derivative/route.ts
@@ -1,0 +1,179 @@
+/**
+ * Mint a viewer-created clip as a Story Protocol derivative IP of the parent livestream.
+ * The viewer (clipper) owns the resulting NFT; the broadcaster receives royalties
+ * via the parent's attached PIL license terms.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { createStoryClient } from "@/lib/sdk/story/client";
+import { getOrCreateCreatorCollection } from "@/lib/sdk/story/collection-service";
+import { mintAndRegisterDerivative } from "@/lib/sdk/story/spg-service";
+import { getVideoAssetById, updateVideoAsset } from "@/services/video-assets";
+import { getStreamByPlaybackId } from "@/services/streams";
+import { groveService } from "@/lib/sdk/grove/service";
+import type { Address } from "viem";
+import { serverLogger } from "@/lib/utils/logger";
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.strict(request);
+  if (rl) return rl;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { clipVideoAssetId, recipient } = body ?? {};
+  if (!clipVideoAssetId || !recipient) {
+    return NextResponse.json(
+      { error: "Missing required fields", hint: "clipVideoAssetId, recipient are required" },
+      { status: 400 }
+    );
+  }
+  if (!ADDRESS_REGEX.test(recipient)) {
+    return NextResponse.json({ error: "Invalid recipient format" }, { status: 400 });
+  }
+
+  const clip = await getVideoAssetById(Number(clipVideoAssetId));
+  if (!clip) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+  }
+  if (clip.source_type !== "Clip") {
+    return NextResponse.json({ error: "Video asset is not a clip" }, { status: 400 });
+  }
+  if (clip.is_minted) {
+    return NextResponse.json({ error: "Clip is already minted" }, { status: 409 });
+  }
+  if (
+    clip.clipper_address &&
+    clip.clipper_address.toLowerCase() !== recipient.toLowerCase()
+  ) {
+    return NextResponse.json(
+      { error: "Only the clipper can mint their own clip" },
+      { status: 403 }
+    );
+  }
+
+  const parentStoryIpId = clip.parent_story_ip_id;
+  const parentPlaybackId = clip.parent_playback_id;
+  if (!parentStoryIpId || !parentPlaybackId) {
+    return NextResponse.json(
+      {
+        error: "Parent stream is not registered as Story IP",
+        hint: "The broadcaster must register this stream as IP before derivative clips can be minted.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const parentStream = await getStreamByPlaybackId(parentPlaybackId);
+  const parentLicenseTermsId =
+    parentStream?.story_license_terms_id ?? clip.story_license_terms_id ?? null;
+  if (!parentLicenseTermsId) {
+    return NextResponse.json(
+      {
+        error: "Parent stream has no license terms attached",
+        hint: "The broadcaster must attach PIL license terms to the stream before derivative clips can be minted.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const privateKey = process.env.STORY_PROTOCOL_PRIVATE_KEY;
+  if (!privateKey) {
+    return NextResponse.json(
+      { error: "Story Protocol not configured", hint: "STORY_PROTOCOL_PRIVATE_KEY required" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const { privateKeyToAccount } = await import("viem/accounts");
+    const fundingAddress = privateKeyToAccount(privateKey as `0x${string}`).address as Address;
+
+    const clipPlaybackUrl = clip.playback_id
+      ? `https://lvpr.tv/?v=${clip.playback_id}`
+      : null;
+
+    const metadata = {
+      name: clip.title || `Clip of ${parentPlaybackId.slice(0, 8)}`,
+      description:
+        clip.description ||
+        `Viewer-created clip from livestream ${parentPlaybackId} (${clip.clip_start_ms}–${clip.clip_end_ms} ms).`,
+      image: clip.thumbnail_url || undefined,
+      animation_url: clipPlaybackUrl || undefined,
+      attributes: [
+        { trait_type: "source_type", value: "Clip" },
+        { trait_type: "parent_playback_id", value: parentPlaybackId },
+        { trait_type: "parent_ip_id", value: parentStoryIpId },
+        { trait_type: "clip_start_ms", value: clip.clip_start_ms },
+        { trait_type: "clip_end_ms", value: clip.clip_end_ms },
+        { trait_type: "clipper", value: clip.clipper_address || recipient },
+      ],
+    };
+
+    const metadataUpload = await groveService.uploadJson(metadata);
+    if (!metadataUpload.success || !metadataUpload.url) {
+      return NextResponse.json(
+        { error: metadataUpload.error || "Failed to upload clip metadata" },
+        { status: 502 }
+      );
+    }
+
+    const client = createStoryClient(fundingAddress, privateKey);
+    const clipperAddress = (clip.clipper_address || recipient) as Address;
+    const collectionAddress = await getOrCreateCreatorCollection(
+      client,
+      clipperAddress,
+      "CRTV Clips",
+      "CLIP"
+    );
+
+    const result = await mintAndRegisterDerivative(client, {
+      collectionAddress,
+      recipient: recipient as Address,
+      parentIpIds: [parentStoryIpId as Address],
+      licenseTermsIds: [parentLicenseTermsId],
+      metadataURI: metadataUpload.url,
+      allowDuplicates: true,
+    });
+
+    await updateVideoAsset(clip.id, {
+      token_id: result.tokenId,
+      contract_address: collectionAddress,
+      story_ip_registered: true,
+      story_ip_id: result.ipId,
+      story_ip_registration_tx: result.txHash,
+      story_ip_registered_at: new Date(),
+      story_license_terms_id: parentLicenseTermsId,
+      metadata_uri: metadataUpload.url,
+      status: "minted",
+    });
+
+    return NextResponse.json({
+      success: true,
+      ipId: result.ipId,
+      tokenId: result.tokenId,
+      txHash: result.txHash,
+      collectionAddress,
+      metadataURI: metadataUpload.url,
+    });
+  } catch (error) {
+    serverLogger.error("Clip derivative mint failed:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to mint clip as derivative",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/story/register-stream/route.ts
+++ b/app/api/story/register-stream/route.ts
@@ -1,0 +1,159 @@
+/**
+ * Register a broadcaster's livestream as a Story Protocol IP Asset and
+ * attach PIL commercial-remix terms so that viewer-created clip NFTs can be
+ * minted as derivative IPs with automatic royalty routing to the broadcaster.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { PILFlavor } from "@story-protocol/core-sdk";
+import { parseEther, type Address } from "viem";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { createStoryClient } from "@/lib/sdk/story/client";
+import { getOrCreateCreatorCollection } from "@/lib/sdk/story/collection-service";
+import { mintAndRegisterIpAndAttachPilTerms } from "@/lib/sdk/story/spg-service";
+import { getStreamByCreator, updateStreamStoryIp } from "@/services/streams";
+import { groveService } from "@/lib/sdk/grove/service";
+import { WIP_TOKEN_ADDRESS } from "@/lib/sdk/story/constants";
+import { serverLogger } from "@/lib/utils/logger";
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const DEFAULT_REV_SHARE = 10;
+
+export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.strict(request);
+  if (rl) return rl;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { creatorAddress, commercialRevShare, streamName, thumbnailUrl } = body ?? {};
+  if (!creatorAddress) {
+    return NextResponse.json({ error: "Missing creatorAddress" }, { status: 400 });
+  }
+  if (!ADDRESS_REGEX.test(creatorAddress)) {
+    return NextResponse.json({ error: "Invalid creatorAddress format" }, { status: 400 });
+  }
+
+  const revShare = commercialRevShare == null ? DEFAULT_REV_SHARE : Number(commercialRevShare);
+  if (!Number.isFinite(revShare) || revShare < 0 || revShare > 100) {
+    return NextResponse.json(
+      { error: "commercialRevShare must be between 0 and 100" },
+      { status: 400 }
+    );
+  }
+
+  const stream = await getStreamByCreator(creatorAddress);
+  if (!stream) {
+    return NextResponse.json({ error: "Stream not found for creator" }, { status: 404 });
+  }
+  if (stream.story_ip_id) {
+    return NextResponse.json(
+      {
+        error: "Stream is already registered as IP",
+        ipId: stream.story_ip_id,
+        licenseTermsId: stream.story_license_terms_id,
+      },
+      { status: 409 }
+    );
+  }
+
+  const privateKey = process.env.STORY_PROTOCOL_PRIVATE_KEY;
+  if (!privateKey) {
+    return NextResponse.json(
+      { error: "Story Protocol not configured", hint: "STORY_PROTOCOL_PRIVATE_KEY required" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const { privateKeyToAccount } = await import("viem/accounts");
+    const fundingAddress = privateKeyToAccount(privateKey as `0x${string}`).address as Address;
+
+    const streamPlaybackUrl = `https://lvpr.tv/?v=${stream.playback_id}`;
+    const resolvedName =
+      (typeof streamName === "string" && streamName.trim()) ||
+      stream.name ||
+      `Livestream ${stream.playback_id.slice(0, 8)}`;
+
+    const metadata = {
+      name: resolvedName,
+      description: `Livestream channel by creator ${creatorAddress}. Viewers can create and mint derivative clip NFTs.`,
+      image: thumbnailUrl || stream.thumbnail_url || undefined,
+      animation_url: streamPlaybackUrl,
+      attributes: [
+        { trait_type: "source_type", value: "Livestream" },
+        { trait_type: "playback_id", value: stream.playback_id },
+        { trait_type: "creator", value: creatorAddress },
+        { trait_type: "commercial_rev_share", value: revShare },
+      ],
+    };
+
+    const metadataUpload = await groveService.uploadJson(metadata);
+    if (!metadataUpload.success || !metadataUpload.url) {
+      return NextResponse.json(
+        { error: metadataUpload.error || "Failed to upload stream metadata" },
+        { status: 502 }
+      );
+    }
+
+    const client = createStoryClient(fundingAddress, privateKey);
+    const collectionAddress = await getOrCreateCreatorCollection(
+      client,
+      creatorAddress as Address,
+      `${resolvedName} Streams`,
+      "STREAM"
+    );
+
+    const result = await mintAndRegisterIpAndAttachPilTerms(client, {
+      collectionAddress,
+      recipient: creatorAddress as Address,
+      metadataURI: metadataUpload.url,
+      allowDuplicates: true,
+      licenseTermsData: [
+        {
+          terms: PILFlavor.commercialRemix({
+            commercialRevShare: revShare,
+            defaultMintingFee: parseEther("0"),
+            currency: WIP_TOKEN_ADDRESS,
+          }),
+        },
+      ],
+    });
+
+    const licenseTermsId = result.licenseTermsIds?.[0] ?? null;
+
+    await updateStreamStoryIp(creatorAddress, {
+      story_ip_id: result.ipId,
+      story_license_terms_id: licenseTermsId,
+      story_ip_registration_tx: result.txHash,
+      story_commercial_rev_share: revShare,
+    });
+
+    return NextResponse.json({
+      success: true,
+      ipId: result.ipId,
+      tokenId: result.tokenId,
+      licenseTermsId,
+      txHash: result.txHash,
+      collectionAddress,
+      metadataURI: metadataUpload.url,
+      commercialRevShare: revShare,
+    });
+  } catch (error) {
+    serverLogger.error("Register stream as IP failed:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to register stream as IP",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/video-assets/clips/by-parent/[playbackId]/route.ts
+++ b/app/api/video-assets/clips/by-parent/[playbackId]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listClipsByParentPlaybackId } from "@/services/video-assets";
+import { serverLogger } from "@/lib/utils/logger";
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ playbackId: string }> }
+) {
+  const { playbackId } = await context.params;
+  if (!playbackId) {
+    return NextResponse.json({ error: "playbackId is required" }, { status: 400 });
+  }
+
+  try {
+    const clips = await listClipsByParentPlaybackId(playbackId);
+    return NextResponse.json({ clips });
+  } catch (e: any) {
+    serverLogger.error("Failed to list clips:", e);
+    return NextResponse.json(
+      { error: e?.message || "Failed to list clips" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/video-assets/clips/route.ts
+++ b/app/api/video-assets/clips/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { createClipVideoAsset } from "@/services/video-assets";
+import { getClipThumbnailUrl } from "@/services/livepeer-clips";
+import { getStreamByPlaybackId } from "@/services/streams";
+import { serverLogger } from "@/lib/utils/logger";
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  const rl = await rateLimiters.strict(request);
+  if (rl) return rl;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const {
+    assetId,
+    playbackId,
+    playbackUrl,
+    name,
+    parentPlaybackId,
+    parentStoryIpId,
+    clipStartMs,
+    clipEndMs,
+    clipperAddress,
+  } = body ?? {};
+
+  if (!assetId || !playbackId || !parentPlaybackId || clipStartMs == null || clipEndMs == null || !clipperAddress) {
+    return NextResponse.json(
+      {
+        error: "Missing required fields",
+        hint: "assetId, playbackId, parentPlaybackId, clipStartMs, clipEndMs, clipperAddress are required",
+      },
+      { status: 400 }
+    );
+  }
+  if (!ADDRESS_REGEX.test(clipperAddress)) {
+    return NextResponse.json({ error: "Invalid clipperAddress format" }, { status: 400 });
+  }
+
+  try {
+    const [clipThumb, parentStream] = await Promise.all([
+      getClipThumbnailUrl(playbackId),
+      getStreamByPlaybackId(parentPlaybackId),
+    ]);
+    const resolvedThumbnail = clipThumb ?? parentStream?.thumbnail_url ?? null;
+
+    const row = await createClipVideoAsset({
+      assetId,
+      playbackId,
+      playbackUrl: playbackUrl ?? null,
+      thumbnailUrl: resolvedThumbnail,
+      name: name ?? null,
+      parentPlaybackId,
+      parentStoryIpId: parentStoryIpId ?? null,
+      clipStartMs: Number(clipStartMs),
+      clipEndMs: Number(clipEndMs),
+      clipperAddress,
+    });
+    return NextResponse.json({ clip: row });
+  } catch (e: any) {
+    serverLogger.error("Failed to persist clip video asset:", e);
+    return NextResponse.json(
+      { error: e?.message || "Failed to persist clip" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -26,7 +26,10 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { LivestreamThumbnail } from "@/components/Live/LivestreamThumbnail";
 import { StreamThumbnailUploader } from "@/components/Live/StreamThumbnailUploader";
+import { StreamIPRegistration } from "@/components/Live/StreamIPRegistration";
+import { CreatorClipsList } from "@/components/Live/CreatorClipsList";
 import { getThumbnailUrl } from "@/services/livepeer-thumbnails";
+import { Switch } from "@/components/ui/switch";
 import { logger } from '@/lib/utils/logger';
 
 
@@ -48,6 +51,12 @@ export default function LivePage() {
   const [streamCreateError, setStreamCreateError] = useState<string | null>(
     null
   );
+  const [allowClipping, setAllowClipping] = useState(true);
+  const [isUpdatingClipPref, setIsUpdatingClipPref] = useState(false);
+  const [streamName, setStreamName] = useState<string | null>(null);
+  const [storyIpId, setStoryIpId] = useState<string | null>(null);
+  const [storyLicenseTermsId, setStoryLicenseTermsId] = useState<string | null>(null);
+  const [storyRevShare, setStoryRevShare] = useState<number | null>(null);
 
 
   // Fetch existing stream and multistream targets
@@ -64,6 +73,11 @@ export default function LivePage() {
           setStreamId(stream.stream_id);
           setPlaybackId(stream.playback_id);
           setThumbnailUrl(stream.thumbnail_url || null);
+          setAllowClipping(stream.allow_clipping ?? true);
+          setStreamName(stream.name ?? null);
+          setStoryIpId(stream.story_ip_id ?? null);
+          setStoryLicenseTermsId(stream.story_license_terms_id ?? null);
+          setStoryRevShare(stream.story_commercial_rev_share ?? null);
         }
 
         // 2. Fetch targets (only if we have a streamId, which we might have just set)
@@ -129,6 +143,21 @@ export default function LivePage() {
 
   function handleThumbnailUpdated(url: string) {
     setThumbnailUrl(url);
+  }
+
+  async function handleToggleClipping(next: boolean) {
+    if (!user?.address) return;
+    const previous = allowClipping;
+    setAllowClipping(next);
+    setIsUpdatingClipPref(true);
+    try {
+      await updateStream(user.address, { allow_clipping: next });
+    } catch (err) {
+      logger.error("Failed to update clipping preference:", err);
+      setAllowClipping(previous);
+    } finally {
+      setIsUpdatingClipPref(false);
+    }
   }
 
   async function handleCreateStream() {
@@ -314,6 +343,42 @@ export default function LivePage() {
               <>
                 <Broadcast streamKey={streamKey} streamId={streamId} creatorAddress={user.address} />
               </>
+            )}
+            {streamId && user?.address && (
+              <StreamIPRegistration
+                creatorAddress={user.address}
+                streamName={streamName}
+                thumbnailUrl={thumbnailUrl}
+                storyIpId={storyIpId}
+                licenseTermsId={storyLicenseTermsId}
+                commercialRevShare={storyRevShare}
+                onRegistered={({ ipId, licenseTermsId, commercialRevShare }) => {
+                  setStoryIpId(ipId);
+                  setStoryLicenseTermsId(licenseTermsId);
+                  setStoryRevShare(commercialRevShare);
+                }}
+              />
+            )}
+            {streamId && (
+              <div className="mt-4 border-t border-white/20 pt-3 max-w-[576px] mx-auto">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold">Allow viewer clipping</p>
+                    <p className="text-xs text-gray-400">
+                      Let viewers create short clips from your stream and mint them as NFTs.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={allowClipping}
+                    onCheckedChange={handleToggleClipping}
+                    disabled={isUpdatingClipPref}
+                    aria-label="Allow viewer clipping"
+                  />
+                </div>
+              </div>
+            )}
+            {playbackId && (
+              <CreatorClipsList playbackId={playbackId} />
             )}
             <div className="mt-4 border-t border-white/20 pt-3 max-w-[576px] mx-auto">
               <p className="mb-2 text-sm font-semibold">Multistream Targets</p>

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -296,6 +296,9 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
             <ClipCreator
               playbackId={playbackId}
               sessionId={sessionId}
+              allowClipping={streamData?.allow_clipping ?? true}
+              parentStoryIpId={streamData?.story_ip_id ?? storyIpId ?? null}
+              parentCommercialRevShare={streamData?.story_commercial_rev_share ?? null}
             />
           </div>
         )}

--- a/components/Live/ClipCreator.tsx
+++ b/components/Live/ClipCreator.tsx
@@ -1,104 +1,297 @@
 "use client";
-import { useState } from "react";
-import { createClip } from "@/services/livepeer-clips";
+import { useCallback, useState } from "react";
+import { useUser } from "@account-kit/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, Scissors, Settings2 } from "lucide-react";
 
-export function ClipCreator({ playbackId, sessionId }: ClipCreatorProps) {
-  const [name, setName] = useState("");
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
+interface ClipCreatorProps {
+  playbackId: string;
+  sessionId: string;
+  allowClipping?: boolean;
+  parentStoryIpId?: string | null;
+  parentCommercialRevShare?: number | null;
+}
+
+interface ClipState {
+  playbackUrl: string;
+  assetId: string;
+  newPlaybackId: string;
+  parentStoryIpId: string | null;
+  parentCommercialRevShare: number | null;
+  clipVideoAssetId?: number;
+}
+
+export function ClipCreator({
+  playbackId,
+  sessionId,
+  allowClipping = true,
+  parentStoryIpId,
+  parentCommercialRevShare,
+}: ClipCreatorProps) {
+  const user = useUser();
+  const clipperAddress = user?.address;
   const [isLoading, setIsLoading] = useState(false);
-  const [result, setResult] = useState<ClipResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [clip, setClip] = useState<ClipState | null>(null);
+  const [customOpen, setCustomOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [customStart, setCustomStart] = useState("");
+  const [customEnd, setCustomEnd] = useState("");
+  const [isMinting, setIsMinting] = useState(false);
+  const [mintResult, setMintResult] = useState<{ ipId: string; txHash: string } | null>(null);
 
-  async function handleCreateClip() {
-    setIsLoading(true);
-    setError(null);
-    setResult(null);
-    const start = Number(startTime);
-    const end = Number(endTime);
-    if (!playbackId || !sessionId || !start || !end || end <= start) {
-      setError(
-        "Please provide valid playbackId, sessionId, start, and end times."
-      );
-      setIsLoading(false);
+  const runClip = useCallback(
+    async (startMs: number, endMs: number) => {
+      if (!clipperAddress) {
+        setError("Connect your wallet to create clips");
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      setClip(null);
+      setMintResult(null);
+      try {
+        const res = await fetch("/api/livepeer/clips", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            playbackId,
+            sessionId,
+            startTime: startMs,
+            endTime: endMs,
+            name: name.trim() || undefined,
+            clipperAddress,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data?.error || `Clip failed (${res.status})`);
+          return;
+        }
+
+        const persistRes = await fetch("/api/video-assets/clips", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            assetId: data.assetId,
+            playbackId: data.newPlaybackId,
+            playbackUrl: data.playbackUrl,
+            name: name.trim() || undefined,
+            parentPlaybackId: data.parentPlaybackId,
+            parentStoryIpId: data.parentStoryIpId,
+            clipStartMs: startMs,
+            clipEndMs: endMs,
+            clipperAddress,
+          }),
+        });
+        const persist = await persistRes.json().catch(() => ({}));
+
+        setClip({
+          playbackUrl: data.playbackUrl,
+          assetId: data.assetId,
+          newPlaybackId: data.newPlaybackId,
+          parentStoryIpId: data.parentStoryIpId ?? parentStoryIpId ?? null,
+          parentCommercialRevShare:
+            data.parentCommercialRevShare ?? parentCommercialRevShare ?? null,
+          clipVideoAssetId: persist?.clip?.id,
+        });
+      } catch (e: any) {
+        setError(e?.message || "Failed to create clip");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [clipperAddress, name, parentCommercialRevShare, parentStoryIpId, playbackId, sessionId]
+  );
+
+  const handleQuickClip = (durationSec: number) => {
+    const now = Date.now();
+    runClip(now - durationSec * 1000, now);
+  };
+
+  const handleCustomClip = () => {
+    const start = Number(customStart);
+    const end = Number(customEnd);
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+      setError("Enter valid start/end in ms with end > start");
       return;
     }
-    const res = await createClip({
-      playbackId,
-      sessionId,
-      startTime: start,
-      endTime: end,
-      name,
-    });
-    if (res.error) setError(res.error);
-    else setResult(res);
-    setIsLoading(false);
+    runClip(start, end);
+  };
+
+  const handleMint = async () => {
+    if (!clip?.clipVideoAssetId || !clipperAddress) return;
+    setIsMinting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/story/mint-derivative", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clipVideoAssetId: clip.clipVideoAssetId,
+          recipient: clipperAddress,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data?.error || `Mint failed (${res.status})`);
+        return;
+      }
+      setMintResult({ ipId: data.ipId, txHash: data.txHash });
+    } catch (e: any) {
+      setError(e?.message || "Failed to mint clip");
+    } finally {
+      setIsMinting(false);
+    }
+  };
+
+  if (!allowClipping) {
+    return (
+      <div className="w-full max-w-3xl mx-auto my-4 px-2">
+        <Alert>
+          <AlertTitle>Clipping disabled</AlertTitle>
+          <AlertDescription>
+            The broadcaster has disabled viewer clips on this stream.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
   }
 
+  if (!clipperAddress) {
+    return (
+      <div className="w-full max-w-3xl mx-auto my-4 px-2">
+        <Alert>
+          <AlertTitle>Connect to clip</AlertTitle>
+          <AlertDescription>
+            Connect your wallet to create clips from this stream.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const canMint = !!clip?.parentStoryIpId && !!clip?.clipVideoAssetId;
+
   return (
-    <div className="w-full max-w-3xl mx-auto my-4 px-2">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+    <div className="w-full max-w-3xl mx-auto my-4 px-2 space-y-3">
+      <div className="flex items-center gap-2">
+        <Scissors className="h-4 w-4" />
+        <span className="text-sm font-medium">Create a clip</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
         <Input
-          placeholder="Clip name"
+          placeholder="Clip name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="flex-1"
+          className="flex-1 min-w-[200px]"
+          maxLength={120}
         />
-        <Input
-          placeholder="Start (ms)"
-          value={startTime}
-          onChange={(e) => setStartTime(e.target.value)}
-          type="number"
-          className="flex-1"
-        />
-        <Input
-          placeholder="End (ms)"
-          value={endTime}
-          onChange={(e) => setEndTime(e.target.value)}
-          type="number"
-          className="flex-1"
-        />
+        <Button onClick={() => handleQuickClip(15)} disabled={isLoading} variant="outline">
+          Last 15s
+        </Button>
+        <Button onClick={() => handleQuickClip(30)} disabled={isLoading} variant="outline">
+          Last 30s
+        </Button>
+        <Button onClick={() => handleQuickClip(60)} disabled={isLoading} variant="outline">
+          Last 60s
+        </Button>
         <Button
-          onClick={handleCreateClip}
-          disabled={isLoading}
-          className="w-full sm:w-auto"
+          onClick={() => setCustomOpen((v) => !v)}
+          variant="ghost"
+          size="icon"
+          aria-label="Toggle custom range"
         >
-          Create Clip
+          <Settings2 className="h-4 w-4" />
         </Button>
       </div>
+
+      {customOpen && (
+        <div className="flex flex-col sm:flex-row gap-2 border rounded-md p-3 bg-muted/30">
+          <Input
+            placeholder="Start (epoch ms)"
+            value={customStart}
+            onChange={(e) => setCustomStart(e.target.value)}
+            type="number"
+            className="flex-1"
+          />
+          <Input
+            placeholder="End (epoch ms)"
+            value={customEnd}
+            onChange={(e) => setCustomEnd(e.target.value)}
+            type="number"
+            className="flex-1"
+          />
+          <Button onClick={handleCustomClip} disabled={isLoading}>
+            Clip range
+          </Button>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Creating clip...
+        </div>
+      )}
+
       {error && (
-        <Alert variant="destructive" className="mt-2">
+        <Alert variant="destructive">
           <AlertTitle>Error</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
-      {result?.playbackUrl && (
-        <Alert className="mt-2">
+
+      {clip?.playbackUrl && (
+        <Alert>
           <AlertTitle>Clip Created!</AlertTitle>
-          <AlertDescription>
+          <AlertDescription className="space-y-3">
             <video
-              src={result.playbackUrl}
+              src={clip.playbackUrl}
               controls
-              className="w-full max-w-xs rounded shadow"
+              className="w-full max-w-sm rounded shadow"
               style={{ aspectRatio: "16/9" }}
             />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                onClick={handleMint}
+                disabled={!canMint || isMinting}
+                title={
+                  !clip.parentStoryIpId
+                    ? "Broadcaster hasn't registered this stream as IP yet."
+                    : undefined
+                }
+              >
+                {isMinting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" /> Minting...
+                  </>
+                ) : (
+                  "Mint as NFT"
+                )}
+              </Button>
+              {clip.parentStoryIpId && clip.parentCommercialRevShare != null && (
+                <span className="text-xs text-muted-foreground">
+                  {clip.parentCommercialRevShare}% royalty to the creator.
+                </span>
+              )}
+              {!clip.parentStoryIpId && (
+                <span className="text-xs text-muted-foreground">
+                  Broadcaster hasn&apos;t registered this stream as IP yet.
+                </span>
+              )}
+            </div>
+            {mintResult && (
+              <div className="text-sm">
+                Minted as Story IP:{" "}
+                <span className="font-mono text-xs">{mintResult.ipId}</span>
+              </div>
+            )}
           </AlertDescription>
         </Alert>
       )}
     </div>
   );
-}
-
-interface ClipCreatorProps {
-  playbackId: string;
-  sessionId: string;
-}
-
-interface ClipResult {
-  playbackUrl: string;
-  assetId: string;
-  error?: string;
 }

--- a/components/Live/CreatorClipsList.tsx
+++ b/components/Live/CreatorClipsList.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Scissors, ExternalLink } from "lucide-react";
+
+interface ClipRow {
+  id: number;
+  title: string | null;
+  playback_id: string;
+  thumbnail_url: string | null;
+  status: string | null;
+  is_minted: boolean | null;
+  duration: number | null;
+  clip_start_ms: number | null;
+  clip_end_ms: number | null;
+  clipper_address: string | null;
+  token_id: string | null;
+  story_ip_id: string | null;
+  contract_address: string | null;
+  created_at: string;
+}
+
+interface CreatorClipsListProps {
+  playbackId: string;
+  refreshKey?: number;
+}
+
+const STORY_SCAN_BASE =
+  process.env.NEXT_PUBLIC_STORY_NETWORK === "mainnet"
+    ? "https://www.storyscan.io"
+    : "https://aeneid.storyscan.io";
+
+function formatDuration(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms)) return "—";
+  const sec = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function shortAddr(addr: string | null): string {
+  if (!addr) return "—";
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export function CreatorClipsList({ playbackId, refreshKey = 0 }: CreatorClipsListProps) {
+  const [clips, setClips] = useState<ClipRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!playbackId) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/video-assets/clips/by-parent/${encodeURIComponent(playbackId)}`
+        );
+        const data = await res.json();
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(data?.error || `Failed to load clips (${res.status})`);
+          return;
+        }
+        setClips(data.clips ?? []);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message || "Failed to load clips");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [playbackId, refreshKey]);
+
+  return (
+    <div className="mt-4 border-t border-white/20 pt-3 max-w-[576px] mx-auto">
+      <div className="flex items-center gap-2 mb-3">
+        <Scissors className="h-4 w-4" />
+        <p className="text-sm font-semibold">Clips from your stream</p>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" /> Loading...
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {!isLoading && !error && clips && clips.length === 0 && (
+        <p className="text-xs text-gray-400">
+          No clips yet. Viewers can create clips once you&apos;re live.
+        </p>
+      )}
+
+      {clips && clips.length > 0 && (
+        <ul className="space-y-2">
+          {clips.map((clip) => {
+            const duration =
+              clip.clip_start_ms != null && clip.clip_end_ms != null
+                ? clip.clip_end_ms - clip.clip_start_ms
+                : clip.duration != null
+                  ? clip.duration * 1000
+                  : null;
+            return (
+              <li
+                key={clip.id}
+                className="flex items-center gap-3 p-2 rounded-md border border-white/10 bg-muted/10"
+              >
+                <div className="w-20 h-12 flex-shrink-0 rounded overflow-hidden bg-black/40">
+                  {clip.thumbnail_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={clip.thumbnail_url}
+                      alt={clip.title ?? "Clip thumbnail"}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-[10px] text-gray-500">
+                      no preview
+                    </div>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm font-medium truncate" title={clip.title ?? undefined}>
+                      {clip.title ?? "Untitled clip"}
+                    </p>
+                    <Badge variant={clip.is_minted ? "default" : "secondary"}>
+                      {clip.is_minted ? "minted" : clip.status ?? "draft"}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-gray-400">
+                    {formatDuration(duration)} · by {shortAddr(clip.clipper_address)}
+                  </p>
+                  {clip.is_minted && clip.story_ip_id && (
+                    <a
+                      href={`${STORY_SCAN_BASE}/ip/${clip.story_ip_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[11px] text-primary hover:underline inline-flex items-center gap-1 mt-0.5"
+                    >
+                      View IP <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/Live/StreamIPRegistration.tsx
+++ b/components/Live/StreamIPRegistration.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, Shield, CheckCircle2 } from "lucide-react";
+
+const STORY_SCAN_BASE =
+  process.env.NEXT_PUBLIC_STORY_NETWORK === "mainnet"
+    ? "https://www.storyscan.io"
+    : "https://aeneid.storyscan.io";
+
+interface StreamIPRegistrationProps {
+  creatorAddress: string;
+  streamName?: string | null;
+  thumbnailUrl?: string | null;
+  storyIpId?: string | null;
+  licenseTermsId?: string | null;
+  commercialRevShare?: number | null;
+  onRegistered?: (result: {
+    ipId: string;
+    licenseTermsId: string | null;
+    commercialRevShare: number;
+  }) => void;
+}
+
+export function StreamIPRegistration({
+  creatorAddress,
+  streamName,
+  thumbnailUrl,
+  storyIpId,
+  licenseTermsId,
+  commercialRevShare,
+  onRegistered,
+}: StreamIPRegistrationProps) {
+  const [revShare, setRevShare] = useState<string>("10");
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isRegistered = !!storyIpId;
+
+  async function handleRegister() {
+    const share = Number(revShare);
+    if (!Number.isFinite(share) || share < 0 || share > 100) {
+      setError("Enter a royalty between 0 and 100.");
+      return;
+    }
+    setIsRegistering(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/story/register-stream", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          creatorAddress,
+          commercialRevShare: share,
+          streamName: streamName || undefined,
+          thumbnailUrl: thumbnailUrl || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data?.error || `Registration failed (${res.status})`);
+        return;
+      }
+      onRegistered?.({
+        ipId: data.ipId,
+        licenseTermsId: data.licenseTermsId ?? null,
+        commercialRevShare: data.commercialRevShare ?? share,
+      });
+    } catch (e: any) {
+      setError(e?.message || "Failed to register stream as IP");
+    } finally {
+      setIsRegistering(false);
+    }
+  }
+
+  if (isRegistered) {
+    return (
+      <div className="mt-4 border-t border-white/20 pt-3 max-w-[576px] mx-auto">
+        <div className="flex items-start gap-2">
+          <CheckCircle2 className="h-5 w-5 text-green-500 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold">Registered as Story IP</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              Viewer clips will mint as derivatives with{" "}
+              <span className="font-medium">
+                {commercialRevShare ?? 0}%
+              </span>{" "}
+              royalty back to you.
+            </p>
+            <a
+              href={`${STORY_SCAN_BASE}/ip/${storyIpId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline mt-1 inline-block font-mono truncate"
+              title={storyIpId!}
+            >
+              {storyIpId!.slice(0, 10)}…{storyIpId!.slice(-6)} →
+            </a>
+            {licenseTermsId && (
+              <p className="text-[10px] text-gray-500 mt-0.5">
+                License terms ID: {licenseTermsId}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 border-t border-white/20 pt-3 max-w-[576px] mx-auto">
+      <div className="flex items-center gap-2 mb-2">
+        <Shield className="h-4 w-4" />
+        <p className="text-sm font-semibold">Register this stream as IP</p>
+      </div>
+      <p className="text-xs text-gray-400 mb-3">
+        Register your livestream as a Story Protocol IP Asset so viewers can mint their
+        clips as derivative NFTs, with automatic royalties back to you.
+      </p>
+      <div className="flex flex-col sm:flex-row sm:items-end gap-2">
+        <div className="flex-1">
+          <Label htmlFor="rev-share" className="text-xs">
+            Royalty share from clip sales (%)
+          </Label>
+          <Input
+            id="rev-share"
+            type="number"
+            min={0}
+            max={100}
+            value={revShare}
+            onChange={(e) => setRevShare(e.target.value)}
+            disabled={isRegistering}
+            className="mt-1"
+          />
+        </div>
+        <Button onClick={handleRegister} disabled={isRegistering}>
+          {isRegistering ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin mr-2" /> Registering...
+            </>
+          ) : (
+            "Register as IP"
+          )}
+        </Button>
+      </div>
+      {error && (
+        <Alert variant="destructive" className="mt-2">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/lib/sdk/story/spg-service.ts
+++ b/lib/sdk/story/spg-service.ts
@@ -316,8 +316,91 @@ export async function mintAndRegisterIp(
 }
 
 /**
+ * Parameters for minting and registering a derivative IP Asset
+ */
+export interface MintAndRegisterDerivativeParams {
+  collectionAddress: Address; // SPG NFT collection address for the derivative (clip)
+  recipient: Address;         // Address to receive the minted derivative NFT
+  parentIpIds: Address[];     // Parent IP Asset IDs (the source stream)
+  licenseTermsIds: string[];  // License terms on the parent that permit derivatives
+  metadataURI?: string;
+  metadataHash?: string;
+  allowDuplicates?: boolean;
+}
+
+export interface MintAndRegisterDerivativeResult extends MintAndRegisterResult {
+  parentIpIds: Address[];
+}
+
+/**
+ * Mint an NFT, register it as a derivative IP Asset of one or more parents,
+ * inheriting their PIL terms (e.g. commercial revenue share flows back to the parent).
+ */
+export async function mintAndRegisterDerivative(
+  client: StoryClient,
+  params: MintAndRegisterDerivativeParams
+): Promise<MintAndRegisterDerivativeResult> {
+  if (!params.parentIpIds.length) {
+    throw new Error("mintAndRegisterDerivative requires at least one parent IP ID");
+  }
+  if (!params.licenseTermsIds.length) {
+    throw new Error("mintAndRegisterDerivative requires at least one license terms ID");
+  }
+
+  try {
+    const result = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
+      spgNftContract: params.collectionAddress,
+      recipient: params.recipient,
+      derivData: {
+        parentIpIds: params.parentIpIds,
+        licenseTermsIds: params.licenseTermsIds.map((id) => BigInt(id)),
+      },
+      ipMetadata: params.metadataURI
+        ? {
+            ipMetadataURI: params.metadataURI,
+            ...(params.metadataHash
+              ? { ipMetadataHash: params.metadataHash as `0x${string}` }
+              : {}),
+          }
+        : undefined,
+      allowDuplicates: params.allowDuplicates ?? true,
+    });
+
+    if (!result.txHash) {
+      throw new Error("Derivative mint transaction hash not returned");
+    }
+
+    const tokenId = result.tokenId?.toString();
+    const ipId = result.ipId;
+
+    if (!tokenId) {
+      throw new Error(
+        "Token ID not returned from derivative mint operation. Transaction hash: " + result.txHash
+      );
+    }
+    if (!ipId) {
+      throw new Error(
+        "IP ID not returned from derivative mint operation. Transaction hash: " + result.txHash
+      );
+    }
+
+    return {
+      tokenId,
+      ipId,
+      txHash: result.txHash,
+      parentIpIds: params.parentIpIds,
+    };
+  } catch (error) {
+    serverLogger.error("Failed to mint and register derivative IP Asset:", error);
+    throw new Error(
+      `Derivative mint failed: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
  * Mint an NFT, register it as an IP Asset, and attach PIL terms in one transaction
- * 
+ *
  * @param client - Story Protocol client instance
  * @param params - Mint, register, and license parameters
  * @returns Token ID, IP ID, license terms IDs, and transaction hash

--- a/lib/types/video-asset.ts
+++ b/lib/types/video-asset.ts
@@ -54,6 +54,13 @@ export interface VideoAsset {
   splits_address: string | null;  // Address of the Splits contract for revenue distribution
   // Livepeer Verifiable Video
   livepeer_attestation_id: string | null;  // Livepeer attestation id (creator attestation)
+  // Clip / source origin (defaults to 'Upload' for non-clip content)
+  source_type?: "Upload" | "Livestream" | "Clip";
+  parent_playback_id?: string | null;  // For clips: playback_id of the source stream
+  parent_story_ip_id?: string | null;  // For clips: Story IP ID of the source stream (if registered)
+  clip_start_ms?: number | null;
+  clip_end_ms?: number | null;
+  clipper_address?: string | null;     // For clips: wallet that created the clip
   created_at: Date;
   updated_at: Date;
 }

--- a/services/livepeer-clips.ts
+++ b/services/livepeer-clips.ts
@@ -1,6 +1,28 @@
 import { Livepeer } from "livepeer";
 import { fullLivepeer } from "@/lib/sdk/livepeer/fullClient";
 
+/**
+ * Best-effort server-side lookup for a Livepeer asset's thumbnail URL.
+ * Returns null if the asset isn't ready yet or no thumbnail source is published.
+ */
+export async function getClipThumbnailUrl(playbackId: string): Promise<string | null> {
+  if (!playbackId) return null;
+  try {
+    const response = await fullLivepeer.playback.get(playbackId);
+    const sources = (response.playbackInfo?.meta?.source ?? []) as Array<{
+      type?: string;
+      hrn?: string;
+      url?: string;
+    }>;
+    const thumbnail = sources.find(
+      (src) => src.type === "image/png" && src.hrn === "Thumbnail (PNG)"
+    );
+    return thumbnail?.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function createClip({
   playbackId,
   sessionId,
@@ -13,9 +35,9 @@ export async function createClip({
   startTime: number;
   endTime: number;
   name?: string;
-}): Promise<{ playbackUrl: string; assetId: string; error?: string }> {
+}): Promise<{ playbackUrl: string; assetId: string; newPlaybackId: string; error?: string }> {
   if (!playbackId || !sessionId || !startTime || !endTime)
-    return { playbackUrl: "", assetId: "", error: "Missing required fields" };
+    return { playbackUrl: "", assetId: "", newPlaybackId: "", error: "Missing required fields" };
   try {
     const result = await fullLivepeer.stream.createClip({
       playbackId,
@@ -26,17 +48,20 @@ export async function createClip({
     });
     const playbackUrl = result.data?.asset.playbackUrl ?? "";
     const assetId = result.data?.asset.id ?? "";
+    const newPlaybackId = result.data?.asset.playbackId ?? "";
     if (!playbackUrl)
       return {
         playbackUrl: "",
         assetId,
+        newPlaybackId,
         error: "Clip created but playback URL not ready yet.",
       };
-    return { playbackUrl, assetId };
+    return { playbackUrl, assetId, newPlaybackId };
   } catch (e: any) {
     return {
       playbackUrl: "",
       assetId: "",
+      newPlaybackId: "",
       error: e?.message ?? "Unknown error",
     };
   }

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -13,6 +13,12 @@ export interface Stream {
     name?: string | null;
     is_live: boolean;
     last_live_at?: string | null;
+    allow_clipping?: boolean;
+    story_ip_id?: string | null;
+    story_license_terms_id?: string | null;
+    story_ip_registration_tx?: string | null;
+    story_ip_registered_at?: string | null;
+    story_commercial_rev_share?: number | null;
     created_at: string;
     updated_at: string;
 }
@@ -51,7 +57,7 @@ export async function getStreamByPlaybackId(playbackId: string) {
 
     const { data, error } = await supabase
         .from("streams")
-        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at")
+        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, allow_clipping, story_ip_id, story_license_terms_id, story_commercial_rev_share, story_ip_registered_at")
         .eq("playback_id", playbackId)
         .maybeSingle();
 
@@ -105,6 +111,42 @@ export async function updateStream(creatorId: string, updates: UpdateStreamParam
     if (error) {
         console.error("Error updating stream record:", error);
         throw new Error(`Failed to update stream: ${error.message}`);
+    }
+
+    return data as Stream;
+}
+
+/**
+ * Record Story Protocol IP registration for a stream
+ */
+export async function updateStreamStoryIp(
+    creatorId: string,
+    storyData: {
+        story_ip_id: string;
+        story_license_terms_id?: string | null;
+        story_ip_registration_tx: string;
+        story_commercial_rev_share?: number | null;
+    }
+) {
+    const supabase = await createServiceClient();
+
+    const { data, error } = await supabase
+        .from("streams")
+        .update({
+            story_ip_id: storyData.story_ip_id,
+            story_license_terms_id: storyData.story_license_terms_id ?? null,
+            story_ip_registration_tx: storyData.story_ip_registration_tx,
+            story_ip_registered_at: new Date().toISOString(),
+            story_commercial_rev_share: storyData.story_commercial_rev_share ?? null,
+            updated_at: new Date().toISOString(),
+        })
+        .ilike("creator_id", creatorId)
+        .select()
+        .single();
+
+    if (error) {
+        console.error("Error updating stream Story IP status:", error);
+        throw new Error(`Failed to update stream Story IP: ${error.message}`);
     }
 
     return data as Stream;

--- a/services/video-assets.ts
+++ b/services/video-assets.ts
@@ -176,6 +176,87 @@ export async function createVideoAsset(
   return result;
 }
 
+export interface CreateClipVideoAssetParams {
+  assetId: string;
+  playbackId: string;
+  playbackUrl?: string | null;
+  thumbnailUrl?: string | null;
+  name?: string | null;
+  parentPlaybackId: string;
+  parentStoryIpId?: string | null;
+  clipStartMs: number;
+  clipEndMs: number;
+  clipperAddress: string;
+}
+
+export async function createClipVideoAsset(params: CreateClipVideoAssetParams) {
+  const supabase = createServiceClient();
+
+  const { data: existing } = await supabase
+    .from("video_assets")
+    .select("*")
+    .eq("asset_id", params.assetId)
+    .maybeSingle();
+  if (existing) return existing;
+
+  const title = params.name?.trim() || `Clip of ${params.parentPlaybackId.slice(0, 8)}`;
+  const durationSec = Math.max(0, Math.round((params.clipEndMs - params.clipStartMs) / 1000));
+
+  const { data, error } = await supabase
+    .from("video_assets")
+    .insert({
+      title,
+      asset_id: params.assetId,
+      playback_id: params.playbackId,
+      category: "clip",
+      location: "",
+      description: null,
+      creator_id: params.clipperAddress.toLowerCase(),
+      status: "draft",
+      duration: durationSec,
+      views_count: 0,
+      likes_count: 0,
+      is_minted: false,
+      current_supply: 0,
+      thumbnail_url: params.thumbnailUrl ?? null,
+      source_type: "Clip",
+      parent_playback_id: params.parentPlaybackId,
+      parent_story_ip_id: params.parentStoryIpId ?? null,
+      clip_start_ms: params.clipStartMs,
+      clip_end_ms: params.clipEndMs,
+      clipper_address: params.clipperAddress.toLowerCase(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create clip video asset: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function listClipsByParentPlaybackId(
+  parentPlaybackId: string,
+  limit: number = 20
+) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("video_assets")
+    .select(
+      "id, title, playback_id, thumbnail_url, status, is_minted, duration, clip_start_ms, clip_end_ms, clipper_address, token_id, story_ip_id, contract_address, created_at"
+    )
+    .eq("source_type", "Clip")
+    .eq("parent_playback_id", parentPlaybackId)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to list clips: ${error.message}`);
+  }
+  return data ?? [];
+}
+
 export async function getVideoAssetById(id: number) {
   const supabase = await createClient();
 

--- a/supabase/migrations/20260419_viewer_clips.sql
+++ b/supabase/migrations/20260419_viewer_clips.sql
@@ -1,0 +1,24 @@
+-- Viewer-created clips from livestreams, mintable as Story Protocol derivative IPs.
+
+alter table public.video_assets
+  add column if not exists source_type text not null default 'Upload'
+    check (source_type in ('Upload', 'Livestream', 'Clip')),
+  add column if not exists parent_playback_id text,
+  add column if not exists parent_story_ip_id text,
+  add column if not exists clip_start_ms bigint,
+  add column if not exists clip_end_ms bigint,
+  add column if not exists clipper_address text;
+
+create index if not exists video_assets_parent_playback_id_idx
+  on public.video_assets (parent_playback_id);
+
+create index if not exists video_assets_source_type_idx
+  on public.video_assets (source_type);
+
+alter table public.streams
+  add column if not exists allow_clipping boolean not null default true,
+  add column if not exists story_ip_id text,
+  add column if not exists story_license_terms_id text,
+  add column if not exists story_ip_registration_tx text,
+  add column if not exists story_ip_registered_at timestamptz,
+  add column if not exists story_commercial_rev_share integer check (story_commercial_rev_share is null or (story_commercial_rev_share >= 0 and story_commercial_rev_share <= 100));


### PR DESCRIPTION
## Summary

- Viewers can clip a livestream (Last 15s / 30s / 60s or custom range) and mint the clip as a Story Protocol derivative IP, with royalties flowing back to the broadcaster via the parent stream's PIL license terms.
- Broadcasters get a "Register as IP" flow (configurable commercial rev share, default 10%), an "Allow viewer clipping" toggle, and a dashboard of clips made from their stream.
- Mint button only enables once the broadcaster has registered the stream as IP — clean fallback with a tooltip otherwise.

## What changed

### Schema (`supabase/migrations/20260419_viewer_clips.sql`)
- `video_assets`: `source_type` ('Upload'|'Livestream'|'Clip'), `parent_playback_id`, `parent_story_ip_id`, `clip_start_ms`, `clip_end_ms`, `clipper_address`.
- `streams`: `allow_clipping` (default true), `story_ip_id`, `story_license_terms_id`, `story_ip_registration_tx`, `story_ip_registered_at`, `story_commercial_rev_share` (0–100).

### New API routes
- `POST /api/livepeer/clips` — viewer clip creation, botId + rate-limited, 120s span cap, honors `allow_clipping`.
- `POST /api/video-assets/clips` — persists clip as a `video_assets` row (also fetches clip thumbnail best-effort with parent-stream fallback).
- `GET /api/video-assets/clips/by-parent/[playbackId]` — list clips for a given parent stream.
- `POST /api/story/register-stream` — mint + register the stream as IP with `PILFlavor.commercialRemix` terms.
- `POST /api/story/mint-derivative` — viewer mints the clip as a derivative IP; only the `clipper_address` can mint their own clip; uploads metadata JSON via Grove.

### Story SDK helper (`lib/sdk/story/spg-service.ts`)
- New `mintAndRegisterDerivative` wrapping `ipAsset.mintAndRegisterIpAndMakeDerivative`.

### UI
- `components/Live/ClipCreator.tsx` — rewritten: quick-duration buttons + custom range, wallet gate, clip preview, Mint CTA with royalty-% caption, disabled state with tooltip when parent isn't registered IP.
- `components/Live/StreamIPRegistration.tsx` — broadcaster registration card (rev-share input, StoryScan link once registered).
- `components/Live/CreatorClipsList.tsx` — dashboard of clips made from the broadcaster's stream with thumbnails, status badges, IP links.
- `app/live/[address]/page.tsx` — wires the above + the allow-clipping switch.
- `app/watch/[playbackId]/WatchClient.tsx` — passes `allowClipping`, `parentStoryIpId`, `parentCommercialRevShare` through to `ClipCreator`.

### Services
- `services/streams.ts` — exposes new columns via `getStreamByPlaybackId`, new `updateStreamStoryIp` helper.
- `services/video-assets.ts` — new `createClipVideoAsset` and `listClipsByParentPlaybackId`.
- `services/livepeer-clips.ts` — returns `newPlaybackId`; new `getClipThumbnailUrl` server helper.

## Gas model

- **Story mainnet** → sponsored by platform via `STORY_PROTOCOL_PRIVATE_KEY` (current architecture, unchanged).
- **Base** → USDC paymaster via existing `useGasSponsorship('usdc')` for any Base ops added later. No Base ops in this flow yet.

## Reviewer notes

- `PILFlavor.commercialRemix` is used the same way as `lib/sdk/nft/minting-service.ts:225` — no new SDK surface.
- `getVideoAssetById` returns `select('*')` so the new columns flow through automatically; only DB-writing paths needed explicit updates.
- `clipper_address` is stored lowercase; comparisons use `.toLowerCase()` on both sides.
- Rate limiting uses the existing `rateLimiters.strict` (5 req / 60s) keyed by IP.
- Only `STORY_PROTOCOL_PRIVATE_KEY` is required env-wise; no new env vars were introduced for Phase 2/3.

## Test plan

- [ ] Run migration: `npx supabase db push`.
- [ ] Broadcaster A: register stream as IP with 10% rev share; confirm StoryScan shows the new IP + attached PIL terms.
- [ ] Viewer B (different wallet): load watch page, click "Last 30s"; confirm Livepeer clip asset, `video_assets` row with `source_type='Clip'` and `parent_playback_id`, and a thumbnail populated.
- [ ] Viewer B clicks "Mint as NFT"; confirm StoryScan shows a child IP with edge to parent, NFT owner = B, license terms attached. Clip appears in broadcaster's "Clips from your stream" list with the minted badge.
- [ ] Broadcaster A flips off "Allow viewer clipping"; confirm viewer sees a disabled state and API returns 403.
- [ ] Unregistered stream: confirm Mint button stays disabled with tooltip "Broadcaster hasn't registered this stream as IP yet."
- [ ] Rate limit: 6 clips from one wallet in <60s → 6th returns 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)