### PR TITLE
Fix react-joyride step property mismatch in Tour

### DIFF
--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -18,7 +18,7 @@ const DESKTOP_STEPS: Step[] = [
     {
         target: '#connect-wallet-btn',
         content: 'Sign in to get started! Click "Get Started" to create your account with just your email.',
-        skipBeacon: true,
+        disableBeacon: true,
         overlayClickAction: false,
         buttons: ['primary', 'skip'],
         blockTargetInteraction: false,
@@ -82,7 +82,7 @@ export const Tour = () => {
         {
             target: '#mobile-menu-btn',
             content: 'Tap the menu to get started by signing in.',
-            skipBeacon: true,
+            disableBeacon: true,
             overlayClickAction: false,
             buttons: ['primary', 'skip'],
             data: { id: 'connect' }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript/Next.js build error caused by using an unsupported `react-joyride` step property in the tour configuration.

### Description
- Replace the invalid `skipBeacon` property with the supported `disableBeacon` on the first step of both `DESKTOP_STEPS` and `MOBILE_STEPS` in `components/Tour/Tour.tsx`.

### Testing
- Ran `yarn run build` in this environment but the build could not complete due to a Yarn workspace/lockfile mismatch (`ui-components-qs-nextjs@workspace:.` missing from lockfile), so the full CI/production build should verify the TypeScript/Next.js compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93e97d24c832488d732b801787027)