### PR TITLE
Pin XMTP browser client to the production network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,10 @@ CRON_SECRET=
 
 # --- Scripts / Paragraph ---
 PARAGRAPH_API_KEY=
+
+# --- XMTP chat ---
+# XMTP network: 'production' (default) | 'dev' | 'local'
+# Must match XMTP_ENV used by scripts/xmtp-moderation-worker.ts
+NEXT_PUBLIC_XMTP_ENV=production
+# Bot inbox ID emitted by xmtp-moderation-worker on first boot
+NEXT_PUBLIC_MODERATION_BOT_INBOX_ID=

--- a/lib/hooks/xmtp/useXmtpClient.ts
+++ b/lib/hooks/xmtp/useXmtpClient.ts
@@ -33,6 +33,13 @@ const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 2000; // 2 seconds
 const MAX_RETRY_DELAY_MS = 10000; // 10 seconds
 
+// Must match XMTP_ENV used by scripts/xmtp-moderation-worker.ts.
+// Browser SDK defaults to 'dev' if omitted, which silently isolates users
+// from the production network and from the moderation bot's inbox.
+type XmtpEnv = 'local' | 'dev' | 'production';
+const XMTP_ENV: XmtpEnv =
+  (process.env.NEXT_PUBLIC_XMTP_ENV as XmtpEnv | undefined) ?? 'production';
+
 /**
  * Hook to initialize and manage XMTP client
  * 
@@ -149,6 +156,7 @@ export function useXmtpClient(): UseXmtpClientReturn {
         hasWalletAddress: !!walletAddress,
         hasSignMessage: !!signMessage,
         hasAccountClient: !!accountClient,
+        xmtpEnv: XMTP_ENV,
         attempt,
         retryCount: attempt,
       });
@@ -204,10 +212,10 @@ export function useXmtpClient(): UseXmtpClientReturn {
         });
       });
       
-      // Create XMTP client with timeout and abort signal
+      // Create XMTP client with timeout and abort signal.
+      // dbEncryptionKey is a no-op in the browser SDK (OPFS storage is not encrypted).
       const initPromise = Client.create(signer, {
-        // Note: dbEncryptionKey is not used for encryption in browser environments
-        // but can be provided for additional security
+        env: XMTP_ENV,
       });
       
       // Check if already aborted
@@ -248,10 +256,11 @@ export function useXmtpClient(): UseXmtpClientReturn {
                          errorMessage.includes('wasm') ||
                          errorMessage.includes('WASM');
 
-      // Only log errors in development or if they're critical
-      if (isDev || errorMessage.includes('wasm') || errorMessage.includes('WASM')) {
-        logger.error(`Error initializing XMTP client (attempt ${attempt + 1}):`, err);
-      }
+      // Always log init errors so production outages are diagnosable from real-user logs.
+      logger.error(`Error initializing XMTP client (attempt ${attempt + 1}):`, {
+        error: err,
+        xmtpEnv: XMTP_ENV,
+      });
 
       // Retry logic for retryable errors
       if (isRetryable && attempt < MAX_RETRIES) {


### PR DESCRIPTION
## Summary

Live and video chat surfaces (`LiveChat`, `VideoChat`) hung on "Connecting…" and nobody could send or view messages.

`lib/hooks/xmtp/useXmtpClient.ts` was calling `Client.create(signer, {})` with no `env` option, so the browser SDK silently defaulted to its `dev` network. Meanwhile `scripts/xmtp-moderation-worker.ts:63` is hard-defaulted to `'production'`, and `NEXT_PUBLIC_MODERATION_BOT_INBOX_ID` was generated by that prod worker. Browsers on dev couldn't resolve the bot's inbox (host `group.addMembers([botId])` threw) and couldn't reliably reach each other on the unmanaged dev cluster either — hence the spinner-forever symptom.

- Read `NEXT_PUBLIC_XMTP_ENV` with a `'production'` default and pass it to `Client.create`, matching `XMTP_ENV` in the moderation worker.
- Always log init errors (previously gated on `NODE_ENV === 'development'`) and include the configured env in the payload so the next regression is diagnosable from real-user logs.
- Document `NEXT_PUBLIC_XMTP_ENV` (and the existing `NEXT_PUBLIC_MODERATION_BOT_INBOX_ID`) in `.env.example`.

This addresses the "No Production Environment Checks" item flagged in `XMTP_CHAT_PRODUCTION_READINESS.md`.

## Test plan

- [ ] `yarn dev`; open `/watch/[playbackId]` with a connected wallet; sign the XMTP prompts; confirm the chat panel exits "Connecting to live chat…" and that messages send/receive.
- [ ] Repeat in a second browser profile (different wallet) on the same URL; confirm both peers see each other's messages within ~1s.
- [ ] DevTools → Network: confirm WebSocket / fetch traffic targets `*.production.xmtp.network`, not `*.dev.xmtp.network`.
- [ ] In dev, console shows `xmtpEnv: 'production'` in the prerequisites debug log.
- [ ] As the stream creator, watch the console for `botProvisioned` failures — should be gone now that the bot's inbox resolves.
- [ ] Note: previously cached `xmtp-live-group-*` keys in `localStorage` are dev-network IDs and won't resolve on prod; first load after deploy creates fresh group IDs. Supabase-persisted history (commit `ab6f7a01`) still hydrates the UI via `useLiveChatModerated`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DefAmu2npyYZVcEZid1b1f)_