### PR TITLE
fix: stop exporting helper from sync-views route

### DIFF
--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -42,7 +42,7 @@ function syncViewsErrorResponse(error: unknown) {
   );
 }
 
-export async function syncViewsForPlayback(
+async function syncViewsForPlayback(
   supabase: SupabaseClient,
   playbackId: string,
 ) {


### PR DESCRIPTION
Next.js route files only allow handler exports; make syncViewsForPlayback internal.