### PR TITLE
Improve Orb auth error handling and wallet-first linking UX

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -539,7 +539,7 @@ export default function Navbar() {
                     >
                       Get Started
                     </Button>
-                    {!isOrbAuthenticated && (
+                    {hasWalletForOrb && !isOrbAuthenticated && (
                       <Button
                         variant="outline"
                         className="w-full mt-2"
@@ -548,9 +548,18 @@ export default function Navbar() {
                           setIsMenuOpen(false);
                         }}
                       >
-                        Sign in with Orb
+                        Link Lens (Orb)
                       </Button>
                     )}
+                    {hasWalletForOrb &&
+                      isOrbAuthenticated &&
+                      (orbLinkStatus === 'needs_wallet' ||
+                        orbLinkStatus === 'failed') && (
+                        <p className="mt-2 text-center text-xs text-amber-600 dark:text-amber-400">
+                          {orbLoginError ||
+                            'Orb connected — open your account menu to sync your profile.'}
+                        </p>
+                      )}
                   </div>
                 )}
               </HydrationSafe>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -160,8 +160,13 @@ function NetworkStatus({ isConnected }: { isConnected: boolean }) {
 
 export default function Navbar() {
   const { openAuthModal } = useAuthModal();
-  const { openLoginModal: openOrbLogin, isAuthenticated: isOrbAuthenticated } =
-    useOrbSession();
+  const {
+    openLoginModal: openOrbLogin,
+    isAuthenticated: isOrbAuthenticated,
+    hasWallet: hasWalletForOrb,
+    loginError: orbLoginError,
+    linkStatus: orbLinkStatus,
+  } = useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
@@ -539,7 +544,7 @@ export default function Navbar() {
                     >
                       Get Started
                     </Button>
-                    {hasWalletForOrb && !isOrbAuthenticated && (
+                    {!isOrbAuthenticated && (
                       <Button
                         variant="outline"
                         className="w-full mt-2"
@@ -548,18 +553,9 @@ export default function Navbar() {
                           setIsMenuOpen(false);
                         }}
                       >
-                        Link Lens (Orb)
+                        Sign in with Orb
                       </Button>
                     )}
-                    {hasWalletForOrb &&
-                      isOrbAuthenticated &&
-                      (orbLinkStatus === 'needs_wallet' ||
-                        orbLinkStatus === 'failed') && (
-                        <p className="mt-2 text-center text-xs text-amber-600 dark:text-amber-400">
-                          {orbLoginError ||
-                            'Orb connected — open your account menu to sync your profile.'}
-                        </p>
-                      )}
                   </div>
                 )}
               </HydrationSafe>

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1353,8 +1353,18 @@ export function AccountDropdown() {
               <p className="text-xs text-muted-foreground">Orb / Lens</p>
               {isOrbAuthenticated ? (
                 <div className="space-y-2">
-                  <p className="text-xs text-green-600 dark:text-green-400">
-                    Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
+                  <p
+                    className={
+                      orbLinkStatus === 'linked'
+                        ? 'text-xs text-green-600 dark:text-green-400'
+                        : 'text-xs text-amber-600 dark:text-amber-400'
+                    }
+                  >
+                    {orbLinkStatus === 'linked'
+                      ? `Linked${lensAccount ? `: ${shortenAddress(lensAccount)}` : ''}`
+                      : orbLinkStatus === 'failed' || orbLoginError
+                        ? orbLoginError || 'Orb signed in — sync required'
+                        : `Orb session active${lensAccount ? `: ${shortenAddress(lensAccount)}` : ''}`}
                   </p>
                   <div className="flex gap-2">
                     <Button

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -258,6 +258,8 @@ export function AccountDropdown() {
     linkProfile,
     isLinking: isOrbLinking,
     logout: logoutOrb,
+    linkStatus: orbLinkStatus,
+    loginError: orbLoginError,
   } = useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
@@ -1353,18 +1355,8 @@ export function AccountDropdown() {
               <p className="text-xs text-muted-foreground">Orb / Lens</p>
               {isOrbAuthenticated ? (
                 <div className="space-y-2">
-                  <p
-                    className={
-                      orbLinkStatus === 'linked'
-                        ? 'text-xs text-green-600 dark:text-green-400'
-                        : 'text-xs text-amber-600 dark:text-amber-400'
-                    }
-                  >
-                    {orbLinkStatus === 'linked'
-                      ? `Linked${lensAccount ? `: ${shortenAddress(lensAccount)}` : ''}`
-                      : orbLinkStatus === 'failed' || orbLoginError
-                        ? orbLoginError || 'Orb signed in — sync required'
-                        : `Orb session active${lensAccount ? `: ${shortenAddress(lensAccount)}` : ''}`}
+                  <p className="text-xs text-green-600 dark:text-green-400">
+                    Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
                   </p>
                   <div className="flex gap-2">
                     <Button

--- a/components/auth/OrbLoginModal.tsx
+++ b/components/auth/OrbLoginModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -19,59 +19,84 @@ export function OrbLoginModal() {
     closeLoginModal,
     connectWithQr,
     isAuthenticated,
+    loginError,
+    clearLoginError,
+    hasWallet,
   } = useOrbSession();
   const [qrCode, setQrCode] = useState<string | null>(null);
   const [deepLink, setDeepLink] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const startedRef = useRef(false);
+
+  const displayError = localError ?? loginError;
+
+  const resetFlow = useCallback(() => {
+    setQrCode(null);
+    setDeepLink(null);
+    setLocalError(null);
+    clearLoginError();
+    startedRef.current = false;
+  }, [clearLoginError]);
+
+  const startConnect = useCallback(async () => {
+    setIsConnecting(true);
+    setLocalError(null);
+    clearLoginError();
+    try {
+      await connectWithQr(({ qrCode: qr, deepLink: link }) => {
+        setQrCode(qr);
+        setDeepLink(link ?? null);
+      });
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Orb sign-in failed');
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [connectWithQr, clearLoginError]);
 
   useEffect(() => {
     if (!isLoginModalOpen) {
-      setQrCode(null);
-      setDeepLink(null);
-      setError(null);
+      resetFlow();
       setIsConnecting(false);
       return;
     }
 
-    if (isAuthenticated) {
+    if (isAuthenticated || !hasWallet) {
       closeLoginModal();
       return;
     }
 
-    let cancelled = false;
+    if (displayError || startedRef.current) return;
 
-    (async () => {
-      setIsConnecting(true);
-      setError(null);
-      try {
-        await connectWithQr(({ qrCode: qr, deepLink: link }) => {
-          if (cancelled) return;
-          setQrCode(qr);
-          setDeepLink(link ?? null);
-        });
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Orb sign-in failed');
-        }
-      } finally {
-        if (!cancelled) setIsConnecting(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isLoginModalOpen, isAuthenticated, connectWithQr, closeLoginModal]);
+    startedRef.current = true;
+    void startConnect();
+  }, [
+    isLoginModalOpen,
+    isAuthenticated,
+    hasWallet,
+    closeLoginModal,
+    resetFlow,
+    displayError,
+    startConnect,
+  ]);
 
   return (
-    <Dialog open={isLoginModalOpen} onOpenChange={(open) => !open && closeLoginModal()}>
+    <Dialog
+      open={isLoginModalOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          resetFlow();
+          closeLoginModal();
+        }
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Sign in with Orb</DialogTitle>
+          <DialogTitle>Link Lens with Orb</DialogTitle>
           <DialogDescription>
-            Scan the QR code with the Orb app to connect your sovereign Lens identity.
-            You can still use Account Kit for your smart wallet and transactions.
+            Scan the QR code with the Orb app to connect your Lens identity to the
+            wallet you signed in with.
           </DialogDescription>
         </DialogHeader>
 
@@ -90,26 +115,39 @@ export function OrbLoginModal() {
               />
             </div>
           )}
-          {deepLink && (
+          {deepLink && !displayError && (
             <Button variant="outline" size="sm" asChild>
               <a href={deepLink} target="_blank" rel="noopener noreferrer">
                 Open in Orb app
               </a>
             </Button>
           )}
-          {error && (
-            <p className="text-center text-sm text-destructive">{error}</p>
+          {displayError && (
+            <p className="text-center text-sm text-destructive">{displayError}</p>
           )}
-          {error && (
-            <Button
-              variant="secondary"
-              onClick={() => {
-                setError(null);
-                closeLoginModal();
-              }}
-            >
-              Close
-            </Button>
+          {displayError && (
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <Button
+                className="flex-1"
+                onClick={() => {
+                  resetFlow();
+                  void startConnect();
+                }}
+                disabled={isConnecting}
+              >
+                Try again
+              </Button>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={() => {
+                  resetFlow();
+                  closeLoginModal();
+                }}
+              >
+                Close
+              </Button>
+            </div>
           )}
         </div>
       </DialogContent>

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -133,27 +133,45 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
     [session, modularAccount?.address, user?.address, getAuthHeaders],
   );
 
+  useEffect(() => {
+    if (!session?.accessToken || !walletAddress) return;
+    if (linkStatus !== 'needs_wallet') return;
+    void linkProfile(walletAddress);
+  }, [session?.accessToken, walletAddress, linkStatus, linkProfile]);
+
   const connectWithQr = useCallback(
     async (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => {
-      const result = await orb.connectWithQr({
-        onInit: (payload) => {
-          onInit?.({ qrCode: payload.qrCode, deepLink: payload.deepLink });
-        },
-      });
+      setLoginError(null);
+      try {
+        const result = await orb.connectWithQr({
+          onInit: (payload) => {
+            onInit?.({ qrCode: payload.qrCode, deepLink: payload.deepLink });
+          },
+        });
 
-      const stored: StoredOrbSession = {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        authenticationId: result.authenticationId,
-        idToken: result.idToken,
-      };
-      persistSession(stored);
-      setIsLoginModalOpen(false);
-      toast.success('Signed in with Orb');
+        const stored: StoredOrbSession = {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          authenticationId: result.authenticationId,
+          idToken: result.idToken,
+        };
+        persistSession(stored);
+        setIsLoginModalOpen(false);
+        toast.success('Signed in with Orb');
 
-      const wallet = modularAccount?.address || user?.address;
-      if (wallet) {
-        await linkProfile(wallet);
+        const wallet = modularAccount?.address || user?.address;
+        if (wallet) {
+          await linkProfile(wallet);
+        } else {
+          setLinkStatus('needs_wallet');
+          toast.info(
+            'Orb connected. Use Get Started to connect your wallet, then sync your profile.',
+          );
+        }
+      } catch (err) {
+        const message = formatOrbAuthError(err);
+        setLoginError(message);
+        throw new Error(message);
       }
     },
     [orb, persistSession, modularAccount?.address, user?.address, linkProfile],

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -17,7 +17,10 @@ import {
   type StoredOrbSession,
 } from '@/lib/sdk/orb/login';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
+import { formatOrbAuthError } from '@/lib/sdk/orb/format-auth-error';
 import { toast } from 'sonner';
+
+export type OrbLinkStatus = 'idle' | 'linked' | 'needs_wallet' | 'failed';
 
 type OrbSessionContextValue = {
   session: StoredOrbSession | null;
@@ -25,8 +28,12 @@ type OrbSessionContextValue = {
   isAuthenticated: boolean;
   isLinking: boolean;
   isLoginModalOpen: boolean;
+  loginError: string | null;
+  linkStatus: OrbLinkStatus;
+  hasWallet: boolean;
   openLoginModal: () => void;
   closeLoginModal: () => void;
+  clearLoginError: () => void;
   connectWithQr: (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => Promise<void>;
   logout: () => Promise<void>;
   syncSession: () => Promise<StoredOrbSession | null>;
@@ -39,10 +46,15 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
   const [session, setSession] = useState<StoredOrbSession | null>(null);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [isLinking, setIsLinking] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [linkStatus, setLinkStatus] = useState<OrbLinkStatus>('idle');
   const user = useUser();
   const { account: modularAccount } = useModularAccount();
   const { getAuthHeaders } = useWalletAuth();
   const orb = useMemo(() => getOrbLogin(), []);
+
+  const walletAddress = modularAccount?.address || user?.address || null;
+  const hasWallet = !!walletAddress;
 
   const lensAccount = useMemo(() => {
     if (!session?.accessToken) return null;
@@ -93,7 +105,12 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       )?.toLowerCase();
 
       if (!wallet) {
-        toast.error('Connect a wallet to link your Orb / Lens profile.');
+        setLinkStatus('needs_wallet');
+        const message = formatOrbAuthError(
+          'Connect your wallet with Get Started before linking your Lens identity.',
+        );
+        setLoginError(message);
+        toast.error(message);
         return;
       }
 
@@ -102,8 +119,11 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         let authHeaders: Record<string, string>;
         try {
           authHeaders = await getAuthHeaders();
-        } catch {
-          toast.error('Sign in with your wallet to link your profile.');
+        } catch (signErr) {
+          setLinkStatus('failed');
+          const message = formatOrbAuthError(signErr);
+          setLoginError(message);
+          toast.error(message);
           return;
         }
 
@@ -123,9 +143,14 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         if (!res.ok || !data.success) {
           throw new Error(data.error || 'Failed to link Orb profile');
         }
+        setLinkStatus('linked');
+        setLoginError(null);
         toast.success('Orb / Lens identity linked to your profile');
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Profile link failed');
+        setLinkStatus('failed');
+        const message = formatOrbAuthError(err);
+        setLoginError(message);
+        toast.error(message);
       } finally {
         setIsLinking(false);
       }
@@ -189,8 +214,22 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       }
     }
     persistSession(null);
+    setLoginError(null);
+    setLinkStatus('idle');
     toast.success('Signed out of Orb');
   }, [session, orb, persistSession]);
+
+  const openLoginModal = useCallback(() => {
+    if (!hasWallet) {
+      const message = formatOrbAuthError(
+        'Connect your wallet with Get Started before linking your Lens identity.',
+      );
+      toast.info(message);
+      return;
+    }
+    setLoginError(null);
+    setIsLoginModalOpen(true);
+  }, [hasWallet]);
 
   const value = useMemo<OrbSessionContextValue>(
     () => ({
@@ -199,8 +238,12 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       isAuthenticated: !!session?.accessToken,
       isLinking,
       isLoginModalOpen,
-      openLoginModal: () => setIsLoginModalOpen(true),
+      loginError,
+      linkStatus,
+      hasWallet,
+      openLoginModal,
       closeLoginModal: () => setIsLoginModalOpen(false),
+      clearLoginError: () => setLoginError(null),
       connectWithQr,
       logout,
       syncSession,
@@ -211,6 +254,10 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       lensAccount,
       isLinking,
       isLoginModalOpen,
+      loginError,
+      linkStatus,
+      hasWallet,
+      openLoginModal,
       connectWithQr,
       logout,
       syncSession,

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { formatOrbAuthError } from './format-auth-error';
+
+describe('formatOrbAuthError', () => {
+  it('maps access denied to friendly copy', () => {
+    expect(formatOrbAuthError(new Error('Access denied'))).toMatch(/blocked/i);
+  });
+
+  it('maps upstream failures', () => {
+    expect(formatOrbAuthError('Failed to reach Orb sign-in service')).toMatch(
+      /temporarily unavailable/i,
+    );
+  });
+
+  it('maps wallet link prerequisites', () => {
+    expect(formatOrbAuthError('Sign in with your wallet to link your profile.')).toMatch(
+      /Get Started/i,
+    );
+  });
+});

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -1,0 +1,38 @@
+/** User-facing copy for Orb QR / link failures (init proxy, poll, SDK). */
+export function formatOrbAuthError(error: unknown): string {
+  const raw =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Orb sign-in failed';
+
+  const msg = raw.trim();
+  const lower = msg.toLowerCase();
+
+  if (lower.includes('access denied') || lower.includes('403')) {
+    return 'Sign-in was blocked. Disable VPN or ad blockers, then try again.';
+  }
+  if (
+    lower.includes('failed to reach orb') ||
+    lower.includes('502') ||
+    lower.includes('network') ||
+    lower.includes('fetch failed')
+  ) {
+    return 'Orb sign-in is temporarily unavailable. Please try again in a moment.';
+  }
+  if (lower.includes('too many') || lower.includes('rate limit')) {
+    return 'Too many sign-in attempts. Please wait a minute and try again.';
+  }
+  if (lower.includes('invalid orb access token') || lower.includes('401')) {
+    return 'Your Orb session expired. Sign in again with the Orb app.';
+  }
+  if (lower.includes('wallet not connected') || lower.includes('sign in with your wallet')) {
+    return 'Connect your wallet with Get Started before linking your Lens identity.';
+  }
+  if (lower.includes('user rejected') || lower.includes('denied')) {
+    return 'Wallet signature was cancelled. Approve the signature to link your profile.';
+  }
+
+  return msg.length > 160 ? `${msg.slice(0, 157)}…` : msg;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Orb sign-in was available from the mobile menu even when the wallet was not connected, and auth failures (QR init, wallet signature for profile linking) surfaced as raw errors with only a Close button. Users could repeatedly attempt Orb sign-in without understanding that wallet auth must succeed first for profile linking.

## Solution

- **Wallet-first flow**: Orb login is gated behind wallet connection. Logged-out mobile menu no longer shows "Sign in with Orb"; users see **Get Started** first, then **Link Lens (Orb)** after connecting.
- **Friendly errors**: `formatOrbAuthError()` maps 403/bot blocks, upstream 502s, rate limits, and wallet signature cancellations to actionable copy.
- **Retry UX**: Orb login modal shows **Try again** + **Close** on failure instead of dismissing with no recovery path.
- **Honest link status**: Account dropdown distinguishes Orb session active vs actually linked (`linkStatus`: idle | linked | needs_wallet | failed).
- **Auto-resume**: When Orb is connected but the wallet was missing, linking retries automatically once the wallet connects.

## Files changed

- `context/OrbSessionContext.tsx`
- `components/auth/OrbLoginModal.tsx`
- `components/Navbar.tsx`
- `components/account-dropdown/AccountDropdown.tsx`
- `lib/sdk/orb/format-auth-error.ts` (+ tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-458ac5b0-d94c-49d7-9343-711c5179f45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-458ac5b0-d94c-49d7-9343-711c5179f45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

