### PR TITLE
Fix zero video views, Lens mainnet RPC, and Orb modules integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ SUPABASE_SERVICE_ROLE_KEY=
 LIVEPEER_API_KEY=
 
 # --- Livepeer (server routes prefer LIVEPEER_FULL_API_KEY; view metrics fall back to LIVEPEER_API_KEY if unset) ---
+# View counts: Studio key must have Viewers/Data API access. On Vercel production, set LIVEPEER_FULL_API_URL
+# to https://livepeer.studio (or leave unset). Smoke test: GET /api/livepeer/views/<playbackId>
 LIVEPEER_FULL_API_KEY=
 LIVEPEER_FULL_API_URL=https://livepeer.studio
 LIVEPEER_API_URL=https://livepeer.studio

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,16 @@ NEXT_PUBLIC_ENABLE_FILECOIN_ARCHIVAL=
 # --- App URL (for server-side redirects / webhooks; Vercel sets VERCEL_URL) ---
 NEXT_PUBLIC_APP_URL=
 
+# --- Orb (@orbclub/modules) — parallel sovereign auth + media ---
+# Defaults use orbapi.xyz QR + api.lens.xyz/graphql; override only if needed.
+NEXT_PUBLIC_LENS_GRAPHQL_URL=
+NEXT_PUBLIC_ORB_QR_INIT_URL=
+NEXT_PUBLIC_ORB_QR_POLL_URL=
+NEXT_PUBLIC_ORB_MEDIA_GATEWAY=
+NEXT_PUBLIC_ORB_LENS_GATEWAY=
+NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY=
+NEXT_PUBLIC_GROVE_API_URL=
+
 # --- Optional / feature flags ---
 NEXT_PUBLIC_STACK_API_KEY=
 NEXT_PUBLIC_LENS_ENV=

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,14 @@ LIVEPEER_WEBHOOK_ID=
 NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID=
 NEXT_PUBLIC_ALCHEMY_RPC_URL=
 NEXT_PUBLIC_BASE_RPC_URL=
+# Lens Chain — Alchemy quickstart: https://www.alchemy.com/docs/reference/lens-api-quickstart
+# Default (no NEXT_PUBLIC_LENS_ENV): Lens Sepolia testnet (37111, GRASS) via NEXT_PUBLIC_ALCHEMY_API_KEY
+#   → https://lens-sepolia.g.alchemy.com/v2/<key>
+# Production: NEXT_PUBLIC_LENS_ENV=production → mainnet (232, GHO); same key if Lens mainnet is on your Alchemy app
+#   → https://lens-mainnet.g.alchemy.com/v2/<key> (else falls back to https://rpc.lens.xyz)
+# Optional full URL override: NEXT_PUBLIC_LENS_RPC_URL=
+NEXT_PUBLIC_LENS_ENV=
+NEXT_PUBLIC_LENS_RPC_URL=
 ALCHEMY_SWAP_PRIVATE_KEY=
 NEXT_PUBLIC_ANYTOKEN_POLICY_ID=
 

--- a/app/api/creator-profiles/link-orb/route.ts
+++ b/app/api/creator-profiles/link-orb/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { checkBotId } from 'botid/server';
+import { createOrbLogin } from '@orbclub/modules/auth';
+import { supabaseService } from '@/lib/sdk/supabase/service';
+import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
+import { serverLogger } from '@/lib/utils/logger';
+import { rateLimiters } from '@/lib/middleware/rateLimit';
+
+export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(request);
+  if (rl) return rl;
+
+  try {
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid JSON body' },
+        { status: 400 },
+      );
+    }
+
+    const accessToken = String(body.accessToken ?? '').trim();
+    const ownerAddress = String(body.owner_address ?? '').trim().toLowerCase();
+    const refreshToken = body.refreshToken
+      ? String(body.refreshToken).trim()
+      : undefined;
+    const authenticationId = body.authentication_id
+      ? String(body.authentication_id).trim()
+      : body.authenticationId
+        ? String(body.authenticationId).trim()
+        : undefined;
+    const lensAccountId = body.lens_account_id
+      ? String(body.lens_account_id).trim().toLowerCase()
+      : undefined;
+    const lensHandle = body.lens_handle ? String(body.lens_handle).trim() : undefined;
+    const lensAvatarUri = body.lens_avatar_uri
+      ? String(body.lens_avatar_uri).trim()
+      : undefined;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { success: false, error: 'accessToken is required' },
+        { status: 400 },
+      );
+    }
+
+    const orb = createOrbLogin();
+    const lensFromToken = orb.getAccountFromAccessToken(accessToken);
+    const resolvedLensAccount = (lensAccountId || lensFromToken || '').toLowerCase();
+    const resolvedOwner = (ownerAddress || resolvedLensAccount).toLowerCase();
+
+    if (!resolvedOwner) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'owner_address or a Lens account from the Orb token is required',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (ownerAddress) {
+      try {
+        await requireWalletAuthFor(request, ownerAddress);
+      } catch (authErr) {
+        if (authErr instanceof WalletAuthError) {
+          return NextResponse.json(
+            { success: false, error: authErr.message },
+            { status: authErr.status },
+          );
+        }
+        throw authErr;
+      }
+    }
+
+    if (!supabaseService) {
+      return NextResponse.json(
+        { success: false, error: 'Database service unavailable' },
+        { status: 500 },
+      );
+    }
+
+    const orbAccountId =
+      authenticationId || resolvedLensAccount || resolvedOwner;
+
+    const payload: Record<string, unknown> = {
+      owner_address: resolvedOwner,
+      orb_account_id: orbAccountId,
+      updated_at: new Date().toISOString(),
+    };
+    if (resolvedLensAccount) payload.lens_account_id = resolvedLensAccount;
+    if (lensHandle) payload.lens_handle = lensHandle;
+    if (lensAvatarUri) {
+      payload.lens_avatar_uri = lensAvatarUri;
+      if (!body.avatar_url) payload.avatar_url = lensAvatarUri;
+    }
+
+    const { data, error } = await supabaseService
+      .from('creator_profiles')
+      .upsert(payload, { onConflict: 'owner_address' })
+      .select()
+      .single();
+
+    if (error) {
+      serverLogger.error('[link-orb] upsert failed:', error);
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    serverLogger.error('[link-orb] error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/creator-profiles/upsert/route.ts
+++ b/app/api/creator-profiles/upsert/route.ts
@@ -39,6 +39,10 @@ export async function POST(request: NextRequest) {
       twin_address,
       twin_avatar_glb_url,
       twin_chat_endpoint,
+      orb_account_id,
+      lens_account_id,
+      lens_handle,
+      lens_avatar_uri,
     } = body;
 
     if (!owner_address) {
@@ -77,6 +81,10 @@ export async function POST(request: NextRequest) {
     }
     if (twin_avatar_glb_url !== undefined) payload.twin_avatar_glb_url = twin_avatar_glb_url;
     if (twin_chat_endpoint !== undefined) payload.twin_chat_endpoint = twin_chat_endpoint;
+    if (orb_account_id !== undefined) payload.orb_account_id = orb_account_id;
+    if (lens_account_id !== undefined) payload.lens_account_id = lens_account_id;
+    if (lens_handle !== undefined) payload.lens_handle = lens_handle;
+    if (lens_avatar_uri !== undefined) payload.lens_avatar_uri = lens_avatar_uri;
 
     let data, error;
 

--- a/app/api/livepeer/views/[playbackId]/route.ts
+++ b/app/api/livepeer/views/[playbackId]/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchAllViews } from '@/app/api/livepeer/views';
-import { createClient } from '@/lib/sdk/supabase/server';
+import { createServiceClient } from '@/lib/sdk/supabase/service';
+import {
+  mergeViewCounts,
+  resolveViewCountSource,
+  sumLivepeerViewMetrics,
+} from '@/lib/livepeer/view-count';
+import { getStoredViewsCount } from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
 
 /**
- * Read-only endpoint to fetch view metrics from Livepeer
- * Falls back to database views_count if Livepeer API fails or returns 0
+ * Read-only endpoint: returns max(Livepeer views, database views_count).
  */
 export async function GET(
   request: NextRequest,
@@ -21,41 +26,22 @@ export async function GET(
       );
     }
 
-    // Fetch metrics from Livepeer API
     const metrics = await fetchAllViews(playbackId);
+    const livepeerTotal = metrics ? sumLivepeerViewMetrics(metrics) : 0;
 
-    if (metrics) {
-      const livepeerTotal =
-        (metrics.viewCount ?? 0) + (metrics.legacyViewCount ?? 0);
-
-      if (livepeerTotal > 0) {
-        return NextResponse.json({
-          success: true,
-          source: 'livepeer' as const,
-          ...metrics,
-        });
-      }
-    }
-
-    // Livepeer returned 0 or failed — fall back to database views_count
-    const supabase = await createClient();
-    const { data: videoAsset } = await supabase
-      .from('video_assets')
-      .select('views_count')
-      .eq('playback_id', playbackId)
-      .single();
-
-    const dbViewCount = videoAsset?.views_count ?? 0;
+    const supabase = createServiceClient();
+    const dbViewCount = await getStoredViewsCount(supabase, playbackId);
+    const displayTotal = mergeViewCounts(dbViewCount, livepeerTotal);
+    const source = resolveViewCountSource(livepeerTotal, dbViewCount);
 
     return NextResponse.json({
       success: true,
-      source: 'database' as const,
+      source,
       playbackId,
-      viewCount: dbViewCount,
+      viewCount: displayTotal,
       playtimeMins: metrics?.playtimeMins ?? 0,
       legacyViewCount: 0,
     });
-
   } catch (error) {
     serverLogger.error('Error fetching view metrics:', error);
     return NextResponse.json(
@@ -64,4 +50,3 @@ export async function GET(
     );
   }
 }
-

--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkBotId } from 'botid/server';
-import { createClient } from '@/lib/sdk/supabase/server';
+import { createServiceClient } from '@/lib/sdk/supabase/service';
 import { fetchAllViews } from '@/app/api/livepeer/views';
+import { sumLivepeerViewMetrics } from '@/lib/livepeer/view-count';
+import { syncStoredViewsCount } from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 
@@ -18,17 +20,15 @@ export async function POST(
 
   try {
     const { playbackId } = await params;
-    
-    // Safely parse JSON body, falling back to empty object on empty/invalid body
-    let body: any = {};
+
+    let body: { viewCount?: number } = {};
     try {
       body = await request.json();
-    } catch (jsonError) {
-      // Empty or invalid JSON body - use empty object
+    } catch {
       body = {};
     }
-    
-    const { viewCount } = body || {};
+
+    const { viewCount: bodyViewCount } = body;
 
     if (!playbackId) {
       return NextResponse.json(
@@ -37,10 +37,12 @@ export async function POST(
       );
     }
 
-    // If viewCount is provided in the request body, use it
-    // Otherwise, fetch from Livepeer API
-    let finalViewCount = viewCount;
-    if (!finalViewCount) {
+    const supabase = createServiceClient();
+    let livepeerTotal: number;
+
+    if (bodyViewCount != null && bodyViewCount > 0) {
+      livepeerTotal = bodyViewCount;
+    } else {
       const metrics = await fetchAllViews(playbackId);
       if (!metrics) {
         return NextResponse.json(
@@ -48,69 +50,55 @@ export async function POST(
           { status: 500 }
         );
       }
-      finalViewCount = metrics.viewCount + metrics.legacyViewCount;
+      livepeerTotal = sumLivepeerViewMetrics(metrics);
     }
 
-    // Update the database
-    const supabase = await createClient();
-    const { error } = await supabase
-      .from('video_assets')
-      .update({ views_count: finalViewCount })
-      .eq('playback_id', playbackId);
-
-    if (error) {
-      serverLogger.error('Failed to update view count:', error);
-      return NextResponse.json(
-        { error: 'Failed to update view count in database' },
-        { status: 500 }
-      );
-    }
+    const { viewCount } = await syncStoredViewsCount(
+      supabase,
+      playbackId,
+      livepeerTotal,
+    );
 
     return NextResponse.json({
       success: true,
       playbackId,
-      viewCount: finalViewCount
+      viewCount,
     });
-
   } catch (error) {
     serverLogger.error('Error syncing view count:', error);
-    
-    // Handle specific error types
+
     if (error instanceof Error) {
-      // Check for Livepeer API errors
       if (error.message.includes('Livepeer') || error.message.includes('playback')) {
         return NextResponse.json(
-          { 
+          {
             error: 'Livepeer API error',
-            details: 'Unable to fetch view metrics from Livepeer. Please try again later.'
+            details: 'Unable to fetch view metrics from Livepeer. Please try again later.',
           },
           { status: 503 }
         );
       }
-      
-      // Check for database errors
+
       if (error.message.includes('database') || error.message.includes('connection')) {
         return NextResponse.json(
-          { 
+          {
             error: 'Database error',
-            details: 'Unable to update view count in database. Please try again later.'
+            details: 'Unable to update view count in database. Please try again later.',
           },
           { status: 503 }
         );
       }
     }
-    
+
     return NextResponse.json(
-      { 
+      {
         error: 'Internal server error',
-        details: error instanceof Error ? error.message : 'Unknown error'
+        details: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );
   }
 }
 
-// Also support GET for manual syncing
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> }
@@ -125,7 +113,6 @@ export async function GET(
       );
     }
 
-    // Fetch from Livepeer API
     const metrics = await fetchAllViews(playbackId);
     if (!metrics) {
       return NextResponse.json(
@@ -134,61 +121,48 @@ export async function GET(
       );
     }
 
-    const totalViews = metrics.viewCount + metrics.legacyViewCount;
-
-    // Update the database
-    const supabase = await createClient();
-    const { error } = await supabase
-      .from('video_assets')
-      .update({ views_count: totalViews })
-      .eq('playback_id', playbackId);
-
-    if (error) {
-      serverLogger.error('Failed to update view count:', error);
-      return NextResponse.json(
-        { error: 'Failed to update view count in database' },
-        { status: 500 }
-      );
-    }
+    const livepeerTotal = sumLivepeerViewMetrics(metrics);
+    const supabase = createServiceClient();
+    const { viewCount } = await syncStoredViewsCount(
+      supabase,
+      playbackId,
+      livepeerTotal,
+    );
 
     return NextResponse.json({
       success: true,
       playbackId,
-      viewCount: totalViews
+      viewCount,
     });
-
   } catch (error) {
     serverLogger.error('Error syncing view count:', error);
-    
-    // Handle specific error types
+
     if (error instanceof Error) {
-      // Check for Livepeer API errors
       if (error.message.includes('Livepeer') || error.message.includes('playback')) {
         return NextResponse.json(
-          { 
+          {
             error: 'Livepeer API error',
-            details: 'Unable to fetch view metrics from Livepeer. Please try again later.'
+            details: 'Unable to fetch view metrics from Livepeer. Please try again later.',
           },
           { status: 503 }
         );
       }
-      
-      // Check for database errors
+
       if (error.message.includes('database') || error.message.includes('connection')) {
         return NextResponse.json(
-          { 
+          {
             error: 'Database error',
-            details: 'Unable to update view count in database. Please try again later.'
+            details: 'Unable to update view count in database. Please try again later.',
           },
           { status: 503 }
         );
       }
     }
-    
+
     return NextResponse.json(
-      { 
+      {
         error: 'Internal server error',
-        details: error instanceof Error ? error.message : 'Unknown error'
+        details: error instanceof Error ? error.message : 'Unknown error',
       },
       { status: 500 }
     );

--- a/app/api/video-assets/sync-views/cron/route.ts
+++ b/app/api/video-assets/sync-views/cron/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/sdk/supabase/service';
 import { fetchAllViews } from '@/app/api/livepeer/views';
+import { mergeViewCounts, sumLivepeerViewMetrics } from '@/lib/livepeer/view-count';
 import { serverLogger } from '@/lib/utils/logger';
 
 export const maxDuration = 300; // 5 minutes for cron jobs
@@ -75,26 +76,27 @@ export async function GET(request: NextRequest) {
             const metrics = await fetchAllViews(video.playback_id);
             
             if (metrics) {
-              const totalViews = metrics.viewCount + metrics.legacyViewCount;
-              
-              // Only update if views have changed (saves DB writes)
-              if (totalViews !== video.views_count) {
+              const livepeerTotal = sumLivepeerViewMetrics(metrics);
+              const merged = mergeViewCounts(video.views_count ?? 0, livepeerTotal);
+
+              if (merged !== video.views_count) {
                 const { error: updateError } = await supabase
                   .from('video_assets')
-                  .update({ views_count: totalViews })
+                  .update({ views_count: merged })
                   .eq('id', video.id);
-                
+
                 if (updateError) {
                   serverLogger.error(`[Cron] Failed to update ${video.playback_id}:`, updateError);
                   errorCount++;
                   errors.push(`${video.title}: ${updateError.message}`);
                 } else {
-                  serverLogger.debug(`[Cron] Updated ${video.title}: ${video.views_count} → ${totalViews} views`);
+                  serverLogger.debug(
+                    `[Cron] Updated ${video.title}: ${video.views_count} → ${merged} views (livepeer=${livepeerTotal})`,
+                  );
                   updatedCount++;
                   successCount++;
                 }
               } else {
-                // No change, but still count as success
                 successCount++;
               }
             } else {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -18,6 +18,8 @@ import { RadixProvider } from "@/components/ui/radix-provider";
 import { cleanupExistingIframes } from "@/components/IframeCleanup";
 import { MembershipGuard } from "@/components/auth/MembershipGuard";
 import { AccountKitStoreGuard } from "@/components/auth/AccountKitStoreGuard";
+import { OrbSessionProvider } from "@/context/OrbSessionContext";
+import { OrbLoginModal } from "@/components/auth/OrbLoginModal";
 import NoSSR from "@/components/NoSSR";
 
 function ErrorFallback({ error }: { error: Error }) {
@@ -75,12 +77,15 @@ export const Providers = (
                     <HeliaProvider>
                       <TourProvider>
                         <VideoProvider>
-                          <AccountKitStoreGuard>
-                          <MembershipGuard>
-                            {props.children}
-                          </MembershipGuard>
-                        </AccountKitStoreGuard>
-                          <Toaster position="top-right" richColors />
+                          <OrbSessionProvider>
+                            <AccountKitStoreGuard>
+                              <MembershipGuard>
+                                {props.children}
+                              </MembershipGuard>
+                            </AccountKitStoreGuard>
+                            <OrbLoginModal />
+                            <Toaster position="top-right" richColors />
+                          </OrbSessionProvider>
                         </VideoProvider>
                       </TourProvider>
                     </HeliaProvider>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -47,6 +47,7 @@ import { TokenBalance } from "./wallet/balance/TokenBalance";
 import { MeTokenBalances } from "./wallet/balance/MeTokenBalances";
 import type { Chain as ViemChain } from "viem";
 import { AccountDropdown } from "@/components/account-dropdown/AccountDropdown";
+import { useOrbSession } from "@/context/OrbSessionContext";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
 import { useMeTokenHoldings } from "@/lib/hooks/metokens/useMeTokenHoldings";
@@ -159,6 +160,8 @@ function NetworkStatus({ isConnected }: { isConnected: boolean }) {
 
 export default function Navbar() {
   const { openAuthModal } = useAuthModal();
+  const { openLoginModal: openOrbLogin, isAuthenticated: isOrbAuthenticated } =
+    useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
@@ -536,6 +539,18 @@ export default function Navbar() {
                     >
                       Get Started
                     </Button>
+                    {!isOrbAuthenticated && (
+                      <Button
+                        variant="outline"
+                        className="w-full mt-2"
+                        onClick={() => {
+                          openOrbLogin();
+                          setIsMenuOpen(false);
+                        }}
+                      >
+                        Sign in with Orb
+                      </Button>
+                    )}
                   </div>
                 )}
               </HydrationSafe>

--- a/components/Player/PreviewPlayer.tsx
+++ b/components/Player/PreviewPlayer.tsx
@@ -17,10 +17,12 @@ import { safelyPauseVideo, safelyPlayVideo } from "@/lib/utils/video-controls";
 import { logger } from '@/lib/utils/logger';
 
 
-export const PreviewPlayer: React.FC<{ src: Src[]; title: string }> = ({
-  src,
-  title,
-}) => {
+export const PreviewPlayer: React.FC<{
+  src: Src[];
+  title: string;
+  /** Canonical Livepeer playback id for view metrics (preferred over parsing src). */
+  playbackId?: string;
+}> = ({ src, title, playbackId: playbackIdProp }) => {
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -246,7 +248,9 @@ export const PreviewPlayer: React.FC<{ src: Src[]; title: string }> = ({
                 <h3 className="text-lg font-medium text-white line-clamp-1">
                   {title}
                 </h3>
-                <ViewsComponent playbackId={getPlaybackId(src)} />
+                <ViewsComponent
+                  playbackId={playbackIdProp || getPlaybackId(src)}
+                />
               </div>
             </div>
 

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -113,6 +113,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
 import { useMeTokenHoldings } from "@/lib/hooks/metokens/useMeTokenHoldings";
 import { chains, lensChain } from "@/config";
+import { useOrbSession } from "@/context/OrbSessionContext";
 import { HydrationSafe } from "@/components/ui/hydration-safe";
 import { useMembershipNFTs, type MembershipNFT } from "@/lib/hooks/unlock/useMembershipNFTs";
 import { LOCK_ADDRESSES } from "@/lib/sdk/unlock/services";
@@ -250,6 +251,14 @@ const SESSION_KEY_TYPES: SessionKeyConfig[] = [
 
 export function AccountDropdown() {
   const { openAuthModal } = useAuthModal();
+  const {
+    isAuthenticated: isOrbAuthenticated,
+    lensAccount,
+    openLoginModal: openOrbLogin,
+    linkProfile,
+    isLinking: isOrbLinking,
+    logout: logoutOrb,
+  } = useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
   const { chain, setChain, isSettingChain } = useChain();
@@ -1337,6 +1346,49 @@ export function AccountDropdown() {
                 )}
               </div>
             </DropdownMenuLabel>
+
+            <DropdownMenuSeparator />
+
+            <div className="px-2 py-2 w-full space-y-2">
+              <p className="text-xs text-muted-foreground">Orb / Lens</p>
+              {isOrbAuthenticated ? (
+                <div className="space-y-2">
+                  <p className="text-xs text-green-600 dark:text-green-400">
+                    Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex-1 text-xs"
+                      disabled={isOrbLinking}
+                      onClick={() =>
+                        linkProfile(smartAccountAddress || user?.address)
+                      }
+                    >
+                      {isOrbLinking ? "Linking…" : "Sync profile"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs"
+                      onClick={() => logoutOrb()}
+                    >
+                      Orb out
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-xs"
+                  onClick={() => openOrbLogin()}
+                >
+                  Sign in with Orb
+                </Button>
+              )}
+            </div>
 
             <DropdownMenuSeparator />
 

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -112,13 +112,14 @@ import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerif
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
 import { useMeTokenHoldings } from "@/lib/hooks/metokens/useMeTokenHoldings";
-import { chains } from "@/config";
+import { chains, lensChain } from "@/config";
 import { HydrationSafe } from "@/components/ui/hydration-safe";
 import { useMembershipNFTs, type MembershipNFT } from "@/lib/hooks/unlock/useMembershipNFTs";
 import { LOCK_ADDRESSES } from "@/lib/sdk/unlock/services";
 
 const chainIconMap: Record<number, string> = {
   [base.id]: "/images/chains/base.svg",
+  [lensChain.id]: "/images/chains/default-chain.svg",
 };
 
 function getChainIcon(chain: { id: number }) {

--- a/components/auth/OrbLoginModal.tsx
+++ b/components/auth/OrbLoginModal.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+import { useOrbSession } from '@/context/OrbSessionContext';
+
+export function OrbLoginModal() {
+  const {
+    isLoginModalOpen,
+    closeLoginModal,
+    connectWithQr,
+    isAuthenticated,
+  } = useOrbSession();
+  const [qrCode, setQrCode] = useState<string | null>(null);
+  const [deepLink, setDeepLink] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoginModalOpen) {
+      setQrCode(null);
+      setDeepLink(null);
+      setError(null);
+      setIsConnecting(false);
+      return;
+    }
+
+    if (isAuthenticated) {
+      closeLoginModal();
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      setIsConnecting(true);
+      setError(null);
+      try {
+        await connectWithQr(({ qrCode: qr, deepLink: link }) => {
+          if (cancelled) return;
+          setQrCode(qr);
+          setDeepLink(link ?? null);
+        });
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Orb sign-in failed');
+        }
+      } finally {
+        if (!cancelled) setIsConnecting(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoginModalOpen, isAuthenticated, connectWithQr, closeLoginModal]);
+
+  return (
+    <Dialog open={isLoginModalOpen} onOpenChange={(open) => !open && closeLoginModal()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Sign in with Orb</DialogTitle>
+          <DialogDescription>
+            Scan the QR code with the Orb app to connect your sovereign Lens identity.
+            You can still use Account Kit for your smart wallet and transactions.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-4 py-2">
+          {isConnecting && !qrCode && (
+            <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
+          )}
+          {qrCode && (
+            <div className="relative h-56 w-56 overflow-hidden rounded-lg border bg-white p-2">
+              <Image
+                src={qrCode}
+                alt="Orb sign-in QR code"
+                fill
+                className="object-contain"
+                unoptimized
+              />
+            </div>
+          )}
+          {deepLink && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={deepLink} target="_blank" rel="noopener noreferrer">
+                Open in Orb app
+              </a>
+            </Button>
+          )}
+          {error && (
+            <p className="text-center text-sm text-destructive">{error}</p>
+          )}
+          {error && (
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setError(null);
+                closeLoginModal();
+              }}
+            >
+              Close
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/home-page/Featured.tsx
+++ b/components/home-page/Featured.tsx
@@ -3,7 +3,10 @@
 import React, { useEffect, useState } from "react";
 import { PreviewPlayer } from "../Player/PreviewPlayer";
 import { getFeaturedPlaybackSource } from "@/lib/hooks/livepeer/useFeaturePlaybackSource";
-import { FEATURED_VIDEO_TITLE } from "@/context/context";
+import {
+  FEATURED_VIDEO_TITLE,
+  LIVEPEER_FEATURED_PLAYBACK_ID,
+} from "@/context/context";
 import { Src } from "@livepeer/react";
 import { useVideo } from "@/context/VideoContext";
 import { logger } from '@/lib/utils/logger';
@@ -96,7 +99,11 @@ const FeaturedVideo: React.FC = () => {
       <h2 className="mb-8 text-2xl font-bold">Featured</h2>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <div className="overflow-hidden rounded-lg bg-gray-900 shadow-md transition-all hover:shadow-lg">
-          <PreviewPlayer src={playbackSource} title={FEATURED_VIDEO_TITLE} />
+          <PreviewPlayer
+            src={playbackSource}
+            title={FEATURED_VIDEO_TITLE}
+            playbackId={LIVEPEER_FEATURED_PLAYBACK_ID}
+          />
         </div>
         <div className="space-y-4">
           <h3 className="text-xl font-medium">{FEATURED_VIDEO_TITLE}</h3>

--- a/components/ui/gateway-image.tsx
+++ b/components/ui/gateway-image.tsx
@@ -7,6 +7,7 @@ import {
   extractIpfsHash,
   getImageUrlWithFallback,
   isIpfsUrl,
+  resolveOrbMediaForGateway,
 } from '@/lib/utils/image-gateway';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { ImageProps } from 'next/image';
@@ -37,13 +38,13 @@ export function GatewayImage({
   ...props
 }: GatewayImageProps) {
   const { fill } = props;
-  const [imageSrc, setImageSrc] = useState(() => {
-    // Convert failing gateways on initial load
-    if (src && convertFailingGateway(src) !== src) {
-      return convertFailingGateway(src);
-    }
-    return src;
-  });
+  const normalizeSrc = (raw: string) => {
+    if (!raw) return raw;
+    const orb = resolveOrbMediaForGateway(raw);
+    return convertFailingGateway(orb);
+  };
+
+  const [imageSrc, setImageSrc] = useState(() => normalizeSrc(src));
   const [fallbackIndex, setFallbackIndex] = useState(0);
   const [hasError, setHasError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -58,9 +59,7 @@ export function GatewayImage({
   // Sync imageSrc state when src prop changes (e.g., when parent updates thumbnailUrl)
   useEffect(() => {
     // Convert failing gateways when src prop changes
-    const convertedSrc = src && convertFailingGateway(src) !== src 
-      ? convertFailingGateway(src) 
-      : (src || '');
+    const convertedSrc = normalizeSrc(src || '');
     
     // Update imageSrc when src prop changes and reset fallback state
     setImageSrc(convertedSrc);

--- a/config.ts
+++ b/config.ts
@@ -8,13 +8,15 @@ import { http } from "viem";
 import { QueryClient } from "@tanstack/react-query";
 import { modularAccountFactoryAddresses } from "./lib/utils/modularAccount";
 import { getStoryChain } from "./lib/sdk/story/chains";
+import { getLensChain } from "./lib/sdk/lens/chains";
 import { SITE_TOPIC_LOGO } from "./context/context";
 import Image from "next/image";
 import React from "react";
 
-// Define the chains we want to support (Base + Story Protocol for client-side signing)
+// Define the chains we want to support (Base + Story + Lens for client-side signing)
 const storyChain = getStoryChain();
-export const chains = [base, storyChain];
+export const lensChain = getLensChain();
+export const chains = [base, storyChain, lensChain];
 
 // Default chain for initial connection
 const defaultChain = base;
@@ -122,6 +124,7 @@ const uiConfig: AlchemyAccountsUIConfig = {
 
 // Transport for Story Protocol (RPC only; client-side signing uses this chain)
 const storyTransport = http(storyChain.rpcUrls.default.http[0] as string);
+const lensTransport = http(lensChain.rpcUrls.default.http[0] as string);
 
 // Create the Account Kit config
 export const config = createConfig(
@@ -131,6 +134,7 @@ export const config = createConfig(
     chains: [
       { chain: base, transport },
       { chain: storyChain, transport: storyTransport },
+      { chain: lensChain, transport: lensTransport },
     ],
     ssr: true,
     enablePopupOauth: true,

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useUser } from '@account-kit/react';
+import useModularAccount from '@/lib/hooks/accountkit/useModularAccount';
+import {
+  getOrbLogin,
+  loadStoredOrbSession,
+  saveStoredOrbSession,
+  type StoredOrbSession,
+} from '@/lib/sdk/orb/login';
+import { toast } from 'sonner';
+
+type OrbSessionContextValue = {
+  session: StoredOrbSession | null;
+  lensAccount: string | null;
+  isAuthenticated: boolean;
+  isLinking: boolean;
+  isLoginModalOpen: boolean;
+  openLoginModal: () => void;
+  closeLoginModal: () => void;
+  connectWithQr: (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => Promise<void>;
+  logout: () => Promise<void>;
+  syncSession: () => Promise<StoredOrbSession | null>;
+  linkProfile: (ownerAddress?: string) => Promise<void>;
+};
+
+const OrbSessionContext = createContext<OrbSessionContextValue | null>(null);
+
+export function OrbSessionProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<StoredOrbSession | null>(null);
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isLinking, setIsLinking] = useState(false);
+  const user = useUser();
+  const { account: modularAccount } = useModularAccount();
+  const orb = useMemo(() => getOrbLogin(), []);
+
+  const lensAccount = useMemo(() => {
+    if (!session?.accessToken) return null;
+    return orb.getAccountFromAccessToken(session.accessToken);
+  }, [session, orb]);
+
+  useEffect(() => {
+    setSession(loadStoredOrbSession());
+  }, []);
+
+  const persistSession = useCallback((next: StoredOrbSession | null) => {
+    saveStoredOrbSession(next);
+    setSession(next);
+  }, []);
+
+  const syncSession = useCallback(async () => {
+    if (!session?.accessToken) return null;
+    try {
+      const synced = await orb.syncSession({
+        accessToken: session.accessToken,
+        refreshToken: session.refreshToken,
+        authenticationId: session.authenticationId,
+      });
+      if (!synced?.accessToken) return null;
+      const stored: StoredOrbSession = {
+        accessToken: synced.accessToken,
+        refreshToken: synced.refreshToken ?? session.refreshToken,
+        authenticationId: synced.authenticationId ?? session.authenticationId,
+        idToken: synced.idToken ?? session.idToken,
+      };
+      persistSession(stored);
+      return stored;
+    } catch {
+      return session;
+    }
+  }, [session, orb, persistSession]);
+
+  const linkProfile = useCallback(
+    async (ownerAddress?: string) => {
+      const active = session ?? loadStoredOrbSession();
+      if (!active?.accessToken) return;
+
+      const wallet =
+        ownerAddress ||
+        modularAccount?.address ||
+        user?.address ||
+        lensAccount ||
+        undefined;
+
+      if (!wallet) {
+        toast.error('Connect a wallet or complete Orb sign-in to link your profile.');
+        return;
+      }
+
+      setIsLinking(true);
+      try {
+        const res = await fetch('/api/creator-profiles/link-orb', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            accessToken: active.accessToken,
+            refreshToken: active.refreshToken,
+            authenticationId: active.authenticationId,
+            owner_address: wallet,
+            lens_account_id: lensAccount ?? undefined,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.success) {
+          throw new Error(data.error || 'Failed to link Orb profile');
+        }
+        toast.success('Orb / Lens identity linked to your profile');
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Profile link failed');
+      } finally {
+        setIsLinking(false);
+      }
+    },
+    [session, modularAccount?.address, user?.address, lensAccount],
+  );
+
+  const connectWithQr = useCallback(
+    async (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => {
+      const result = await orb.connectWithQr({
+        onInit: (payload) => {
+          onInit?.({ qrCode: payload.qrCode, deepLink: payload.deepLink });
+        },
+      });
+
+      const stored: StoredOrbSession = {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        authenticationId: result.authenticationId,
+        idToken: result.idToken,
+      };
+      persistSession(stored);
+      setIsLoginModalOpen(false);
+      toast.success('Signed in with Orb');
+
+      const wallet = modularAccount?.address || user?.address;
+      if (wallet) {
+        await linkProfile(wallet);
+      }
+    },
+    [orb, persistSession, modularAccount?.address, user?.address, linkProfile],
+  );
+
+  const logout = useCallback(async () => {
+    if (session?.authenticationId && session.accessToken) {
+      try {
+        await orb.revoke({
+          authenticationId: session.authenticationId,
+          accessToken: session.accessToken,
+        });
+      } catch {
+        // still clear local session
+      }
+    }
+    persistSession(null);
+    toast.success('Signed out of Orb');
+  }, [session, orb, persistSession]);
+
+  const value = useMemo<OrbSessionContextValue>(
+    () => ({
+      session,
+      lensAccount,
+      isAuthenticated: !!session?.accessToken,
+      isLinking,
+      isLoginModalOpen,
+      openLoginModal: () => setIsLoginModalOpen(true),
+      closeLoginModal: () => setIsLoginModalOpen(false),
+      connectWithQr,
+      logout,
+      syncSession,
+      linkProfile,
+    }),
+    [
+      session,
+      lensAccount,
+      isLinking,
+      isLoginModalOpen,
+      connectWithQr,
+      logout,
+      syncSession,
+      linkProfile,
+    ],
+  );
+
+  return (
+    <OrbSessionContext.Provider value={value}>{children}</OrbSessionContext.Provider>
+  );
+}
+
+export function useOrbSession(): OrbSessionContextValue {
+  const ctx = useContext(OrbSessionContext);
+  if (!ctx) {
+    throw new Error('useOrbSession must be used within OrbSessionProvider');
+  }
+  return ctx;
+}

--- a/hooks/useLens.ts
+++ b/hooks/useLens.ts
@@ -4,7 +4,8 @@ import { useState, useCallback, useEffect } from "react";
 import { useSmartAccountClient, useUser } from "@account-kit/react";
 import { signLensChallenge } from "@/lib/sdk/lens/account-kit-adapter";
 import { publicClient } from "@/lib/sdk/lens/client";
-import { textOnly, video, MediaVideoMimeType, MetadataLicenseType } from "@lens-protocol/metadata";
+import { useOrbSession } from "@/context/OrbSessionContext";
+import { video, MediaVideoMimeType, MetadataLicenseType } from "@lens-protocol/metadata";
 import { groveService } from "@/lib/sdk/grove/service";
 import { post } from "@lens-protocol/client/actions";
 import { uri, SessionClient } from "@lens-protocol/client";
@@ -12,144 +13,154 @@ import { WalletClient } from "viem";
 import { toast } from "sonner";
 
 export interface CreatePostParams {
-    content: string;
-    mediaUrl: string;
-    title?: string;
-    coverUrl?: string;
-    mimeType?: MediaVideoMimeType;
+  content: string;
+  mediaUrl: string;
+  title?: string;
+  coverUrl?: string;
+  mimeType?: MediaVideoMimeType;
 }
 
 export interface UseLensReturn {
-    isLoggedIn: boolean;
-    isPosting: boolean;
-    login: () => Promise<void>;
-    createPost: (params: CreatePostParams) => Promise<string | undefined>;
+  isLoggedIn: boolean;
+  isPosting: boolean;
+  login: () => Promise<void>;
+  createPost: (params: CreatePostParams) => Promise<string | undefined>;
 }
 
 export function useLens(): UseLensReturn {
-    const [sessionClient, setSessionClient] = useState<SessionClient | null>(null);
-    const [isPosting, setIsPosting] = useState(false);
-    const { client } = useSmartAccountClient({
-        accountParams: { mode: "7702" },
+  const [sessionClient, setSessionClient] = useState<SessionClient | null>(null);
+  const [isPosting, setIsPosting] = useState(false);
+  const { client } = useSmartAccountClient({
+    accountParams: { mode: "7702" },
+  });
+  const user = useUser();
+  const accountAddress = user?.address;
+  const orb = useOrbSession();
+  const hydrateSessionClientFromWallet = useCallback(async (): Promise<SessionClient | null> => {
+    if (!client || !accountAddress) {
+      toast.error("Please connect your wallet first.");
+      return null;
+    }
+
+    const challengeResult = await publicClient.challenge({
+      onboardingUser: { wallet: accountAddress },
     });
-    const user = useUser();
-    const accountAddress = user?.address;
 
-    // TODO: Ideally we persist the session in local storage or use the SDK's storage provider
-    // for auto-resume. For now, we'll keep it in state.
+    if (challengeResult.isErr()) {
+      throw new Error(challengeResult.error.message);
+    }
 
-    const login = useCallback(async () => {
-        if (!client || !accountAddress) {
-            toast.error("Please connect your wallet first.");
-            return;
+    const { id, text } = challengeResult.value;
+    const signature = await signLensChallenge(
+      client as unknown as WalletClient,
+      accountAddress,
+      text,
+    );
+
+    const authResult = await publicClient.authenticate({ id, signature });
+    if (authResult.isErr()) {
+      throw new Error(authResult.error.message);
+    }
+
+    const session = authResult.value;
+    setSessionClient(session);
+    return session;
+  }, [client, accountAddress]);
+
+  const login = useCallback(async () => {
+    if (orb.isAuthenticated && orb.session?.accessToken) {
+      try {
+        const synced = await orb.syncSession();
+        if (synced?.accessToken) {
+          toast.success("Lens session synced via Orb");
+          if (accountAddress) {
+            await orb.linkProfile(accountAddress);
+          }
+          return;
         }
+      } catch (err) {
+        console.error("Orb Lens sync failed:", err);
+      }
+    }
 
-        try {
-            // 1. Request Challenge
-            // Using `onboardingUser` for wallet-based login.
-            const challengeResult = await publicClient.challenge({
-                onboardingUser: {
-                    wallet: accountAddress,
-                },
-            });
+    orb.openLoginModal();
+  }, [orb, accountAddress]);
 
-            if (challengeResult.isErr()) {
-                throw new Error(challengeResult.error.message);
-            }
+  useEffect(() => {
+    if (!orb.session?.accessToken) return;
+    orb.syncSession().catch(() => undefined);
+  }, [orb.session?.accessToken, orb.syncSession]);
 
-            const { id, text } = challengeResult.value;
-
-            // 2. Sign Challenge
-            const signature = await signLensChallenge(
-                client as unknown as WalletClient,
-                accountAddress,
-                text
-            );
-
-            // 3. Authenticate
-            const authResult = await publicClient.authenticate({
-                id,
-                signature,
-            });
-
-            if (authResult.isErr()) {
-                throw new Error(authResult.error.message);
-            }
-
-            const session = authResult.value;
-            setSessionClient(session);
-            toast.success("Signed in to Lens!");
-
-        } catch (err: any) {
-            console.error("Lens Login Error:", err);
-            toast.error(`Login failed: ${err.message}`);
-        }
-    }, [client, accountAddress]);
-
-    const createPost = useCallback(async ({
-        content,
-        mediaUrl,
-        title = "Creative TV Video",
-        coverUrl,
-        mimeType = MediaVideoMimeType.MP4
+  const createPost = useCallback(
+    async ({
+      content,
+      mediaUrl,
+      title = "Creative TV Video",
+      coverUrl,
+      mimeType = MediaVideoMimeType.MP4,
     }: CreatePostParams) => {
-        if (!sessionClient) {
-            await login();
-            // We can't immediately retry because login sets state asynchronously 
-            // and we won't have the sessionClient in this closure instantly.
-            return;
+      let activeClient = sessionClient;
+      if (!activeClient) {
+        activeClient = await hydrateSessionClientFromWallet();
+        if (!activeClient) {
+          if (orb.isAuthenticated) {
+            toast.error(
+              "Connect your smart wallet to post on Lens, or complete Orb sign-in.",
+            );
+            orb.openLoginModal();
+          }
+          return;
+        }
+      }
+
+      setIsPosting(true);
+      try {
+        const metadata = video({
+          title,
+          content,
+          video: {
+            item: mediaUrl,
+            type: mimeType,
+            cover: coverUrl,
+            license: MetadataLicenseType.CCO,
+          },
+          locale: "en",
+        });
+
+        const uploadResult = await groveService.uploadJson(metadata);
+        if (!uploadResult.success || !uploadResult.url) {
+          throw new Error("Failed to upload post metadata to Grove");
         }
 
-        setIsPosting(true);
-        try {
-            // 1. Create Video Metadata
-            const metadata = video({
-                title: title,
-                content: content,
-                video: {
-                    item: mediaUrl,
-                    type: mimeType,
-                    cover: coverUrl, // Optional cover image
-                    license: MetadataLicenseType.CCO, // Defaulting to CC0 for now
-                },
-                locale: "en",
-            });
+        const result = await post(activeClient, {
+          contentUri: uri(uploadResult.url),
+        });
 
-            // 2. Upload to Grove (IPFS)
-            const uploadResult = await groveService.uploadJson(metadata);
-
-            if (!uploadResult.success || !uploadResult.url) {
-                throw new Error("Failed to upload post metadata to Grove");
-            }
-
-            // 3. Create Post
-            const result = await post(sessionClient, {
-                contentUri: uri(uploadResult.url),
-            });
-
-            if (result.isErr()) {
-                throw new Error(result.error.message);
-            }
-
-            const value = result.value;
-
-            console.log("Post result:", value);
-            toast.success("Post submitted to Lens!");
-
-            return "posted";
-
-        } catch (err: any) {
-            console.error("Lens Post Error:", err);
-            toast.error(`Posting failed: ${err.message}`);
-        } finally {
-            setIsPosting(false);
+        if (result.isErr()) {
+          throw new Error(result.error.message);
         }
-    }, [sessionClient, login]);
 
-    return {
-        isLoggedIn: !!sessionClient,
-        isPosting,
-        login,
-        createPost,
-    };
+        toast.success("Post submitted to Lens!");
+        return "posted";
+      } catch (err: unknown) {
+        console.error("Lens Post Error:", err);
+        toast.error(
+          `Posting failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+        );
+      } finally {
+        setIsPosting(false);
+      }
+    },
+    [sessionClient, hydrateSessionClientFromWallet, orb],
+  );
+
+  const isLoggedIn =
+    !!sessionClient || (orb.isAuthenticated && !!orb.session?.accessToken);
+
+  return {
+    isLoggedIn,
+    isPosting,
+    login,
+    createPost,
+  };
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -9,6 +9,7 @@ initBotId({
     { path: '/api/swap/execute', method: 'POST' },
     { path: '/api/ipfs/upload', method: 'POST' },
     { path: '/api/creator-profiles/upsert', method: 'POST' },
+    { path: '/api/creator-profiles/link-orb', method: 'POST' },
     { path: '/api/creator-profiles', method: 'POST' },
     { path: '/api/creator-profiles', method: 'PUT' },
     { path: '/api/creator-profiles', method: 'DELETE' },

--- a/lib/hooks/orb/useOrbSession.ts
+++ b/lib/hooks/orb/useOrbSession.ts
@@ -1,0 +1,1 @@
+export { useOrbSession } from '@/context/OrbSessionContext';

--- a/lib/livepeer/sync-view-count.ts
+++ b/lib/livepeer/sync-view-count.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { mergeViewCounts } from '@/lib/livepeer/view-count';
+
+export async function getStoredViewsCount(
+  supabase: SupabaseClient,
+  playbackId: string,
+): Promise<number> {
+  const { data } = await supabase
+    .from('video_assets')
+    .select('views_count')
+    .eq('playback_id', playbackId)
+    .maybeSingle();
+
+  return data?.views_count ?? 0;
+}
+
+/**
+ * Persists max(stored, livepeer) for a playback id. Never decreases views_count.
+ */
+export async function syncStoredViewsCount(
+  supabase: SupabaseClient,
+  playbackId: string,
+  livepeerTotal: number,
+): Promise<{ viewCount: number; updated: boolean }> {
+  const stored = await getStoredViewsCount(supabase, playbackId);
+  const merged = mergeViewCounts(stored, livepeerTotal);
+
+  if (merged !== stored) {
+    const { error } = await supabase
+      .from('video_assets')
+      .update({ views_count: merged })
+      .eq('playback_id', playbackId);
+
+    if (error) {
+      throw error;
+    }
+
+    return { viewCount: merged, updated: true };
+  }
+
+  return { viewCount: merged, updated: false };
+}

--- a/lib/livepeer/view-count.ts
+++ b/lib/livepeer/view-count.ts
@@ -1,0 +1,28 @@
+/**
+ * Merge stored and Livepeer view counts without decreasing stored values.
+ * Used by read and sync routes so cron/API misreads cannot zero out history.
+ */
+export function mergeViewCounts(stored: number, livepeer: number): number {
+  return Math.max(stored ?? 0, livepeer ?? 0);
+}
+
+export function sumLivepeerViewMetrics(metrics: {
+  viewCount?: number;
+  legacyViewCount?: number;
+}): number {
+  return (metrics.viewCount ?? 0) + (metrics.legacyViewCount ?? 0);
+}
+
+export type ViewCountSource = 'livepeer' | 'database' | 'merged';
+
+export function resolveViewCountSource(
+  livepeerTotal: number,
+  dbViewCount: number,
+): ViewCountSource {
+  if (livepeerTotal > 0 && dbViewCount > 0 && livepeerTotal !== dbViewCount) {
+    return 'merged';
+  }
+  if (livepeerTotal > 0 && livepeerTotal >= dbViewCount) return 'livepeer';
+  if (dbViewCount > 0) return 'database';
+  return 'merged';
+}

--- a/lib/sdk/grove/service.ts
+++ b/lib/sdk/grove/service.ts
@@ -1,6 +1,6 @@
 
 import { StorageClient, immutable } from "@lens-chain/storage-client";
-import { chains } from "@lens-chain/sdk/viem";
+import { getLensChainId } from "@/lib/sdk/lens/chains";
 import { serverLogger } from '@/lib/utils/logger';
 
 export interface GroveUploadResult {
@@ -26,13 +26,7 @@ export class GroveService {
      */
     async uploadFile(file: File): Promise<GroveUploadResult> {
         try {
-            // Use Testnet chain ID for now as per examples (or default to a safe one)
-            // If we are on Mainnet, we should switch. 
-            // Ideally this comes from config, but for now we follow the 'lens-getting-started' pattern.
-            // 37111 is Lens Testnet (Sepolia). 
-            // chains.testnet might ideally map to this.
-
-            const acl = immutable(chains.testnet.id);
+            const acl = immutable(getLensChainId());
 
             const response = await this.client.uploadFile(file, { acl });
 
@@ -68,7 +62,7 @@ export class GroveService {
      */
     async uploadJson(json: unknown): Promise<GroveUploadResult> {
         try {
-            const acl = immutable(chains.testnet.id);
+            const acl = immutable(getLensChainId());
 
             const response = await this.client.uploadAsJson(json, { acl });
 

--- a/lib/sdk/lens/chains.ts
+++ b/lib/sdk/lens/chains.ts
@@ -1,0 +1,64 @@
+/**
+ * Lens Chain definitions for Account Kit, viem, and Grove storage.
+ *
+ * Alchemy quickstart (Lens Sepolia, chain 37111, GRASS):
+ * https://www.alchemy.com/docs/reference/lens-api-quickstart
+ *
+ * Alchemy’s docs emphasize Sepolia testnet; mainnet (232, GHO) uses the same
+ * NEXT_PUBLIC_ALCHEMY_API_KEY when your app has Lens mainnet enabled, or public RPC.
+ */
+import { chains as lensSdkChains } from "@lens-chain/sdk/viem";
+import type { Chain } from "viem";
+
+export type LensNetwork = "mainnet" | "testnet";
+
+/** Lens Sepolia testnet — Alchemy’s documented Lens network (chain 37111). */
+export const LENS_SEPOLIA_CHAIN_ID = lensSdkChains.testnet.id;
+
+/** Lens Chain mainnet (chain 232). */
+export const LENS_MAINNET_CHAIN_ID = lensSdkChains.mainnet.id;
+
+export function getLensNetwork(): LensNetwork {
+  return process.env.NEXT_PUBLIC_LENS_ENV === "production" ? "mainnet" : "testnet";
+}
+
+/** Alchemy JSON-RPC base URLs per Lens network. */
+export function lensAlchemyRpcUrl(network: LensNetwork, apiKey: string): string {
+  return network === "mainnet"
+    ? `https://lens-mainnet.g.alchemy.com/v2/${apiKey}`
+    : `https://lens-sepolia.g.alchemy.com/v2/${apiKey}`;
+}
+
+/**
+ * Resolves Lens Chain RPC URL (client-safe env vars only).
+ * Priority: NEXT_PUBLIC_LENS_RPC_URL → NEXT_PUBLIC_ALCHEMY_API_KEY → public Lens RPC.
+ */
+export function resolveLensRpcUrl(network: LensNetwork = getLensNetwork()): string {
+  const override = process.env.NEXT_PUBLIC_LENS_RPC_URL?.trim();
+  if (override) return override;
+
+  const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY?.trim();
+  if (alchemyKey) return lensAlchemyRpcUrl(network, alchemyKey);
+
+  const fallback = lensSdkChains[network].rpcUrls.default.http[0];
+  if (fallback) return fallback;
+
+  return network === "mainnet" ? "https://rpc.lens.xyz" : "https://rpc.testnet.lens.dev";
+}
+
+/** Lens chain for Account Kit / viem with Alchemy RPC when configured. */
+export function getLensChain(network: LensNetwork = getLensNetwork()): Chain {
+  const base = lensSdkChains[network];
+  const rpc = resolveLensRpcUrl(network);
+  return {
+    ...base,
+    rpcUrls: {
+      ...base.rpcUrls,
+      default: { http: [rpc] },
+    },
+  };
+}
+
+export function getLensChainId(network: LensNetwork = getLensNetwork()): number {
+  return lensSdkChains[network].id;
+}

--- a/lib/sdk/lens/viem-client.ts
+++ b/lib/sdk/lens/viem-client.ts
@@ -1,0 +1,17 @@
+/**
+ * viem public client for Lens Chain RPC (Alchemy or public fallback).
+ * Mirrors Alchemy Lens quickstart: https://www.alchemy.com/docs/reference/lens-api-quickstart
+ */
+import { createPublicClient, http } from "viem";
+import { getLensChain, resolveLensRpcUrl, getLensNetwork } from "@/lib/sdk/lens/chains";
+
+export function createLensViemPublicClient() {
+  const network = getLensNetwork();
+  const chain = getLensChain(network);
+  const rpcUrl = resolveLensRpcUrl(network);
+
+  return createPublicClient({
+    chain,
+    transport: http(rpcUrl),
+  });
+}

--- a/lib/sdk/orb/config.ts
+++ b/lib/sdk/orb/config.ts
@@ -1,0 +1,45 @@
+import type { LensAuthPluginConfig } from '@orbclub/modules/auth/lens';
+import type { MediaPluginConfig } from '@orbclub/modules/media';
+import type { QrAuthPluginConfig } from '@orbclub/modules/auth/qr';
+import type { OrbLoginConfig } from '@orbclub/modules/auth';
+import type { GroveUploadPluginConfig } from '@orbclub/modules/upload/grove';
+import { getLensChainId } from '@/lib/sdk/lens/chains';
+
+/** Resolved Orb/Lens auth + media config from app env (package does not read env). */
+export function getOrbLoginConfig(): OrbLoginConfig {
+  const qr: QrAuthPluginConfig = {};
+  const lens: LensAuthPluginConfig = {};
+
+  const graphqlUrl = process.env.NEXT_PUBLIC_LENS_GRAPHQL_URL?.trim();
+  if (graphqlUrl) lens.graphqlUrl = graphqlUrl;
+
+  const qrInit = process.env.NEXT_PUBLIC_ORB_QR_INIT_URL?.trim();
+  const qrPoll = process.env.NEXT_PUBLIC_ORB_QR_POLL_URL?.trim();
+  if (qrInit) qr.initUrl = qrInit;
+  if (qrPoll) qr.pollUrl = qrPoll;
+
+  return { qr, lens };
+}
+
+export function getOrbMediaConfig(): MediaPluginConfig {
+  const ipfsGateway =
+    process.env.NEXT_PUBLIC_IPFS_GATEWAY?.trim() || 'https://w3s.link/ipfs';
+  return {
+    ipfsGateway,
+    imageGateway: process.env.NEXT_PUBLIC_ORB_MEDIA_GATEWAY?.trim() || ipfsGateway,
+    lensGateway:
+      process.env.NEXT_PUBLIC_ORB_LENS_GATEWAY?.trim() ||
+      'https://api.grove.storage/ipfs',
+    arweaveGateway:
+      process.env.NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY?.trim() ||
+      'https://arweave.net',
+    defaultThumbnailDimension: 768,
+  };
+}
+
+export function getOrbGroveUploadConfig(): GroveUploadPluginConfig {
+  return {
+    apiUrl: process.env.NEXT_PUBLIC_GROVE_API_URL?.trim(),
+    chainId: getLensChainId(),
+  };
+}

--- a/lib/sdk/orb/grove-upload.ts
+++ b/lib/sdk/orb/grove-upload.ts
@@ -1,0 +1,26 @@
+import { createSDK } from '@orbclub/modules';
+import { groveUploadPlugin } from '@orbclub/modules/upload/grove';
+import { getOrbGroveUploadConfig } from '@/lib/sdk/orb/config';
+
+const groveSdk = createSDK({
+  plugins: [groveUploadPlugin(getOrbGroveUploadConfig())],
+});
+
+export type OrbGroveUploadInput = {
+  file: File;
+  account: string;
+  onProgress?: (progress: number) => void;
+  signal?: AbortSignal;
+};
+
+export type OrbGroveUploadResult = {
+  uri: string;
+  gatewayUrl: string;
+  storageKey: string;
+};
+
+export async function uploadFileToGrove(
+  input: OrbGroveUploadInput,
+): Promise<OrbGroveUploadResult> {
+  return groveSdk.upload.uploadFile(input);
+}

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -1,0 +1,42 @@
+import { createOrbLogin, type OrbLogin } from '@orbclub/modules/auth';
+import { getOrbLoginConfig } from '@/lib/sdk/orb/config';
+
+let orbLoginSingleton: OrbLogin | null = null;
+
+export function getOrbLogin(): OrbLogin {
+  if (!orbLoginSingleton) {
+    orbLoginSingleton = createOrbLogin(getOrbLoginConfig());
+  }
+  return orbLoginSingleton;
+}
+
+export type StoredOrbSession = {
+  accessToken: string;
+  refreshToken?: string;
+  authenticationId?: string;
+  idToken?: string;
+};
+
+export const ORB_SESSION_STORAGE_KEY = 'crtv_orb_session';
+
+export function loadStoredOrbSession(): StoredOrbSession | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(ORB_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredOrbSession;
+    if (!parsed?.accessToken) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredOrbSession(session: StoredOrbSession | null): void {
+  if (typeof window === 'undefined') return;
+  if (!session?.accessToken) {
+    localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(session));
+}

--- a/lib/sdk/orb/media.ts
+++ b/lib/sdk/orb/media.ts
@@ -1,0 +1,49 @@
+import { createSDK } from '@orbclub/modules';
+import { mediaPlugin } from '@orbclub/modules/media';
+import { getOrbMediaConfig } from '@/lib/sdk/orb/config';
+
+const mediaConfig = getOrbMediaConfig();
+const sdk = createSDK({
+  plugins: [mediaPlugin(mediaConfig)],
+});
+
+/** URIs that should use Orb media resolution before IPFS gateway fallbacks. */
+export function shouldResolveWithOrbMedia(url: string | null | undefined): boolean {
+  if (!url || typeof url !== 'string') return false;
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('blob:') || trimmed.startsWith('data:')) return false;
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    if (/\.(m3u8|mp4|mov|webm)(\?|$)/i.test(trimmed)) return false;
+    if (trimmed.includes('livepeer')) return false;
+    return false;
+  }
+  return (
+    trimmed.startsWith('ipfs://') ||
+    trimmed.startsWith('grove://') ||
+    trimmed.startsWith('lens://') ||
+    trimmed.startsWith('ar://') ||
+    trimmed.includes('thumbnailDimension')
+  );
+}
+
+export function resolveOrbImageUrl(
+  url: string | null | undefined,
+  dimension = mediaConfig.defaultThumbnailDimension ?? 768,
+): string | null {
+  if (!url || !shouldResolveWithOrbMedia(url)) return url ?? null;
+  return sdk.media.parseImage(url, dimension);
+}
+
+export function resolveOrbMediaUrl(
+  url: string | null | undefined,
+  opts?: { type?: 'image' | 'audio' | 'video'; dimension?: number },
+): string | null {
+  if (!url || !shouldResolveWithOrbMedia(url)) return url ?? null;
+  if (opts?.type === 'audio') return sdk.media.parseAudio(url);
+  if (opts?.type === 'video') return sdk.media.parseVideo(url);
+  return sdk.media.parse(url, {
+    type: opts?.type ?? 'image',
+    dimension: opts?.dimension,
+  });
+}

--- a/lib/sdk/supabase/client.ts
+++ b/lib/sdk/supabase/client.ts
@@ -98,6 +98,10 @@ export interface CreatorProfile {
   twin_pinata_connected_at?: string | null;
   // twin_pinata_gateway_token deliberately omitted from client-readable type;
   // it's column-locked to service-role reads.
+  orb_account_id?: string | null;
+  lens_account_id?: string | null;
+  lens_handle?: string | null;
+  lens_avatar_uri?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -111,6 +115,10 @@ export interface CreateCreatorProfileData {
   twin_address?: string | null;
   twin_avatar_glb_url?: string | null;
   twin_chat_endpoint?: string | null;
+  orb_account_id?: string | null;
+  lens_account_id?: string | null;
+  lens_handle?: string | null;
+  lens_avatar_uri?: string | null;
 }
 
 export interface UpdateCreatorProfileData {
@@ -121,4 +129,8 @@ export interface UpdateCreatorProfileData {
   twin_address?: string | null;
   twin_avatar_glb_url?: string | null;
   twin_chat_endpoint?: string | null;
+  orb_account_id?: string | null;
+  lens_account_id?: string | null;
+  lens_handle?: string | null;
+  lens_avatar_uri?: string | null;
 }

--- a/lib/services/thumbnail-upload.ts
+++ b/lib/services/thumbnail-upload.ts
@@ -1,5 +1,12 @@
 import { groveService } from '@/lib/sdk/grove/service';
+import { uploadFileToGrove } from '@/lib/sdk/orb/grove-upload';
 import { serverLogger } from '@/lib/utils/logger';
+
+export interface ThumbnailUploadOptions {
+  /** Lens account address for Orb Grove upload plugin (browser only). */
+  groveAccount?: string;
+  onProgress?: (progress: number) => void;
+}
 
 
 export interface ThumbnailUploadResult {
@@ -19,8 +26,7 @@ export interface ThumbnailUploadResult {
 export async function uploadThumbnailToIPFS(
   file: File,
   playbackId: string,
-  // service param removed but kept compatible if passed as any/ignored, 
-  // though we change signature here as we confirmed callsites don't pass it.
+  options?: ThumbnailUploadOptions,
 ): Promise<ThumbnailUploadResult> {
   try {
     // Validate file type
@@ -32,6 +38,25 @@ export async function uploadThumbnailToIPFS(
     }
 
     serverLogger.debug('[ThumbnailUpload] Starting upload with Grove...');
+
+    if (typeof window !== 'undefined' && options?.groveAccount) {
+      try {
+        const orbResult = await uploadFileToGrove({
+          file,
+          account: options.groveAccount,
+          onProgress: options.onProgress,
+        });
+        return {
+          success: true,
+          thumbnailUrl: orbResult.gatewayUrl,
+        };
+      } catch (orbErr) {
+        serverLogger.warn(
+          '[ThumbnailUpload] Orb Grove upload failed, falling back:',
+          orbErr,
+        );
+      }
+    }
 
     const result = await groveService.uploadFile(file);
 

--- a/lib/utils/image-gateway.ts
+++ b/lib/utils/image-gateway.ts
@@ -1,5 +1,12 @@
-
+import { resolveOrbImageUrl, shouldResolveWithOrbMedia } from '@/lib/sdk/orb/media';
 import { logger } from '@/lib/utils/logger';
+
+/** Apply Orb media resolver before IPFS gateway fallbacks. */
+export function resolveOrbMediaForGateway(url: string | null | undefined): string {
+  if (!url) return '';
+  if (!shouldResolveWithOrbMedia(url)) return url;
+  return resolveOrbImageUrl(url) ?? url;
+}
 /**
  * IPFS Gateway utilities with fallback support
  * Handles conversion of IPFS URLs to alternative gateways when primary gateway fails
@@ -120,6 +127,9 @@ export function isIpfsUrl(url: string): boolean {
  */
 export function convertFailingGateway(url: string): string {
   if (!url) return url;
+
+  const orbResolved = resolveOrbMediaForGateway(url);
+  if (orbResolved !== url) return orbResolved;
 
   // Handle Google Cloud Storage URLs (these are not IPFS, so we can't convert them)
   // These Livepeer AI images are temporary and expired - should be uploaded to IPFS

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@livepeer/ai": "^0.6.2",
     "@livepeer/react": "^4.3.6",
     "@neondatabase/serverless": "^1.0.0",
+    "@orbclub/modules": "^0.1.1",
     "@paragraph-com/sdk": "^1.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.3",

--- a/supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
+++ b/supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
@@ -1,0 +1,19 @@
+-- Orb / Lens sovereign identity fields on creator_profiles
+ALTER TABLE public.creator_profiles
+  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
+  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON public.creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON public.creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
+
+COMMENT ON COLUMN public.creator_profiles.orb_account_id IS 'Orb sovereign account id from QR sign-in';
+COMMENT ON COLUMN public.creator_profiles.lens_account_id IS 'Lens account address linked via Orb';
+COMMENT ON COLUMN public.creator_profiles.lens_handle IS 'Lens username/handle for display';
+COMMENT ON COLUMN public.creator_profiles.lens_avatar_uri IS 'Lens profile picture URI (ipfs/lens)';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4381,6 +4381,11 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.6.tgz"
   integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
 
+"@orbclub/modules@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/@orbclub/modules/-/modules-0.1.1.tgz#418a70aa08d186f608ad22e1985f024c7a9b664f"
+  integrity sha512-yNIkEHzCtNxoOIY/1WQ+LJxNhcUWexAOOcGJDbujIgIdM/9fukeTg286lb8EPDdD2luiR15+plbxi2lyriXuWA==
+
 "@oxc-resolver/binding-darwin-arm64@9.0.2":
   version "9.0.2"
   resolved "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-9.0.2.tgz"
@@ -5349,19 +5354,19 @@
     suspend-react "^0.1.3"
     zustand "^3.7.1"
 
-"@reality.eth/contracts@^3.2.21":
-  version "3.2.21"
-  resolved "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.2.21.tgz"
-  integrity sha512-Z2NOrbXhxTCcHYEg8ni+dMlIsuL854V/qm7lsLxXnbpIadMEHNQqSootzxIOvBTyDvUAreKm7Ygus7gp6rX/Eg==
+"@reality.eth/contracts@^3.2.22":
+  version "3.2.22"
+  resolved "https://registry.npmjs.org/@reality.eth/contracts/-/contracts-3.2.22.tgz#ce6befffcbb44458e7eed2c451e91b4b6ea5bcf9"
+  integrity sha512-TAK5dtMLmIDvWFyoa7pjo7AYykVUFO8va4xIqXBlXYhoeDr0CSimTgZd24GMpoukYdzcSiKhWilHyjP2Sp38Nw==
   dependencies:
     ethers "^5.8.0"
 
-"@reality.eth/reality-eth-lib@^3.4.23":
-  version "3.4.23"
-  resolved "https://registry.npmjs.org/@reality.eth/reality-eth-lib/-/reality-eth-lib-3.4.23.tgz"
-  integrity sha512-ExBe8xtvXyfKgqybe6z+gg5HaIhUTUKITCmI4TqVP0JJt0wuGSF9lTtn6IR51EBgQ1lWC9uy0pQwltA/gAAUJQ==
+"@reality.eth/reality-eth-lib@^3.4.25":
+  version "3.4.25"
+  resolved "https://registry.npmjs.org/@reality.eth/reality-eth-lib/-/reality-eth-lib-3.4.25.tgz#76740a15a6972c1ee0ceab5b84e20df59349a214"
+  integrity sha512-H7AZ/Sh2PINJfWyI2jSCDgVhULmjYiYukLdq+znp7rB5RAlaX0DXSVxCBG7jft7dJBvjGYOcxbxovuCf0jcqHQ==
   dependencies:
-    "@reality.eth/contracts" "^3.2.21"
+    "@reality.eth/contracts" "^3.2.22"
     bignumber.js "^7.2.1"
     bn.js "^5.2.1"
     ethereumjs-abi "^0.6.5"
@@ -17327,10 +17332,10 @@ ox@0.6.9:
     abitype "^1.0.6"
     eventemitter3 "5.0.1"
 
-ox@^0.14.10:
-  version "0.14.10"
-  resolved "https://registry.npmjs.org/ox/-/ox-0.14.10.tgz"
-  integrity sha512-PYsqEnSP7CrcxISS3uVBtw9yPy2gATAnWNptTI0pMnlrXLTiw0Xw/IIivJVHDFgGvKuRAtBSafhVjs+jis3CVA==
+ox@^0.14.20:
+  version "0.14.22"
+  resolved "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz#ec4bbb5cfbdb8fbd03ec23cfe0732263a7c14697"
+  integrity sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==
   dependencies:
     "@adraffy/ens-normalize" "^1.11.0"
     "@noble/ciphers" "^1.3.0"


### PR DESCRIPTION
## Summary

- **Video views:** Monotonic sync so cron/API never decrease `views_count`; read path returns `max(Livepeer, DB)` so zeros from Livepeer do not wipe stored counts.
- **Lens Chain:** Mainnet/testnet chain config via shared `NEXT_PUBLIC_ALCHEMY_API_KEY`, wired into Account Kit and Grove ACL.
- **Orb (@orbclub/modules):** Parallel Orb QR auth alongside Account Kit, media resolver in `GatewayImage`, creator profile linking (`orb_account_id` / Lens fields), optional Grove thumbnail upload.

## Test plan

- [ ] Confirm video cards and detail pages show non-zero views when DB or Livepeer has counts; verify sync cron does not decrease counts after a Livepeer `0`.
- [ ] Set `NEXT_PUBLIC_LENS_ENV=production` and verify Lens/Grove flows use mainnet RPC with Alchemy key.
- [ ] Run migration `20260519170000_add_orb_lens_to_creator_profiles.sql`.
- [ ] Sign in with Orb from Navbar; link profile; confirm `GatewayImage` resolves Orb/Grove URLs.
- [ ] Confirm Account Kit wallet flows still work independently of Orb session.


Made with [Cursor](https://cursor.com)