### PR TITLE
fix: show Orb sign-in in mobile account dropdown, not nav menu

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -47,7 +47,6 @@ import { TokenBalance } from "./wallet/balance/TokenBalance";
 import { MeTokenBalances } from "./wallet/balance/MeTokenBalances";
 import type { Chain as ViemChain } from "viem";
 import { AccountDropdown } from "@/components/account-dropdown/AccountDropdown";
-import { useOrbSession } from "@/context/OrbSessionContext";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
 import { useMeTokenHoldings } from "@/lib/hooks/metokens/useMeTokenHoldings";
@@ -160,13 +159,6 @@ function NetworkStatus({ isConnected }: { isConnected: boolean }) {
 
 export default function Navbar() {
   const { openAuthModal } = useAuthModal();
-  const {
-    openLoginModal: openOrbLogin,
-    isAuthenticated: isOrbAuthenticated,
-    hasWallet: hasWalletForOrb,
-    loginError: orbLoginError,
-    linkStatus: orbLinkStatus,
-  } = useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
@@ -452,11 +444,18 @@ export default function Navbar() {
           </div>
 
           {/* Mobile menu button */}
-          <div className="flex md:hidden items-center">
+          <div className="flex md:hidden items-center gap-2">
             <ThemeToggleComponent />
+            <HydrationSafe>
+              {user ? (
+                <div className="flex items-center">
+                  <AccountDropdown />
+                </div>
+              ) : null}
+            </HydrationSafe>
             <button
               className={
-                "ml-2 inline-flex items-center justify-center rounded-md p-2 " +
+                "inline-flex items-center justify-center rounded-md p-2 " +
                 "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 " +
                 "dark:hover:bg-gray-800 dark:hover:text-gray-50 transition-colors"
               }
@@ -544,18 +543,6 @@ export default function Navbar() {
                     >
                       Get Started
                     </Button>
-                    {!isOrbAuthenticated && (
-                      <Button
-                        variant="outline"
-                        className="w-full mt-2"
-                        onClick={() => {
-                          openOrbLogin();
-                          setIsMenuOpen(false);
-                        }}
-                      >
-                        Sign in with Orb
-                      </Button>
-                    )}
                   </div>
                 )}
               </HydrationSafe>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -443,39 +443,32 @@ export default function Navbar() {
             </nav>
           </div>
 
-          {/* Mobile menu button */}
-          <div className="flex md:hidden items-center gap-2">
+          {/* Header actions: single theme toggle + account dropdown (avoids duplicate DOM ids) */}
+          <div className="flex items-center gap-2">
             <ThemeToggleComponent />
             <HydrationSafe>
               {user ? (
-                <div className="flex items-center">
+                <AccountDropdown />
+              ) : (
+                <div className="hidden md:block">
                   <AccountDropdown />
                 </div>
-              ) : null}
+              )}
             </HydrationSafe>
             <button
               className={
-                "inline-flex items-center justify-center rounded-md p-2 " +
+                "md:hidden inline-flex items-center justify-center rounded-md p-2 " +
                 "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 " +
                 "dark:hover:bg-gray-800 dark:hover:text-gray-50 transition-colors"
               }
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-expanded={isMenuOpen}
               id="mobile-menu-btn"
+              aria-label="Open main menu"
             >
               <span className="sr-only">Open main menu</span>
               <MenuIcon className="h-6 w-6" />
             </button>
-          </div>
-
-          {/* Desktop wallet display */}
-          <div className="hidden md:flex items-center space-x-4">
-            <div className="flex items-center">
-              <ThemeToggleComponent />
-            </div>
-            <div>
-              <AccountDropdown />
-            </div>
           </div>
 
           {/* Mobile menu */}

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -85,8 +85,10 @@ export const Tour = () => {
             data: { id: 'connect' }
         },
         {
-            target: '#mobile-menu-btn',
-            content: 'In the menu, you can select "Upload" to add your own content.',
+            target: '#nav-user-menu',
+            content:
+                'Tap your profile avatar to open the account menu, then select "Upload" to add your own content.',
+            spotlightClicks: true,
             data: { id: 'user-menu' }
         },
         {

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1283,12 +1283,12 @@ export function AccountDropdown() {
         </TooltipProvider>
       </HydrationSafe>
 
-      {/* Desktop Dropdown */}
+      {/* Account dropdown (desktop header + mobile when rendered from Navbar) */}
       <HydrationSafe
         fallback={
           <Button
             variant="outline"
-            className="hidden md:flex items-center gap-2 transition-all hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-500"
+            className="flex items-center gap-2 transition-all hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-500"
           >
             <Avatar className="h-8 w-8">
               <AvatarImage
@@ -1296,7 +1296,7 @@ export function AccountDropdown() {
                 alt="Wallet avatar"
               />
             </Avatar>
-            <span className="max-w-[100px] truncate">
+            <span className="max-w-[100px] truncate hidden sm:inline">
               {displayAddress || "Loading..."}
             </span>
           </Button>
@@ -1306,7 +1306,7 @@ export function AccountDropdown() {
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="hidden md:flex items-center gap-2 transition-all hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-500"
+              className="flex items-center gap-2 transition-all hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-blue-500"
               id="nav-user-menu"
             >
               <Avatar className="h-8 w-8">
@@ -1315,7 +1315,7 @@ export function AccountDropdown() {
                   alt="Wallet avatar"
                 />
               </Avatar>
-              <span className="max-w-[100px] truncate">
+              <span className="max-w-[100px] truncate hidden sm:inline">
                 {displayAddress || "Loading..."}
               </span>
             </Button>

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1283,7 +1283,7 @@ export function AccountDropdown() {
         </TooltipProvider>
       </HydrationSafe>
 
-      {/* Account dropdown (desktop header + mobile when rendered from Navbar) */}
+      {/* Account menu trigger (visible on all breakpoints when signed in) */}
       <HydrationSafe
         fallback={
           <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, when signed out, the hamburger menu showed both **Get Started** and **Sign in with Orb**. Desktop only shows **Get Started** in the header and keeps Orb in the account dropdown after wallet connection.

## Solution

- **Signed-out mobile menu:** Only **Get Started** (Orb removed from nav list).
- **Signed-in mobile:** Single **AccountDropdown** in the header (avatar) with Orb inside — same as desktop.
- **Code review follow-up:** One `AccountDropdown` mount for all breakpoints (fixes duplicate `nav-user-menu` id and duplicate dropdown/dialog state). Desktop-only **Get Started** in header when signed out.
- **Mobile tour:** User-menu step now targets `#nav-user-menu` (profile avatar) instead of the hamburger.

## Files changed

- `components/Navbar.tsx` — unified header actions
- `components/account-dropdown/AccountDropdown.tsx` — account trigger visible on mobile
- `components/Tour/Tour.tsx` — mobile tour target update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad13543a-c7a8-440e-a67b-e36d146699e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad13543a-c7a8-440e-a67b-e36d146699e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

