### PR TITLE
Fix 403 on stream IP registration and viewer clip minting

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -14,6 +14,9 @@ initBotId({
     { path: '/api/creator-profiles', method: 'DELETE' },
     { path: '/api/story/transfer', method: 'POST' },
     { path: '/api/story/mint', method: 'POST' },
+    { path: '/api/story/register-stream', method: 'POST' },
+    { path: '/api/story/mint-derivative', method: 'POST' },
+    { path: '/api/story/prepare-mint', method: 'POST' },
     // rpc-proxy omitted: BotID blocks legitimate client RPC (e.g. eth_getBalance for funding wallet).
     // Mint/transfer remain protected; proxy is read/forward only.
     { path: '/api/story/factory/deploy-collection', method: 'POST' },


### PR DESCRIPTION
## Summary
- Three `/api/story/*` routes added in dd8dc4ce0 ("Add viewer-created clips with derivative NFT minting") call `checkBotId()` server-side but were never added to the client-side `protect` array in `instrumentation-client.ts` — so every request to them returns **403 "Access denied"**.
- Adds `/api/story/register-stream`, `/api/story/mint-derivative`, and `/api/story/prepare-mint` to the BotID protect list alongside the already-working `/api/story/mint` and `/api/story/transfer`.
- Unblocks the **Register as IP** button on the stream config page and viewer-clip derivative NFT minting.

## Root cause
BotID is two-sided: the client's `initBotId({ protect: [...] })` tells the browser which routes need verification headers attached to outgoing requests, and the server's `checkBotId()` reads those headers. If a route is only registered server-side, no headers are ever sent → `isBot: true` → 403. The three new routes were protected server-side only.

## Test plan
- [ ] Hard-refresh the stream config page (BotID initializes on client boot)
- [ ] Enter a royalty share and click **Register as IP** — no 403; returns a Story IP ID or a non-BotID error
- [ ] Viewer clip minting via `ClipCreator` no longer returns 403 on `/api/story/mint-derivative`
- [ ] Existing `/api/story/mint` and `/api/story/transfer` flows still succeed (regression check)

## Follow-up (not in this PR)
`/api/story/register-stream` has no server-side authorization — it trusts `creatorAddress` from the request body. Any authenticated user could pass any wallet. `/api/metokens/alchemy` already has the right pattern (compare `user.id` from Supabase auth to `creatorAddress`) and can be used as a reference for a separate hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)