### PR TITLE
Fix Orb QR sign-in 403 (BotID client protect)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,14 +105,22 @@ NEXT_PUBLIC_ENABLE_FILECOIN_ARCHIVAL=
 NEXT_PUBLIC_APP_URL=
 
 # --- Orb (@orbclub/modules) — parallel sovereign auth + media ---
-# QR sign-in defaults to same-origin /api/auth/orb/qr/* proxies (avoids orbapi.xyz CORS).
-# Override only for custom auth infrastructure.
+# Package defaults (browser-direct): orbapi.xyz init/poll + api.lens.xyz/graphql.
+# App defaults (this repo): same-origin /api/auth/orb/qr/* proxies to avoid CORS.
+# Suggested env names (Orb docs) use NEXT_PUBLIC_ for client-side createOrbLogin().
+# Legacy NEXT_PUBLIC_ORB_* names are still supported.
 NEXT_PUBLIC_LENS_GRAPHQL_URL=
+NEXT_PUBLIC_QR_INIT_URL=
+NEXT_PUBLIC_QR_POLL_URL=
 NEXT_PUBLIC_ORB_QR_INIT_URL=
 NEXT_PUBLIC_ORB_QR_POLL_URL=
+NEXT_PUBLIC_MEDIA_GATEWAY=
 NEXT_PUBLIC_ORB_MEDIA_GATEWAY=
+NEXT_PUBLIC_LENS_GATEWAY=
 NEXT_PUBLIC_ORB_LENS_GATEWAY=
+NEXT_PUBLIC_ARWEAVE_GATEWAY=
 NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY=
+NEXT_PUBLIC_IPFS_GATEWAY=
 NEXT_PUBLIC_GROVE_API_URL=
 
 # --- Optional / feature flags ---

--- a/app/api/auth/orb/qr/init/route.ts
+++ b/app/api/auth/orb/qr/init/route.ts
@@ -13,6 +13,7 @@ const DEFAULT_CREDENTIALS = 'id_access_refresh';
 export async function GET(request: NextRequest) {
   const verification = await checkBotId();
   if (verification.isBot) {
+    serverLogger.warn('[orb/qr/init] BotID rejected request');
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
 
@@ -34,6 +35,11 @@ export async function GET(request: NextRequest) {
     });
 
     const body = await res.text();
+    if (!res.ok) {
+      serverLogger.warn(
+        `[orb/qr/init] upstream ${res.status} from ${ORB_QR_INIT_UPSTREAM}`,
+      );
+    }
     return new NextResponse(body, {
       status: res.status,
       headers: {

--- a/app/api/auth/orb/qr/poll/route.ts
+++ b/app/api/auth/orb/qr/poll/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { checkBotId } from 'botid/server';
 import { rateLimit } from '@/lib/middleware/rateLimit';
 import { serverLogger } from '@/lib/utils/logger';
 import {
@@ -8,6 +9,12 @@ import {
 
 /** Same-origin proxy for Orb QR poll (avoids browser CORS to orbapi.xyz). */
 export async function POST(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    serverLogger.warn('[orb/qr/poll] BotID rejected request');
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+
   const rl = await rateLimit(request, {
     maxRequests: 90,
     windowMs: 60 * 1000,
@@ -46,6 +53,11 @@ export async function POST(request: NextRequest) {
     });
 
     const text = await res.text();
+    if (!res.ok) {
+      serverLogger.warn(
+        `[orb/qr/poll] upstream ${res.status} from ${ORB_QR_POLL_UPSTREAM}`,
+      );
+    }
     return new NextResponse(text, {
       status: res.status,
       headers: {

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1385,7 +1385,10 @@ export function AccountDropdown() {
                   variant="outline"
                   size="sm"
                   className="w-full text-xs"
-                  onClick={() => openOrbLogin()}
+                  onClick={() => {
+                    setIsDropdownOpen(false);
+                    openOrbLogin();
+                  }}
                 >
                   Sign in with Orb
                 </Button>

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -10,6 +10,8 @@ initBotId({
     { path: '/api/ipfs/upload', method: 'POST' },
     { path: '/api/creator-profiles/upsert', method: 'POST' },
     { path: '/api/creator-profiles/link-orb', method: 'POST' },
+    { path: '/api/auth/orb/qr/init', method: 'GET' },
+    { path: '/api/auth/orb/qr/poll', method: 'POST' },
     { path: '/api/creator-profiles', method: 'POST' },
     { path: '/api/creator-profiles', method: 'PUT' },
     { path: '/api/creator-profiles', method: 'DELETE' },

--- a/lib/sdk/orb/config.ts
+++ b/lib/sdk/orb/config.ts
@@ -5,33 +5,59 @@ import type { OrbLoginConfig } from '@orbclub/modules/auth';
 import type { GroveUploadPluginConfig } from '@orbclub/modules/upload/grove';
 import { getLensChainId } from '@/lib/sdk/lens/chains';
 
-/** Resolved Orb/Lens auth + media config from app env (package does not read env). */
+/** @orbclub/modules defaults when using `createOrbLogin()` with no overrides. */
+export const ORB_SDK_QR_INIT_DEFAULT = 'https://orbapi.xyz/init-sign-in';
+export const ORB_SDK_QR_POLL_DEFAULT = 'https://orbapi.xyz/poll-sign-in';
+export const ORB_SDK_LENS_GRAPHQL_DEFAULT = 'https://api.lens.xyz/graphql';
+
+/**
+ * Creative TV defaults: same-origin proxies so the browser avoids orbapi.xyz CORS.
+ * Set `NEXT_PUBLIC_QR_INIT_URL` / `NEXT_PUBLIC_QR_POLL_URL` to the SDK URLs above
+ * only if orbapi.xyz allows your production origin.
+ */
+export const ORB_APP_QR_INIT_PROXY = '/api/auth/orb/qr/init';
+export const ORB_APP_QR_POLL_PROXY = '/api/auth/orb/qr/poll';
+
+/** First set `NEXT_PUBLIC_*` key wins. Maps Orb docs names → Next.js client env. */
+function readClientEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/** Resolved Orb/Lens auth + media config from app env (@orbclub/modules does not read env). */
 export function getOrbLoginConfig(): OrbLoginConfig {
   const qr: QrAuthPluginConfig = {};
   const lens: LensAuthPluginConfig = {};
 
-  const graphqlUrl = process.env.NEXT_PUBLIC_LENS_GRAPHQL_URL?.trim();
+  const graphqlUrl = readClientEnv('NEXT_PUBLIC_LENS_GRAPHQL_URL');
   if (graphqlUrl) lens.graphqlUrl = graphqlUrl;
 
   qr.initUrl =
-    process.env.NEXT_PUBLIC_ORB_QR_INIT_URL?.trim() ?? '/api/auth/orb/qr/init';
+    readClientEnv('NEXT_PUBLIC_QR_INIT_URL', 'NEXT_PUBLIC_ORB_QR_INIT_URL') ??
+    ORB_APP_QR_INIT_PROXY;
   qr.pollUrl =
-    process.env.NEXT_PUBLIC_ORB_QR_POLL_URL?.trim() ?? '/api/auth/orb/qr/poll';
+    readClientEnv('NEXT_PUBLIC_QR_POLL_URL', 'NEXT_PUBLIC_ORB_QR_POLL_URL') ??
+    ORB_APP_QR_POLL_PROXY;
 
   return { qr, lens };
 }
 
 export function getOrbMediaConfig(): MediaPluginConfig {
   const ipfsGateway =
-    process.env.NEXT_PUBLIC_IPFS_GATEWAY?.trim() || 'https://w3s.link/ipfs';
+    readClientEnv('NEXT_PUBLIC_IPFS_GATEWAY') || 'https://w3s.link/ipfs';
   return {
     ipfsGateway,
-    imageGateway: process.env.NEXT_PUBLIC_ORB_MEDIA_GATEWAY?.trim() || ipfsGateway,
+    imageGateway:
+      readClientEnv('NEXT_PUBLIC_MEDIA_GATEWAY', 'NEXT_PUBLIC_ORB_MEDIA_GATEWAY') ||
+      ipfsGateway,
     lensGateway:
-      process.env.NEXT_PUBLIC_ORB_LENS_GATEWAY?.trim() ||
+      readClientEnv('NEXT_PUBLIC_LENS_GATEWAY', 'NEXT_PUBLIC_ORB_LENS_GATEWAY') ||
       'https://api.grove.storage/ipfs',
     arweaveGateway:
-      process.env.NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY?.trim() ||
+      readClientEnv('NEXT_PUBLIC_ARWEAVE_GATEWAY', 'NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY') ||
       'https://arweave.net',
     defaultThumbnailDimension: 768,
   };
@@ -39,7 +65,7 @@ export function getOrbMediaConfig(): MediaPluginConfig {
 
 export function getOrbGroveUploadConfig(): GroveUploadPluginConfig {
   return {
-    apiUrl: process.env.NEXT_PUBLIC_GROVE_API_URL?.trim(),
+    apiUrl: readClientEnv('NEXT_PUBLIC_GROVE_API_URL'),
     chainId: getLensChainId(),
   };
 }

--- a/lib/sdk/orb/qr-proxy.ts
+++ b/lib/sdk/orb/qr-proxy.ts
@@ -1,7 +1,12 @@
 import type { NextRequest } from 'next/server';
 
-export const ORB_QR_INIT_UPSTREAM = 'https://orbapi.xyz/init-sign-in';
-export const ORB_QR_POLL_UPSTREAM = 'https://orbapi.xyz/poll-sign-in';
+import {
+  ORB_SDK_QR_INIT_DEFAULT,
+  ORB_SDK_QR_POLL_DEFAULT,
+} from '@/lib/sdk/orb/config';
+
+export const ORB_QR_INIT_UPSTREAM = ORB_SDK_QR_INIT_DEFAULT;
+export const ORB_QR_POLL_UPSTREAM = ORB_SDK_QR_POLL_DEFAULT;
 
 /** orbapi.xyz requires Origin; forward the browser value or derive from the request. */
 export function buildOrbUpstreamHeaders(request: NextRequest): HeadersInit {


### PR DESCRIPTION
## Summary
- Register `GET /api/auth/orb/qr/init` and `POST /api/auth/orb/qr/poll` in BotID `initBotId` protect list so the browser sends verification headers before the init route runs `checkBotId()`.
- Add server logging on Orb QR init when BotID rejects a request or when `orbapi.xyz` returns a non-OK status.
- Close the wallet dropdown before opening the Orb sign-in modal to avoid the Radix `aria-hidden` focus warning.

## Context
Production showed `403` on `/api/auth/orb/qr/init` and the UI message "Sign-in was blocked. Disable VPN or ad blockers…" because init used `checkBotId()` without a matching client-side protected route.

## Test plan
- [ ] Deploy preview and open **Sign in with Orb** — `GET /api/auth/orb/qr/init` returns **200** with QR payload
- [ ] Retry with a common ad blocker enabled
- [ ] Complete QR scan → poll succeeds → profile link flow works
- [ ] Confirm wallet dropdown + Orb modal no longer triggers `aria-hidden` console warning


Made with [Cursor](https://cursor.com)