### PR TITLE
Fix Joyride tour TypeScript build errors

### DIFF
--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -8,27 +8,27 @@ import {
     type CallBackProps,
     type Step,
 } from 'react-joyride';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useUser } from '@account-kit/react';
 import { useTour } from '@/context/TourContext';
 import { logger } from '@/lib/utils/logger';
 
+type TourStep = Step & {
+    data?: { id: string };
+};
 
-const DESKTOP_STEPS: Step[] = [
+const DESKTOP_STEPS: TourStep[] = [
     {
         target: '#connect-wallet-btn',
         content: 'Sign in to get started! Click "Get Started" to create your account with just your email.',
         disableBeacon: true,
-        overlayClickAction: false,
-        buttons: ['primary', 'skip'],
-        blockTargetInteraction: false,
+        spotlightClicks: true,
         data: { id: 'connect' }
     },
     {
         target: '#nav-user-menu',
         content: 'Click your profile to open the menu, then select "Upload" to start adding content.',
-        overlayClickAction: false,
-        blockTargetInteraction: false,
+        spotlightClicks: true,
         data: { id: 'user-menu' }
     },
     {
@@ -60,7 +60,6 @@ const DESKTOP_STEPS: Step[] = [
 
 export const Tour = () => {
     const { run, stepIndex, setRun, setStepIndex } = useTour();
-    const router = useRouter();
     const pathname = usePathname();
     const user = useUser();
     const isConnected = !!user;
@@ -78,13 +77,11 @@ export const Tour = () => {
         return () => window.removeEventListener('resize', checkMobile);
     }, []);
 
-    const MOBILE_STEPS: Step[] = [
+    const MOBILE_STEPS: TourStep[] = [
         {
             target: '#mobile-menu-btn',
             content: 'Tap the menu to get started by signing in.',
             disableBeacon: true,
-            overlayClickAction: false,
-            buttons: ['primary', 'skip'],
             data: { id: 'connect' }
         },
         {
@@ -118,13 +115,13 @@ export const Tour = () => {
 
     // Helper to find step index by ID
     const getStepIndex = (id: string) => {
-        return steps.findIndex(s => (s.data as any)?.id === id);
+        return steps.findIndex(s => s.data?.id === id);
     };
 
     const handleJoyrideCallback = (data: CallBackProps) => {
         const { index, status, type, action } = data;
         const currentStep = steps[index];
-        const currentId = (currentStep?.data as any)?.id;
+        const currentId = currentStep?.data?.id;
 
         logger.debug("Tour: Callback", { index, status, type, action, currentId });
 
@@ -239,11 +236,14 @@ export const Tour = () => {
             stepIndex={stepIndex}
             callback={handleJoyrideCallback}
             continuous
-            options={{
-                showProgress: true,
-                buttons: ['skip', 'back', 'primary', 'close'],
-                primaryColor: '#4f46e5',
-                zIndex: 10000,
+            showProgress
+            showSkipButton
+            disableOverlayClose
+            styles={{
+                options: {
+                    primaryColor: '#4f46e5',
+                    zIndex: 10000,
+                },
             }}
             tooltipComponent={TourTooltip}
         />


### PR DESCRIPTION
### Motivation
- The Next.js TypeScript build failed because per-step properties used in the tour (`overlayClickAction`, `buttons`, `blockTargetInteraction`) are not part of the locked `react-joyride` API and caused excess-property/type errors. 
- Keep the tour behavior and metadata (step `data.id`) while aligning to the supported Joyride props and types so the project compiles under Vercel's TypeScript checks.

### Description
- Modified `components/Tour/Tour.tsx` to introduce a local `TourStep` type (`Step & { data?: { id: string } }`) and switched the desktop/mobile step arrays to `TourStep[]` to preserve typed `data.id` without `any` casts. 
- Removed unsupported per-step fields `overlayClickAction`, `buttons`, and `blockTargetInteraction` and replaced interaction behavior on affected steps with the supported `spotlightClicks` field. 
- Moved global tour configuration from an `options` object to supported top-level props: `showProgress`, `showSkipButton`, `disableOverlayClose`, and `styles.options` (primary color and `zIndex`). 
- Cleaned up unused imports (removed `useRouter`) and tightened step lookup code to use `s.data?.id` and `currentStep?.data?.id` (no `any` casts). 

### Testing
- `git diff --check` ran and reported no whitespace/patch issues. (passed)
- Type-checking `tsc` against a small local declaration stub (`/tmp/tour-stubs.d.ts`) and `components/Tour/Tour.tsx` was executed to validate the changes against Joyride typings and succeeded. (passed)
- `yarn run build` could not be completed in the environment due to package resolution/lockfile mismatches and registry 403 errors (Yarn 4 vs repo lockfile / network access); this blocked a full Next.js build in the local session. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94fe1cc948324b54b2717b6a47062)