### PR TITLE
Remove Creator Pass gate for livestream viewers

### DIFF
--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -2,7 +2,6 @@ import { signAccessJwt } from "@livepeer/core/crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { checkBotId } from "botid/server";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
-import { unlockService } from "@/lib/sdk/unlock/services";
 
 export async function POST(req: NextRequest) {
     const verification = await checkBotId();
@@ -34,25 +33,6 @@ export async function POST(req: NextRequest) {
             );
         }
 
-        // Server-Side Membership Verification
-        if (!userAddress) {
-            return NextResponse.json(
-                { message: "Login required to watch this stream" },
-                { status: 401 }
-            );
-        }
-
-        // Check if user has ANY valid membership (Creator Pass)
-        const memberships = await unlockService.getAllMemberships(userAddress);
-        const hasValidMembership = memberships.some(m => m.isValid);
-
-        if (!hasValidMembership) {
-            return NextResponse.json(
-                { message: "Valid membership required to watch this stream" },
-                { status: 403 }
-            );
-        }
-
         const token = await signAccessJwt({
             privateKey: accessControlPrivateKey,
             publicKey: accessControlPublicKey,
@@ -60,7 +40,7 @@ export async function POST(req: NextRequest) {
             playbackId,
             expiration: 3600, // 1 hour
             custom: {
-                userId: userAddress // Bind the JWT to the user's address for auditing if needed
+                userId: userAddress || "anonymous"
             }
         });
 

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -111,11 +111,6 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         if (jwtRes.ok) {
           const { token } = await jwtRes.json();
           setJwt(token);
-          if (error && error.includes("required")) {
-            setError(null);
-          }
-        } else if (jwtRes.status === 401) {
-          setError("Authentication required: Please connect your wallet");
         } else {
           const errData = await jwtRes.json().catch(() => ({}));
           logger.warn("Failed to sign JWT for stream:", errData);


### PR DESCRIPTION
## Summary
- `/api/livepeer/sign-jwt` no longer requires a logged-in wallet or a valid Unlock Creator Pass — any viewer (anonymous or logged in) can now get a playback JWT.
- Drops the now-dead 401 "connect your wallet" branch in the watch client.
- **Broadcasting remains gated**: the `MembershipGuard` wrapper on `/live/[address]` still requires a Creator Pass to go live.
- **Chat remains gated**: `LiveChat` still requires a wallet connection to participate (XMTP-based).

## Background
A Creator Pass holder was unable to watch another pass holder's livestream. Root cause: the server-side membership check in `sign-jwt` was too strict (or the Unlock lookup was returning stale data). Gating playback on an on-chain lookup is fragile; we now gate only the acts that create value (broadcasting, chatting).

## Test plan
- [ ] Open a public `/watch/[playbackId]` URL while logged out → player loads, stream plays.
- [ ] Open `/watch/[playbackId]` logged in without a Creator Pass → player loads, stream plays.
- [ ] Visit `/live/[address]` without a Creator Pass → still blocked by `MembershipGuard`.
- [ ] Chat input on the watch page still shows "Connect your wallet to join the live chat" when logged out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)