### PR TITLE
Consolidate mobile navigation into a single menu

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -240,8 +240,10 @@ export default function Navbar() {
   const openAccountAction = (
     action: "buy" | "send" | "swap" | "session-keys"
   ) => {
-    accountDropdownRef.current?.openAction(action);
-    setIsMenuOpen(false);
+    if (accountDropdownRef.current) {
+      accountDropdownRef.current.openAction(action);
+      setIsMenuOpen(false);
+    }
   };
 
   const copyToClipboard = async () => {
@@ -389,7 +391,7 @@ export default function Navbar() {
                         </Avatar>
                         <div>
                           <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {smartAccountAddress ? "Smart Wallet" : "EOA"}
+                            {user?.type === "sca" ? "Smart Wallet" : "EOA"}
                           </p>
                           <p className="text-sm font-medium font-mono">
                             {displayAddress}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,7 +12,6 @@ import {
 import { HydrationSafe } from "@/components/ui/hydration-safe";
 import { Button } from "@/components/ui/button"; // Corrected import
 import {
-  Dialog as AccountKitDialog,
   useAuthModal,
   useLogout,
   useUser,
@@ -41,24 +40,22 @@ import {
 import type { User as AccountUser } from "@account-kit/signer";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { base } from "@account-kit/infra";
-import { ArrowBigDown, ArrowBigUp, ChevronDown, Search, X } from "lucide-react";
-import CoinbaseFundButton from "./wallet/buy/coinbase-fund-button";
 import { TokenBalance } from "./wallet/balance/TokenBalance";
 import { MeTokenBalances } from "./wallet/balance/MeTokenBalances";
 import type { Chain as ViemChain } from "viem";
-import { AccountDropdown } from "@/components/account-dropdown/AccountDropdown";
+import {
+  AccountDropdown,
+  type AccountDropdownHandle,
+} from "@/components/account-dropdown/AccountDropdown";
+import { MobileOrbSection } from "@/components/account-dropdown/MobileOrbSection";
+import { shortenAddress } from "@/lib/utils/utils";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
 import { useMeTokenHoldings } from "@/lib/hooks/metokens/useMeTokenHoldings";
 import { MembershipSection } from "./account-dropdown/MembershipSection";
 import { ChainSelect } from "@/components/ui/select";
-import { TokenSelect } from "@/components/ui/token-select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import makeBlockie from "ethereum-blockies-base64";
-import { type Address, erc20Abi, formatUnits } from 'viem';
-import { BASE_TOKENS, TOKEN_INFO, type TokenSymbol, alchemySwapService, AlchemySwapService } from '@/lib/sdk/alchemy/swap-service';
-import { AlchemySwapWidget } from './wallet/swap/AlchemySwapWidget';
 import { logger } from '@/lib/utils/logger';
 
 type UseUserResult = (AccountUser & { type: "eoa" | "sca" }) | null;
@@ -166,9 +163,7 @@ export default function Navbar() {
   const [displayAddress, setDisplayAddress] = useState<string>("");
   const { client: smartAccountClient } = useSmartAccountClient({});
   const [isNetworkConnected, setIsNetworkConnected] = useState(true);
-  const [isSessionSigsModalOpen, setIsSessionSigsModalOpen] = useState(false);
   const { isVerified, hasMembership } = useMembershipVerification();
-  const [selectedToken, setSelectedToken] = useState<"ETH" | "USDC" | "DAI">("ETH");
 
   // Check for MeTokens to conditionally render the section
   const { userMeToken, loading: meTokenLoading } = useMeTokensSupabase();
@@ -189,11 +184,7 @@ export default function Navbar() {
   }, [modularAccount?.address, user?.address]);
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [dialogAction, setDialogAction] = useState<"buy" | "send" | "swap">(
-    "buy"
-  );
-  const addressRef = useRef<HTMLDivElement | null>(null);
+  const accountDropdownRef = useRef<AccountDropdownHandle>(null);
   const [copySuccess, setCopySuccess] = useState(false);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -246,9 +237,11 @@ export default function Navbar() {
     setIsMenuOpen(false);
   };
 
-  const handleActionClick = (action: "buy" | "send" | "swap") => {
-    setDialogAction(action);
-    setIsDialogOpen(true);
+  const openAccountAction = (
+    action: "buy" | "send" | "swap" | "session-keys"
+  ) => {
+    accountDropdownRef.current?.openAction(action);
+    setIsMenuOpen(false);
   };
 
   const copyToClipboard = async () => {
@@ -289,106 +282,7 @@ export default function Navbar() {
     : "bg-white dark:bg-gray-900"
     }`;
 
-  // Dialog content based on the selected action
-  const getDialogContent = () => {
-    switch (dialogAction) {
-      case "buy":
-        return (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-            <h2 className="text-xl font-bold mb-4">Buy Crypto</h2>
-            <p className="mb-4">Purchase crypto directly to your wallet.</p>
-            <CoinbaseFundButton />
-            <div className="flex justify-end">
-              <Button onClick={() => setIsDialogOpen(false)}>Close</Button>
-            </div>
-          </div>
-        );
-      case "send":
-        return (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-4">
-            <h2 className="text-xl font-bold mb-4">Send Crypto</h2>
-            <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">Send crypto to another address.</p>
-            <div className="flex flex-col gap-4">
-              {/* Token Selection */}
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Token</label>
-                <div className="grid grid-cols-3 gap-2">
-                  {(['ETH', 'USDC', 'DAI'] as const).map((token) => (
-                    <button
-                      key={token}
-                      type="button"
-                      onClick={() => setSelectedToken(token)}
-                      className={`flex items-center justify-center space-x-2 p-2 border rounded-lg transition-colors ${selectedToken === token
-                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400'
-                        : 'border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600'
-                        }`}
-                    >
-                      <Image
-                        src={`/images/tokens/${token.toLowerCase()}-logo.svg`}
-                        alt={token}
-                        width={16}
-                        height={16}
-                        className="w-4 h-4 flex-shrink-0"
-                      />
-                      <span className={`text-sm font-medium ${selectedToken === token
-                        ? 'text-blue-700 dark:text-blue-300'
-                        : 'text-gray-900 dark:text-gray-100'
-                        }`}>
-                        {token}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className="space-y-2">
-                <label htmlFor="recipient-address" className="text-sm font-medium text-gray-900 dark:text-gray-100">Recipient Address</label>
-                <input
-                  id="recipient-address"
-                  name="recipientAddress"
-                  type="text"
-                  placeholder="0x..."
-                  className="w-full p-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 bg-white border-gray-200 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400"
-                />
-              </div>
-              <div className="space-y-2">
-                <label htmlFor="send-amount" className="text-sm font-medium text-gray-900 dark:text-gray-100">Amount ({selectedToken})</label>
-                <input
-                  id="send-amount"
-                  name="sendAmount"
-                  type="number"
-                  placeholder="0.0"
-                  step="any"
-                  className="w-full p-3 border rounded-lg dark:bg-gray-700 dark:border-gray-600 bg-white border-gray-200 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400"
-                />
-              </div>
-              <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                <Button
-                  variant="outline"
-                  className="w-full sm:w-auto sm:order-2"
-                  onClick={() => setIsDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button className="w-full sm:flex-1 sm:order-1">Send</Button>
-              </div>
-            </div>
-          </div>
-        );
-      case "swap":
-        return (
-          <AlchemySwapWidget
-            onSwapSuccess={() => {
-              toast.success("Swap successful!");
-              setIsDialogOpen(false);
-            }}
-            hideHeader={true}
-            className="border-none shadow-none p-0"
-          />
-        );
-      default:
-        return null;
-    }
-  };
+  const smartAccountAddress = modularAccount?.address;
 
   return (
     <header className={headerClassName}>
@@ -443,17 +337,11 @@ export default function Navbar() {
             </nav>
           </div>
 
-          {/* Header actions: single theme toggle + account dropdown (avoids duplicate DOM ids) */}
+          {/* Desktop: account dropdown. Mobile: hamburger only. */}
           <div className="flex items-center gap-2">
             <ThemeToggleComponent />
             <HydrationSafe>
-              {user ? (
-                <AccountDropdown />
-              ) : (
-                <div className="hidden md:block">
-                  <AccountDropdown />
-                </div>
-              )}
+              <AccountDropdown ref={accountDropdownRef} />
             </HydrationSafe>
             <button
               className={
@@ -464,7 +352,7 @@ export default function Navbar() {
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-expanded={isMenuOpen}
               id="mobile-menu-btn"
-              aria-label="Open main menu"
+              aria-label={isMenuOpen ? "Close main menu" : "Open main menu"}
             >
               <span className="sr-only">Open main menu</span>
               <MenuIcon className="h-6 w-6" />
@@ -500,9 +388,20 @@ export default function Navbar() {
                           />
                         </Avatar>
                         <div>
-                          <p className="text-sm font-medium">
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {smartAccountAddress ? "Smart Wallet" : "EOA"}
+                          </p>
+                          <p className="text-sm font-medium font-mono">
                             {displayAddress}
                           </p>
+                          {user?.address &&
+                            smartAccountAddress &&
+                            user.address.toLowerCase() !==
+                              smartAccountAddress.toLowerCase() && (
+                              <p className="text-xs text-gray-500 dark:text-gray-400">
+                                Signer: {shortenAddress(user.address)}
+                              </p>
+                            )}
                           <p className="text-xs text-gray-500 dark:text-gray-400">
                             {getChainName(currentChain)}
                           </p>
@@ -521,6 +420,7 @@ export default function Navbar() {
                         )}
                       </Button>
                     </div>
+                    <MobileOrbSection />
                   </div>
                 ) : (
                   <div className="pb-4 border-b border-gray-200 dark:border-gray-700">
@@ -582,20 +482,29 @@ export default function Navbar() {
                         Options
                       </div>
                       <Link
-                        href="/profile"
+                        href={`/profile/${smartAccountAddress || user?.address}`}
                         className={mobileMemberNavLinkClass}
                         onClick={handleLinkClick}
                       >
                         <ShieldUser className="mr-2 h-4 w-4" /> Profile
                       </Link>
                       <Link
-                        href="/upload"
+                        href={`/upload/${smartAccountAddress || user?.address}`}
                         className={mobileMemberNavLinkClass}
                         onClick={handleLinkClick}
                         id="nav-upload-link"
                       >
                         <CloudUpload className="mr-2 h-4 w-4" /> Upload
                       </Link>
+                      {user?.type !== "eoa" && (
+                        <button
+                          type="button"
+                          className={mobileMemberNavLinkClass}
+                          onClick={() => openAccountAction("session-keys")}
+                        >
+                          <Key className="mr-2 h-4 w-4 text-yellow-500" /> Session Keys
+                        </button>
+                      )}
 
                       {/* Membership Status Section */}
                       <div className="mt-4">
@@ -678,22 +587,16 @@ export default function Navbar() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => {
-                          handleActionClick("buy");
-                          setIsMenuOpen(false);
-                        }}
+                        onClick={() => openAccountAction("buy")}
                         className="flex items-center justify-center"
                       >
                         <Plus className="mr-2 h-4 w-4 text-green-500" />
-                        Buy
+                        Add
                       </Button>
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => {
-                          handleActionClick("send");
-                          setIsMenuOpen(false);
-                        }}
+                        onClick={() => openAccountAction("send")}
                         className="flex items-center justify-center"
                       >
                         <ArrowUpRight className="mr-2 h-4 w-4 text-blue-500" />
@@ -702,10 +605,7 @@ export default function Navbar() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => {
-                          handleActionClick("swap");
-                          setIsMenuOpen(false);
-                        }}
+                        onClick={() => openAccountAction("swap")}
                         className="flex items-center justify-center"
                       >
                         <ArrowUpDown className="mr-2 h-4 w-4 text-purple-500" />
@@ -748,10 +648,6 @@ export default function Navbar() {
             </div>
           </div>
 
-          {/* Account Kit Dialog for actions */}
-          <AccountKitDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)}>
-            <div className="max-w-md mx-auto">{getDialogContent()}</div>
-          </AccountKitDialog>
         </div>
       </div>
     </header>

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -22,7 +22,13 @@
  *    - Chain Switching: Changes the network for Account Kit integration
  */
 
-import { useState, useEffect } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
 import {
   useAuthModal,
   useLogout,
@@ -249,7 +255,12 @@ const SESSION_KEY_TYPES: SessionKeyConfig[] = [
   },
 ];
 
-export function AccountDropdown() {
+export type AccountDropdownHandle = {
+  openAction: (action: "buy" | "send" | "swap" | "session-keys") => void;
+};
+
+export const AccountDropdown = forwardRef<AccountDropdownHandle>(
+  function AccountDropdown(_, ref) {
   const { openAuthModal } = useAuthModal();
   const {
     isAuthenticated: isOrbAuthenticated,
@@ -431,13 +442,22 @@ export function AccountDropdown() {
     }
   };
 
-  const handleActionClick = (
-    action: "buy" | "send" | "swap" | "session-keys"
-  ) => {
-    setDialogAction(action);
-    setIsDialogOpen(true);
-    setIsDropdownOpen(false); // Close dropdown when action is clicked
-  };
+  const handleActionClick = useCallback(
+    (action: "buy" | "send" | "swap" | "session-keys") => {
+      setDialogAction(action);
+      setIsDialogOpen(true);
+      setIsDropdownOpen(false);
+    },
+    []
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      openAction: handleActionClick,
+    }),
+    [handleActionClick]
+  );
 
   const handleChainSwitch = async (newChain: any) => {
     if (isSettingChain) return;
@@ -1187,11 +1207,16 @@ export function AccountDropdown() {
   };
 
   if (!user) {
-    return <LoginButton />;
+    return (
+      <div className="hidden md:block">
+        <LoginButton />
+      </div>
+    );
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <>
+    <div className="hidden md:flex items-center gap-2">
       <HydrationSafe
         fallback={
           <Button
@@ -1655,6 +1680,7 @@ export function AccountDropdown() {
           </DropdownMenuContent>
         </DropdownMenu>
       </HydrationSafe>
+    </div>
 
       <Dialog
         open={isDialogOpen}
@@ -1698,6 +1724,6 @@ export function AccountDropdown() {
           </div>
         </DialogContent>
       </Dialog>
-    </div>
+    </>
   );
-}
+});

--- a/components/account-dropdown/MobileOrbSection.tsx
+++ b/components/account-dropdown/MobileOrbSection.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useOrbSession } from "@/context/OrbSessionContext";
+import { shortenAddress } from "@/lib/utils/utils";
+import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
+import { useUser } from "@account-kit/react";
+
+export function MobileOrbSection() {
+  const user = useUser();
+  const { account: modularAccount } = useModularAccount();
+  const {
+    isAuthenticated: isOrbAuthenticated,
+    lensAccount,
+    openLoginModal: openOrbLogin,
+    linkProfile,
+    isLinking: isOrbLinking,
+    logout: logoutOrb,
+  } = useOrbSession();
+
+  const walletAddress = modularAccount?.address || user?.address;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground font-semibold">Orb / Lens</p>
+      {isOrbAuthenticated ? (
+        <div className="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-700">
+          <p className="text-xs text-green-600 dark:text-green-400">
+            Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1 text-xs"
+              disabled={isOrbLinking}
+              onClick={() => linkProfile(walletAddress)}
+            >
+              {isOrbLinking ? "Linking…" : "Sync profile"}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs"
+              onClick={() => logoutOrb()}
+            >
+              Orb out
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full text-xs"
+          onClick={() => openOrbLogin()}
+        >
+          Sign in with Orb
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, signed-in users saw **two competing menus** in the header:

1. **Account avatar dropdown** — wallet details, Orb, profile, membership, buy/send/swap
2. **Hamburger menu** — largely the same links and actions

That duplicated UI, crowded the header (theme + avatar + hamburger), and felt inconsistent across breakpoints.

## Solution

- **Hide account dropdown triggers below `md`** — avatar and chain switcher only show on tablet/desktop
- **Single mobile entry point** — hamburger sheet holds navigation, account, Orb/Lens, session keys, and wallet actions
- **Shared wallet dialogs** — mobile Add/Send/Swap/Session Keys call `AccountDropdown` via `ref` so behavior matches desktop without a second dialog implementation
- **`MobileOrbSection`** — Orb/Lens controls in the mobile sheet (previously only in the dropdown)

## Responsive behavior

| Viewport | Navigation | Account |
|----------|------------|---------|
| `< md` | Hamburger sheet | Wallet, Orb, actions inside sheet |
| `≥ md` | Inline nav links | Account dropdown in header |

## Files changed

- `components/Navbar.tsx` — unified mobile menu, removed duplicate Account Kit dialog
- `components/account-dropdown/AccountDropdown.tsx` — `forwardRef` + desktop-only triggers
- `components/account-dropdown/MobileOrbSection.tsx` — Orb/Lens block for mobile sheet
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80c14d6b-471a-4dcd-9169-422d42d191eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80c14d6b-471a-4dcd-9169-422d42d191eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

