### PR TITLE
Proxy Orb QR sign-in through same-origin API routes.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,7 +105,8 @@ NEXT_PUBLIC_ENABLE_FILECOIN_ARCHIVAL=
 NEXT_PUBLIC_APP_URL=
 
 # --- Orb (@orbclub/modules) — parallel sovereign auth + media ---
-# Defaults use orbapi.xyz QR + api.lens.xyz/graphql; override only if needed.
+# QR sign-in defaults to same-origin /api/auth/orb/qr/* proxies (avoids orbapi.xyz CORS).
+# Override only for custom auth infrastructure.
 NEXT_PUBLIC_LENS_GRAPHQL_URL=
 NEXT_PUBLIC_ORB_QR_INIT_URL=
 NEXT_PUBLIC_ORB_QR_POLL_URL=

--- a/app/api/auth/orb/qr/init/route.ts
+++ b/app/api/auth/orb/qr/init/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { checkBotId } from 'botid/server';
+import { rateLimiters } from '@/lib/middleware/rateLimit';
+import { serverLogger } from '@/lib/utils/logger';
+import {
+  buildOrbUpstreamHeaders,
+  ORB_QR_INIT_UPSTREAM,
+} from '@/lib/sdk/orb/qr-proxy';
+
+const DEFAULT_CREDENTIALS = 'id_access_refresh';
+
+/** Same-origin proxy for Orb QR init (avoids browser CORS to orbapi.xyz). */
+export async function GET(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+
+  const rl = await rateLimiters.standard(request);
+  if (rl) return rl;
+
+  const { searchParams } = new URL(request.url);
+  const credentials =
+    searchParams.get('credentials')?.trim() || DEFAULT_CREDENTIALS;
+
+  const upstream = new URL(ORB_QR_INIT_UPSTREAM);
+  upstream.searchParams.set('credentials', credentials);
+
+  try {
+    const res = await fetch(upstream.toString(), {
+      method: 'GET',
+      headers: buildOrbUpstreamHeaders(request),
+      cache: 'no-store',
+    });
+
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: {
+        'Content-Type': res.headers.get('content-type') ?? 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    serverLogger.error('Orb QR init proxy failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to reach Orb sign-in service' },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/auth/orb/qr/poll/route.ts
+++ b/app/api/auth/orb/qr/poll/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rateLimit } from '@/lib/middleware/rateLimit';
+import { serverLogger } from '@/lib/utils/logger';
+import {
+  buildOrbUpstreamHeaders,
+  ORB_QR_POLL_UPSTREAM,
+} from '@/lib/sdk/orb/qr-proxy';
+
+/** Same-origin proxy for Orb QR poll (avoids browser CORS to orbapi.xyz). */
+export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, {
+    maxRequests: 90,
+    windowMs: 60 * 1000,
+    errorMessage: 'Too many QR poll requests. Please try again.',
+  });
+  if (rl) return rl;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const secret =
+    typeof body === 'object' &&
+    body !== null &&
+    'secret' in body &&
+    typeof (body as { secret: unknown }).secret === 'string'
+      ? (body as { secret: string }).secret.trim()
+      : '';
+
+  if (!secret) {
+    return NextResponse.json({ error: 'secret is required' }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(ORB_QR_POLL_UPSTREAM, {
+      method: 'POST',
+      headers: {
+        ...buildOrbUpstreamHeaders(request),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ secret }),
+      cache: 'no-store',
+    });
+
+    const text = await res.text();
+    return new NextResponse(text, {
+      status: res.status,
+      headers: {
+        'Content-Type': res.headers.get('content-type') ?? 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    serverLogger.error('Orb QR poll proxy failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to reach Orb sign-in service' },
+      { status: 502 },
+    );
+  }
+}

--- a/lib/sdk/orb/config.ts
+++ b/lib/sdk/orb/config.ts
@@ -13,10 +13,10 @@ export function getOrbLoginConfig(): OrbLoginConfig {
   const graphqlUrl = process.env.NEXT_PUBLIC_LENS_GRAPHQL_URL?.trim();
   if (graphqlUrl) lens.graphqlUrl = graphqlUrl;
 
-  const qrInit = process.env.NEXT_PUBLIC_ORB_QR_INIT_URL?.trim();
-  const qrPoll = process.env.NEXT_PUBLIC_ORB_QR_POLL_URL?.trim();
-  if (qrInit) qr.initUrl = qrInit;
-  if (qrPoll) qr.pollUrl = qrPoll;
+  qr.initUrl =
+    process.env.NEXT_PUBLIC_ORB_QR_INIT_URL?.trim() ?? '/api/auth/orb/qr/init';
+  qr.pollUrl =
+    process.env.NEXT_PUBLIC_ORB_QR_POLL_URL?.trim() ?? '/api/auth/orb/qr/poll';
 
   return { qr, lens };
 }

--- a/lib/sdk/orb/qr-proxy.ts
+++ b/lib/sdk/orb/qr-proxy.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from 'next/server';
+
+export const ORB_QR_INIT_UPSTREAM = 'https://orbapi.xyz/init-sign-in';
+export const ORB_QR_POLL_UPSTREAM = 'https://orbapi.xyz/poll-sign-in';
+
+/** orbapi.xyz requires Origin; forward the browser value or derive from the request. */
+export function buildOrbUpstreamHeaders(request: NextRequest): HeadersInit {
+  const origin = resolveRequestOrigin(request);
+  const referer = request.headers.get('referer')?.trim() ?? origin;
+  return {
+    Accept: 'application/json',
+    Origin: origin,
+    Referer: referer,
+  };
+}
+
+function resolveRequestOrigin(request: NextRequest): string {
+  const fromHeader = request.headers.get('origin')?.trim();
+  if (fromHeader) return fromHeader;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (appUrl) {
+    try {
+      return new URL(appUrl).origin;
+    } catch {
+      /* ignore invalid URL */
+    }
+  }
+
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  if (host) {
+    const proto =
+      request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim() ?? 'https';
+    return `${proto}://${host.split(',')[0].trim()}`;
+  }
+
+  return 'http://localhost:3000';
+}


### PR DESCRIPTION
Avoids browser CORS blocks to orbapi.xyz by defaulting init/poll to /api/auth/orb/qr/* and forwarding Origin to the upstream Orb API.