### PR TITLE
Fix Orb Lens QR sign-in 403 from BotID/Kasada

### DIFF
--- a/app/api/auth/orb/qr/init/route.ts
+++ b/app/api/auth/orb/qr/init/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import { serverLogger } from '@/lib/utils/logger';
 import {
@@ -9,13 +8,8 @@ import {
 
 const DEFAULT_CREDENTIALS = 'id_access_refresh';
 
-/** Same-origin proxy for Orb QR init (avoids browser CORS to orbapi.xyz). */
+/** Same-origin proxy for Orb QR init (avoids browser CORS to orbapi.xyz). BotID omitted: QR polling is high-frequency and rate-limited instead. */
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
-  if (verification.isBot) {
-    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-  }
-
   const rl = await rateLimiters.standard(request);
   if (rl) return rl;
 

--- a/app/api/auth/orb/qr/poll/route.ts
+++ b/app/api/auth/orb/qr/poll/route.ts
@@ -46,6 +46,13 @@ export async function POST(request: NextRequest) {
     });
 
     const text = await res.text();
+    if (!res.ok) {
+      serverLogger.warn('Orb QR poll upstream error', {
+        status: res.status,
+        origin: request.headers.get('origin') ?? '(none)',
+        bodyPreview: text.slice(0, 200),
+      });
+    }
     return new NextResponse(text, {
       status: res.status,
       headers: {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,6 +3,9 @@ import { initBotId } from 'botid/client/core';
 /**
  * BotID protected routes: client attaches headers for these paths so server
  * can call checkBotId(). Excludes cron routes (no browser context).
+ *
+ * Orb QR sign-in (/api/auth/orb/qr/init, /api/auth/orb/qr/poll) is intentionally
+ * omitted — poll loops every ~1–2s and Kasada/BotID flags that as bot traffic.
  */
 initBotId({
   protect: [

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -3,7 +3,8 @@ import { formatOrbAuthError } from './format-auth-error';
 
 describe('formatOrbAuthError', () => {
   it('maps access denied to friendly copy', () => {
-    expect(formatOrbAuthError(new Error('Access denied'))).toMatch(/blocked/i);
+    expect(formatOrbAuthError(new Error('Access denied'))).toMatch(/security checks/i);
+    expect(formatOrbAuthError(new Error('Access denied'))).not.toMatch(/VPN/i);
   });
 
   it('maps upstream failures', () => {

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -11,7 +11,7 @@ export function formatOrbAuthError(error: unknown): string {
   const lower = msg.toLowerCase();
 
   if (lower.includes('access denied') || lower.includes('403')) {
-    return 'Sign-in was blocked. Disable VPN or ad blockers, then try again.';
+    return 'Sign-in was blocked by security checks. Try a private window with extensions off, or try again in a minute.';
   }
   if (
     lower.includes('failed to reach orb') ||


### PR DESCRIPTION
## Summary
- Remove BotID from Orb QR init so Kasada no longer blocks the high-frequency poll loop with 403 Access denied.
- Document that `/api/auth/orb/qr/init` and `/api/auth/orb/qr/poll` are intentionally excluded from `initBotId` protect.
- Replace misleading VPN/ad-blocker error copy with accurate security-check messaging.
- Log upstream Orb poll failures for easier production debugging.

## Test plan
- [ ] Open Link Lens with Orb on `tv.creativeplatform.xyz` with wallet connected
- [ ] Confirm QR loads and `POST /api/auth/orb/qr/poll` returns 200/pending (not 403)
- [ ] Scan QR in Orb app and verify profile links via `/api/creator-profiles/link-orb`
- [ ] If poll still 403s with `x-kpsdk-*` headers, add Vercel Firewall exception for the poll path


Made with [Cursor](https://cursor.com)