### PR TITLE
Fix dynamic Livepeer view metrics

### DIFF
--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchAllViews,
+  livepeerStudioApiBaseUrl,
+  resolveLivepeerStudioAuthToken,
+} from "./views";
+
+describe("Livepeer view metrics helpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("prefers the full Livepeer API key", () => {
+    vi.stubEnv("LIVEPEER_FULL_API_KEY", "full-key");
+    vi.stubEnv("LIVEPEER_API_KEY", "standard-key");
+
+    expect(resolveLivepeerStudioAuthToken()).toBe("full-key");
+  });
+
+  it("normalizes the Studio API base URL", () => {
+    vi.stubEnv("LIVEPEER_FULL_API_URL", "https://livepeer.example/");
+
+    expect(livepeerStudioApiBaseUrl()).toBe("https://livepeer.example");
+  });
+
+  it("fetches view metrics without using cache", async () => {
+    vi.stubEnv("LIVEPEER_FULL_API_KEY", "full-key");
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        playbackId: "playback-1",
+        viewCount: 12,
+        playtimeMins: 34,
+        legacyViewCount: 5,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAllViews("playback-1")).resolves.toEqual({
+      playbackId: "playback-1",
+      viewCount: 12,
+      playtimeMins: 34,
+      legacyViewCount: 5,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://livepeer.studio/api/data/views/query/total/playback-1",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.any(Headers),
+      }),
+    );
+    const [, options] = fetchMock.mock.calls[0];
+    expect((options?.headers as Headers).get("Authorization")).toBe(
+      "Bearer full-key",
+    );
+  });
+});

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -1,4 +1,3 @@
-'use server';
 import { serverLogger } from '@/lib/utils/logger';
 
 /** Prefer full-access key for Studio data routes; fall back to LIVEPEER_API_KEY (same key in most setups). */
@@ -37,6 +36,7 @@ export const fetchAllViews = async (
     method: 'GET',
     headers: myHeaders,
     redirect: 'follow' as const,
+    cache: 'no-store' as const,
   };
 
   try {

--- a/app/api/livepeer/views/[playbackId]/route.ts
+++ b/app/api/livepeer/views/[playbackId]/route.ts
@@ -3,6 +3,16 @@ import { fetchAllViews } from '@/app/api/livepeer/views';
 import { createClient } from '@/lib/sdk/supabase/server';
 import { serverLogger } from '@/lib/utils/logger';
 
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+const noStoreHeaders = {
+  'Cache-Control': 'no-store, no-cache, max-age=0, must-revalidate',
+  Pragma: 'no-cache',
+  Expires: '0',
+};
+
 /**
  * Read-only endpoint to fetch view metrics from Livepeer
  * Falls back to database views_count if Livepeer API fails or returns 0
@@ -17,7 +27,7 @@ export async function GET(
     if (!playbackId) {
       return NextResponse.json(
         { error: 'Playback ID is required' },
-        { status: 400 }
+        { status: 400, headers: noStoreHeaders }
       );
     }
 
@@ -29,11 +39,14 @@ export async function GET(
         (metrics.viewCount ?? 0) + (metrics.legacyViewCount ?? 0);
 
       if (livepeerTotal > 0) {
-        return NextResponse.json({
-          success: true,
-          source: 'livepeer' as const,
-          ...metrics,
-        });
+        return NextResponse.json(
+          {
+            success: true,
+            source: 'livepeer' as const,
+            ...metrics,
+          },
+          { headers: noStoreHeaders }
+        );
       }
     }
 
@@ -47,20 +60,23 @@ export async function GET(
 
     const dbViewCount = videoAsset?.views_count ?? 0;
 
-    return NextResponse.json({
-      success: true,
-      source: 'database' as const,
-      playbackId,
-      viewCount: dbViewCount,
-      playtimeMins: metrics?.playtimeMins ?? 0,
-      legacyViewCount: 0,
-    });
+    return NextResponse.json(
+      {
+        success: true,
+        source: 'database' as const,
+        playbackId,
+        viewCount: dbViewCount,
+        playtimeMins: metrics?.playtimeMins ?? 0,
+        legacyViewCount: 0,
+      },
+      { headers: noStoreHeaders }
+    );
 
   } catch (error) {
     serverLogger.error('Error fetching view metrics:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
-      { status: 500 }
+      { status: 500, headers: noStoreHeaders }
     );
   }
 }

--- a/app/api/video-assets/published/route.ts
+++ b/app/api/video-assets/published/route.ts
@@ -3,12 +3,21 @@ import { getPublishedVideoAssets } from "@/services/video-assets";
 import { serverLogger } from "@/lib/utils/logger";
 
 export const runtime = "edge";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const noStoreHeaders = {
+  "Cache-Control": "no-store, no-cache, max-age=0, must-revalidate",
+  Pragma: "no-cache",
+  Expires: "0",
+};
 
 /**
  * GET /api/video-assets/published
  * 
- * Fetches published video assets from Supabase with caching
- * Uses Vercel Edge Cache for optimal performance
+ * Fetches published video assets from Supabase without caching so view-count
+ * ordering reflects the latest synced metrics.
  * 
  * Query parameters:
  * - limit: number (default: 12)
@@ -35,7 +44,7 @@ export async function GET(request: NextRequest) {
     if (limit < 1 || limit > 100) {
       return NextResponse.json(
         { error: "Limit must be between 1 and 100" },
-        { status: 400 }
+        { status: 400, headers: noStoreHeaders }
       );
     }
 
@@ -50,24 +59,7 @@ export async function GET(request: NextRequest) {
       search,
     });
 
-    // Create cache key based on query parameters
-    const cacheKey = `published-videos-${limit}-${offset}-${orderBy}-${order}-${creatorId || 'all'}-${category || 'all'}-${search || 'none'}`;
-
-    // Set cache headers for Vercel Edge Cache
-    // Cache for 60 seconds, revalidate in background for 300 seconds
-    const response = NextResponse.json(result);
-    
-    response.headers.set(
-      "Cache-Control",
-      search 
-        ? "public, s-maxage=30, stale-while-revalidate=60" // Shorter cache for search queries
-        : "public, s-maxage=60, stale-while-revalidate=300" // Longer cache for standard queries
-    );
-    
-    // Add custom cache tags for Vercel
-    response.headers.set("x-vercel-cache-tags", `videos,published,${cacheKey}`);
-
-    return response;
+    return NextResponse.json(result, { headers: noStoreHeaders });
   } catch (error) {
     serverLogger.error("Error fetching published videos:", error);
     
@@ -80,7 +72,7 @@ export async function GET(request: NextRequest) {
             error: 'Database connection error',
             details: 'Unable to connect to the database. Please try again later.'
           },
-          { status: 503 }
+          { status: 503, headers: noStoreHeaders }
         );
       }
       
@@ -91,7 +83,7 @@ export async function GET(request: NextRequest) {
             error: 'Validation error',
             details: error.message
           },
-          { status: 400 }
+          { status: 400, headers: noStoreHeaders }
         );
       }
     }
@@ -101,7 +93,7 @@ export async function GET(request: NextRequest) {
         error: "Failed to fetch published videos",
         details: error instanceof Error ? error.message : "Unknown error"
       },
-      { status: 500 }
+      { status: 500, headers: noStoreHeaders }
     );
   }
 }

--- a/components/Player/ViewsComponent.tsx
+++ b/components/Player/ViewsComponent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import { EyeIcon } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useLivepeerViewMetrics } from "@/lib/hooks/livepeer/useLivepeerViewMetrics";

--- a/components/Player/ViewsComponent.tsx
+++ b/components/Player/ViewsComponent.tsx
@@ -1,71 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { EyeIcon } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { logger } from '@/lib/utils/logger';
+import { useLivepeerViewMetrics } from "@/lib/hooks/livepeer/useLivepeerViewMetrics";
 
 
 interface ViewsComponentProps {
   playbackId: string;
 }
 
-interface ViewMetrics {
-  playbackId: string;
-  viewCount: number;
-  playtimeMins: number;
-  legacyViewCount: number;
-}
-
 export const ViewsComponent: React.FC<ViewsComponentProps> = ({
   playbackId,
 }) => {
-  const [viewMetrics, setViewMetrics] = useState<ViewMetrics | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function fetchViewMetrics() {
-      if (!playbackId) {
-        setError("No playback ID provided");
-        setLoading(false);
-        return;
-      }
-
-      try {
-        setLoading(true);
-        const response = await fetch(`/api/livepeer/views/${playbackId}`);
-
-        const data = await response.json();
-
-        if (!response.ok) {
-          const msg =
-            typeof data?.error === "string"
-              ? data.error
-              : "Failed to fetch view metrics";
-          throw new Error(msg);
-        }
-        
-        if (data.success) {
-          setViewMetrics({
-            playbackId: data.playbackId,
-            viewCount: data.viewCount,
-            playtimeMins: data.playtimeMins,
-            legacyViewCount: data.legacyViewCount,
-          });
-        } else {
-          setError("Failed to fetch view metrics");
-        }
-      } catch (err) {
-        setError((err as Error).message || "Failed to fetch view metrics");
-        logger.error("Error fetching view metrics:", err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchViewMetrics();
-  }, [playbackId]);
+  const { totalViews, viewMetrics, loading, error } =
+    useLivepeerViewMetrics(playbackId);
 
   if (loading) {
     return (
@@ -96,9 +44,6 @@ export const ViewsComponent: React.FC<ViewsComponentProps> = ({
       </div>
     );
   }
-
-  const totalViews =
-    (viewMetrics.viewCount ?? 0) + (viewMetrics.legacyViewCount ?? 0);
 
   return (
     <div className="flex items-center gap-1 text-sm text-gray-200">

--- a/components/Videos/VideoViewMetrics.tsx
+++ b/components/Videos/VideoViewMetrics.tsx
@@ -1,67 +1,17 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useLivepeerViewMetrics } from "@/lib/hooks/livepeer/useLivepeerViewMetrics";
 
 interface VideoViewMetricsProps {
   playbackId: string;
 }
 
 const VideoViewMetrics: React.FC<VideoViewMetricsProps> = ({ playbackId }) => {
-  const [viewMetrics, setViewMetrics] = useState<{
-    playbackId: string;
-    viewCount: number;
-    playtimeMins: number;
-    legacyViewCount: number;
-  } | null>(null);
-
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function fetchViewMetrics() {
-      if (!playbackId) {
-        setLoading(false);
-        return;
-      }
-
-      try {
-        const response = await fetch(`/api/livepeer/views/${playbackId}`);
-        
-        const data = await response.json();
-
-        if (!response.ok) {
-          const msg =
-            typeof data?.error === "string"
-              ? data.error
-              : "Failed to fetch view metrics";
-          throw new Error(msg);
-        }
-        
-        if (data.success) {
-          setViewMetrics({
-            playbackId: data.playbackId,
-            viewCount: data.viewCount,
-            playtimeMins: data.playtimeMins,
-            legacyViewCount: data.legacyViewCount,
-          });
-        } else {
-          setError("Failed to fetch view metrics");
-        }
-      } catch (err) {
-        setError((err as Error).message || "Failed to fetch view metrics");
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchViewMetrics();
-  }, [playbackId]);
+  const { totalViews, loading, error } = useLivepeerViewMetrics(playbackId);
 
   if (loading) return <Skeleton className="w-16 h-4" />;
   if (error) return <p>Error: {error}</p>;
-
-  const totalViews =
-    (viewMetrics?.viewCount ?? 0) + (viewMetrics?.legacyViewCount ?? 0);
 
   return (
     <>

--- a/lib/hooks/livepeer/useLivepeerViewMetrics.test.ts
+++ b/lib/hooks/livepeer/useLivepeerViewMetrics.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLivepeerViewMetrics } from "./useLivepeerViewMetrics";
+
+describe("fetchLivepeerViewMetrics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("parses a successful payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          success: true,
+          playbackId: "playback-1",
+          viewCount: 3,
+          playtimeMins: 10,
+          legacyViewCount: 2,
+        }),
+      ),
+    );
+
+    await expect(fetchLivepeerViewMetrics("playback-1")).resolves.toEqual({
+      playbackId: "playback-1",
+      viewCount: 3,
+      playtimeMins: 10,
+      legacyViewCount: 2,
+    });
+  });
+
+  it("throws with server error message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ error: "Server broke" }, { status: 503 }),
+      ),
+    );
+
+    await expect(fetchLivepeerViewMetrics("p1")).rejects.toThrow(
+      "Server broke",
+    );
+  });
+
+  it("aborts when signal is aborted", async () => {
+    const ac = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((_resolve, reject) => {
+            ac.signal.addEventListener("abort", () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            });
+          }),
+      ),
+    );
+
+    const pending = fetchLivepeerViewMetrics("p1", ac.signal);
+    ac.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/lib/hooks/livepeer/useLivepeerViewMetrics.ts
+++ b/lib/hooks/livepeer/useLivepeerViewMetrics.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { skipToken, useQuery } from "@tanstack/react-query";
 
 export interface LivepeerViewMetrics {
   playbackId: string;
@@ -15,107 +15,84 @@ interface UseLivepeerViewMetricsOptions {
 
 const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
 
+export function livepeerViewMetricsQueryKey(playbackId: string) {
+  return ["livepeer-view-metrics", playbackId] as const;
+}
+
+export async function fetchLivepeerViewMetrics(
+  playbackId: string,
+  signal?: AbortSignal,
+): Promise<LivepeerViewMetrics> {
+  const response = await fetch(
+    `/api/livepeer/views/${encodeURIComponent(playbackId)}?t=${Date.now()}`,
+    {
+      cache: "no-store",
+      headers: {
+        "Cache-Control": "no-cache",
+        Pragma: "no-cache",
+      },
+      signal,
+    },
+  );
+
+  const data = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const message =
+      typeof data?.error === "string"
+        ? data.error
+        : "Failed to fetch view metrics";
+    throw new Error(message);
+  }
+
+  if (!data.success) {
+    throw new Error("Failed to fetch view metrics");
+  }
+
+  return {
+    playbackId: String(data.playbackId ?? playbackId),
+    viewCount: Number(data.viewCount ?? 0) || 0,
+    playtimeMins: Number(data.playtimeMins ?? 0) || 0,
+    legacyViewCount: Number(data.legacyViewCount ?? 0) || 0,
+  };
+}
+
+/** Shared via React Query so duplicate playbackIds dedupe fetches and polling. */
 export function useLivepeerViewMetrics(
   playbackId: string,
   options: UseLivepeerViewMetricsOptions = {},
 ) {
   const refreshIntervalMs =
     options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
-  const [viewMetrics, setViewMetrics] = useState<LivepeerViewMetrics | null>(
-    null,
-  );
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!playbackId) {
-      setViewMetrics(null);
-      setError(null);
-      setLoading(false);
-      return;
-    }
+  const id = playbackId?.trim() ?? "";
+  const enabled = id.length > 0;
 
-    let isMounted = true;
-    let controller: AbortController | null = null;
+  const query = useQuery({
+    queryKey: livepeerViewMetricsQueryKey(enabled ? id : "__skipped__"),
+    queryFn: enabled
+      ? ({ signal }) => fetchLivepeerViewMetrics(id, signal)
+      : skipToken,
+    staleTime: 0,
+    refetchInterval:
+      enabled && refreshIntervalMs > 0 ? refreshIntervalMs : false,
+  });
 
-    async function fetchViewMetrics(showLoading: boolean) {
-      controller?.abort();
-      controller = new AbortController();
-      const signal = controller.signal;
-
-      if (showLoading) {
-        setLoading(true);
-      }
-      setError(null);
-
-      try {
-        const response = await fetch(
-          `/api/livepeer/views/${encodeURIComponent(playbackId)}?t=${Date.now()}`,
-          {
-            cache: "no-store",
-            headers: {
-              "Cache-Control": "no-cache",
-              Pragma: "no-cache",
-            },
-            signal,
-          },
-        );
-
-        const data = await response.json();
-
-        if (!response.ok) {
-          const message =
-            typeof data?.error === "string"
-              ? data.error
-              : "Failed to fetch view metrics";
-          throw new Error(message);
-        }
-
-        if (!data.success) {
-          throw new Error("Failed to fetch view metrics");
-        }
-
-        if (isMounted) {
-          setViewMetrics({
-            playbackId: data.playbackId,
-            viewCount: data.viewCount,
-            playtimeMins: data.playtimeMins,
-            legacyViewCount: data.legacyViewCount,
-          });
-        }
-      } catch (err) {
-        if (!isMounted || signal.aborted) return;
-        setError((err as Error).message || "Failed to fetch view metrics");
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
-      }
-    }
-
-    fetchViewMetrics(true);
-
-    const intervalId =
-      refreshIntervalMs > 0
-        ? window.setInterval(() => fetchViewMetrics(false), refreshIntervalMs)
-        : undefined;
-
-    return () => {
-      isMounted = false;
-      controller?.abort();
-      if (intervalId) {
-        window.clearInterval(intervalId);
-      }
-    };
-  }, [playbackId, refreshIntervalMs]);
-
+  const viewMetrics = query.data ?? null;
   const totalViews =
     (viewMetrics?.viewCount ?? 0) + (viewMetrics?.legacyViewCount ?? 0);
+
+  const errorMsg =
+    query.error instanceof Error
+      ? query.error.message
+      : query.error != null
+        ? String(query.error)
+        : null;
 
   return {
     viewMetrics,
     totalViews,
-    loading,
-    error,
+    loading: enabled ? query.isPending : false,
+    error: errorMsg,
   };
 }

--- a/lib/hooks/livepeer/useLivepeerViewMetrics.ts
+++ b/lib/hooks/livepeer/useLivepeerViewMetrics.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface LivepeerViewMetrics {
+  playbackId: string;
+  viewCount: number;
+  playtimeMins: number;
+  legacyViewCount: number;
+}
+
+interface UseLivepeerViewMetricsOptions {
+  refreshIntervalMs?: number;
+}
+
+const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
+
+export function useLivepeerViewMetrics(
+  playbackId: string,
+  options: UseLivepeerViewMetricsOptions = {},
+) {
+  const refreshIntervalMs =
+    options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
+  const [viewMetrics, setViewMetrics] = useState<LivepeerViewMetrics | null>(
+    null,
+  );
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!playbackId) {
+      setViewMetrics(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    let controller: AbortController | null = null;
+
+    async function fetchViewMetrics(showLoading: boolean) {
+      controller?.abort();
+      controller = new AbortController();
+      const signal = controller.signal;
+
+      if (showLoading) {
+        setLoading(true);
+      }
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/livepeer/views/${encodeURIComponent(playbackId)}?t=${Date.now()}`,
+          {
+            cache: "no-store",
+            headers: {
+              "Cache-Control": "no-cache",
+              Pragma: "no-cache",
+            },
+            signal,
+          },
+        );
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          const message =
+            typeof data?.error === "string"
+              ? data.error
+              : "Failed to fetch view metrics";
+          throw new Error(message);
+        }
+
+        if (!data.success) {
+          throw new Error("Failed to fetch view metrics");
+        }
+
+        if (isMounted) {
+          setViewMetrics({
+            playbackId: data.playbackId,
+            viewCount: data.viewCount,
+            playtimeMins: data.playtimeMins,
+            legacyViewCount: data.legacyViewCount,
+          });
+        }
+      } catch (err) {
+        if (!isMounted || signal.aborted) return;
+        setError((err as Error).message || "Failed to fetch view metrics");
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchViewMetrics(true);
+
+    const intervalId =
+      refreshIntervalMs > 0
+        ? window.setInterval(() => fetchViewMetrics(false), refreshIntervalMs)
+        : undefined;
+
+    return () => {
+      isMounted = false;
+      controller?.abort();
+      if (intervalId) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [playbackId, refreshIntervalMs]);
+
+  const totalViews =
+    (viewMetrics?.viewCount ?? 0) + (viewMetrics?.legacyViewCount ?? 0);
+
+  return {
+    viewMetrics,
+    totalViews,
+    loading,
+    error,
+  };
+}

--- a/lib/utils/published-videos-client.ts
+++ b/lib/utils/published-videos-client.ts
@@ -20,7 +20,7 @@ export interface PublishedVideosResponse {
 
 /**
  * Client-side utility to fetch published videos from the API
- * Uses Vercel Edge Cache for optimal performance
+ * Uses an uncached request so view-count ordering reflects the latest synced data.
  */
 export async function fetchPublishedVideos(
   options: FetchPublishedVideosOptions = {}
@@ -37,12 +37,11 @@ export async function fetchPublishedVideos(
 
   const response = await fetch(`/api/video-assets/published?${params.toString()}`, {
     method: "GET",
+    cache: "no-store",
     headers: {
       "Content-Type": "application/json",
-    },
-    // Use Next.js cache revalidation
-    next: {
-      revalidate: options.search ? 30 : 60, // Shorter cache for search
+      "Cache-Control": "no-cache",
+      Pragma: "no-cache",
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the Server Action directive from the Livepeer views helper so Next.js production builds can compile.
- Force Livepeer view metric and published video API responses to bypass cache.
- Implement `useLivepeerViewMetrics` with **TanStack React Query** (`useQuery`) so all components sharing a `playbackId` share one request and one polling interval; empty IDs use `skipToken`.
- Export `fetchLivepeerViewMetrics`, `livepeerViewMetricsQueryKey`, and Vitest coverage for the client fetch parser.
- Earlier: Vitest coverage for server Livepeer helpers (`app/api/livepeer/views.test.ts`).

### Testing
- `yarn vitest run app/api/livepeer/views.test.ts`
- `yarn vitest run lib/hooks/livepeer/useLivepeerViewMetrics.test.ts`
- `./node_modules/.bin/eslint` on touched TS/TSX files (full `yarn lint` still fails on generated `public/workbox-*.js`).

### Deploy / local build notes
Production-style `yarn run build` in CI needs real env; locally, placeholder public vars can unblock collect-page-data failures unrelated to this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78bcbbc4-32ee-4a90-8abe-8ab1ace27bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78bcbbc4-32ee-4a90-8abe-8ab1ace27bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

