### PR TITLE
Animate mobile menu icon and add Creative Platform apps drawer

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -57,6 +57,8 @@ import { ChainSelect } from "@/components/ui/select";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import makeBlockie from "ethereum-blockies-base64";
 import { logger } from '@/lib/utils/logger';
+import { AnimatedMenuIcon } from "@/components/navbar/AnimatedMenuIcon";
+import { CreativePlatformAppsDrawer } from "@/components/navbar/CreativePlatformAppsDrawer";
 
 type UseUserResult = (AccountUser & { type: "eoa" | "sca" }) | null;
 
@@ -341,6 +343,7 @@ export default function Navbar() {
 
           {/* Desktop: account dropdown. Mobile: hamburger only. */}
           <div className="flex items-center gap-2">
+            <CreativePlatformAppsDrawer />
             <ThemeToggleComponent />
             <HydrationSafe>
               <AccountDropdown ref={accountDropdownRef} />
@@ -356,8 +359,10 @@ export default function Navbar() {
               id="mobile-menu-btn"
               aria-label={isMenuOpen ? "Close main menu" : "Open main menu"}
             >
-              <span className="sr-only">Open main menu</span>
-              <MenuIcon className="h-6 w-6" />
+              <span className="sr-only">
+                {isMenuOpen ? "Close main menu" : "Open main menu"}
+              </span>
+              <AnimatedMenuIcon isOpen={isMenuOpen} />
             </button>
           </div>
 
@@ -653,27 +658,5 @@ export default function Navbar() {
         </div>
       </div>
     </header>
-  );
-}
-
-function MenuIcon(props: any) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="h-6 w-6"
-      {...props}
-    >
-      <line x1="4" x2="20" y1="12" y2="12" />
-      <line x1="4" x2="20" y1="6" y2="6" />
-      <line x1="4" x2="20" y1="18" y2="18" />
-    </svg>
   );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -59,6 +59,7 @@ import makeBlockie from "ethereum-blockies-base64";
 import { logger } from '@/lib/utils/logger';
 import { AnimatedMenuIcon } from "@/components/navbar/AnimatedMenuIcon";
 import { CreativePlatformAppsDrawer } from "@/components/navbar/CreativePlatformAppsDrawer";
+import { navIconButtonProps } from "@/components/navbar/navButtonStyles";
 
 type UseUserResult = (AccountUser & { type: "eoa" | "sca" }) | null;
 
@@ -348,22 +349,16 @@ export default function Navbar() {
             <HydrationSafe>
               <AccountDropdown ref={accountDropdownRef} />
             </HydrationSafe>
-            <button
-              className={
-                "md:hidden inline-flex items-center justify-center rounded-md p-2 " +
-                "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 " +
-                "dark:hover:bg-gray-800 dark:hover:text-gray-50 transition-colors"
-              }
+            <Button
+              {...navIconButtonProps}
+              className="md:hidden"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-expanded={isMenuOpen}
               id="mobile-menu-btn"
               aria-label={isMenuOpen ? "Close main menu" : "Open main menu"}
             >
-              <span className="sr-only">
-                {isMenuOpen ? "Close main menu" : "Open main menu"}
-              </span>
               <AnimatedMenuIcon isOpen={isMenuOpen} />
-            </button>
+            </Button>
           </div>
 
           {/* Mobile menu */}

--- a/components/navbar/AnimatedMenuIcon.tsx
+++ b/components/navbar/AnimatedMenuIcon.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { cn } from "@/lib/utils/utils";
+
+interface AnimatedMenuIconProps {
+  isOpen: boolean;
+  className?: string;
+}
+
+export function AnimatedMenuIcon({ isOpen, className }: AnimatedMenuIconProps) {
+  return (
+    <span
+      className={cn("relative flex h-6 w-6 items-center justify-center", className)}
+      aria-hidden
+    >
+      <span className="absolute h-6 w-6">
+        <span
+          className={cn(
+            "absolute left-1/2 top-[6px] block h-0.5 w-5 -translate-x-1/2 rounded-full bg-current",
+            "transition-all duration-300 ease-in-out",
+            isOpen ? "top-1/2 -translate-y-1/2 rotate-45" : ""
+          )}
+        />
+        <span
+          className={cn(
+            "absolute left-1/2 top-1/2 block h-0.5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current",
+            "transition-all duration-300 ease-in-out",
+            isOpen ? "scale-x-0 opacity-0" : "opacity-100"
+          )}
+        />
+        <span
+          className={cn(
+            "absolute left-1/2 top-[18px] block h-0.5 w-5 -translate-x-1/2 rounded-full bg-current",
+            "transition-all duration-300 ease-in-out",
+            isOpen ? "top-1/2 -translate-y-1/2 -rotate-45" : ""
+          )}
+        />
+      </span>
+    </span>
+  );
+}

--- a/components/navbar/CreativePlatformAppsDrawer.tsx
+++ b/components/navbar/CreativePlatformAppsDrawer.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import {
+  LayoutGrid,
+  Newspaper,
+  Tv,
+  Bot,
+  Landmark,
+  Disc3,
+  Gamepad2,
+  Mic,
+  ExternalLink,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils/utils";
+
+const CREATIVE_PLATFORM_APPS = [
+  {
+    name: "News",
+    href: "https://news.creativeplatform.xyz",
+    icon: Newspaper,
+    description: "Stories and updates from the platform",
+  },
+  {
+    name: "TV",
+    href: "https://tv.creativeplatform.xyz",
+    icon: Tv,
+    description: "Watch and discover video content",
+    isCurrent: true,
+  },
+  {
+    name: "Pixels",
+    href: "https://create.creativeplatform.xyz",
+    icon: Bot,
+    description: "Create with AI-powered tools",
+  },
+  {
+    name: "Finance",
+    href: "https://finance.creativeplatform.xyz",
+    icon: Landmark,
+    description: "Manage your creative finances",
+  },
+  {
+    name: "Mixtape",
+    href: "https://air.creativeplatform.xyz/app",
+    icon: Disc3,
+    description: "Curate and share music mixes",
+  },
+  {
+    name: "Beat Me",
+    href: "https://beatme.creativeplatform.xyz",
+    icon: Gamepad2,
+    description: "Compete in rhythm challenges",
+  },
+  {
+    name: "Podcast",
+    href: "https://open.spotify.com/show/4zAsBnJwZKquxvI7oPqRam?si=ZCEjVk6VQ4ClhyCsabtn8A",
+    icon: Mic,
+    description: "Listen on Spotify",
+  },
+] as const;
+
+const navButtonClass =
+  "inline-flex items-center justify-center rounded-md p-2 text-gray-500 " +
+  "hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 " +
+  "dark:hover:text-gray-50 transition-colors";
+
+export function CreativePlatformAppsDrawer() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={navButtonClass}
+          aria-label="Open Creative Platform apps"
+          id="creative-platform-apps-btn"
+        >
+          <LayoutGrid className="h-5 w-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full sm:max-w-sm">
+        <SheetHeader className="text-left">
+          <SheetTitle>Creative Platform</SheetTitle>
+          <SheetDescription>
+            Explore apps across the Creative Platform ecosystem.
+          </SheetDescription>
+        </SheetHeader>
+        <nav className="mt-6 grid gap-2">
+          {CREATIVE_PLATFORM_APPS.map((app) => {
+            const Icon = app.icon;
+            const isExternal = app.href.startsWith("http");
+
+            return (
+              <Link
+                key={app.name}
+                href={app.href}
+                target={isExternal ? "_blank" : undefined}
+                rel={isExternal ? "noopener noreferrer" : undefined}
+                className={cn(
+                  "group flex items-center gap-3 rounded-lg border border-transparent p-3",
+                  "transition-colors hover:border-gray-200 hover:bg-gray-50",
+                  "dark:hover:border-gray-700 dark:hover:bg-gray-800/50",
+                  "isCurrent" in app && app.isCurrent &&
+                    "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50"
+                )}
+              >
+                <span
+                  className={cn(
+                    "flex h-10 w-10 shrink-0 items-center justify-center rounded-md",
+                    "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200",
+                    "group-hover:bg-white dark:group-hover:bg-gray-900"
+                  )}
+                >
+                  <Icon className="h-5 w-5" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-2">
+                    <span className="font-medium">{app.name}</span>
+                    {"isCurrent" in app && app.isCurrent && (
+                      <span className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-500">
+                        Current
+                      </span>
+                    )}
+                  </span>
+                  <span className="block truncate text-sm text-muted-foreground">
+                    {app.description}
+                  </span>
+                </span>
+                {isExternal && (
+                  <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                )}
+              </Link>
+            );
+          })}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/navbar/CreativePlatformAppsDrawer.tsx
+++ b/components/navbar/CreativePlatformAppsDrawer.tsx
@@ -69,23 +69,17 @@ const CREATIVE_PLATFORM_APPS = [
   },
 ] as const;
 
-const navButtonClass =
-  "inline-flex items-center justify-center rounded-md p-2 text-gray-500 " +
-  "hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 " +
-  "dark:hover:text-gray-50 transition-colors";
-
 export function CreativePlatformAppsDrawer() {
   return (
     <Sheet>
       <SheetTrigger asChild>
         <Button
-          variant="ghost"
+          variant="outline"
           size="icon"
-          className={navButtonClass}
-          aria-label="Open Creative Platform apps"
           id="creative-platform-apps-btn"
         >
-          <LayoutGrid className="h-5 w-5" />
+          <LayoutGrid className="h-[1.2rem] w-[1.2rem]" />
+          <span className="sr-only">Browse Creative Platform apps</span>
         </Button>
       </SheetTrigger>
       <SheetContent side="right" className="w-full sm:max-w-sm">
@@ -95,7 +89,7 @@ export function CreativePlatformAppsDrawer() {
             Explore apps across the Creative Platform ecosystem.
           </SheetDescription>
         </SheetHeader>
-        <nav className="mt-6 grid gap-2">
+        <nav className="mt-6 grid gap-2" aria-label="Creative Platform apps">
           {CREATIVE_PLATFORM_APPS.map((app) => {
             const Icon = app.icon;
             const isExternal = app.href.startsWith("http");

--- a/components/navbar/CreativePlatformAppsDrawer.tsx
+++ b/components/navbar/CreativePlatformAppsDrawer.tsx
@@ -22,6 +22,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils/utils";
+import { navIconButtonProps } from "@/components/navbar/navButtonStyles";
 
 const CREATIVE_PLATFORM_APPS = [
   {
@@ -74,8 +75,7 @@ export function CreativePlatformAppsDrawer() {
     <Sheet>
       <SheetTrigger asChild>
         <Button
-          variant="outline"
-          size="icon"
+          {...navIconButtonProps}
           id="creative-platform-apps-btn"
         >
           <LayoutGrid className="h-[1.2rem] w-[1.2rem]" />
@@ -93,6 +93,7 @@ export function CreativePlatformAppsDrawer() {
           {CREATIVE_PLATFORM_APPS.map((app) => {
             const Icon = app.icon;
             const isExternal = app.href.startsWith("http");
+            const isCurrent = "isCurrent" in app && app.isCurrent;
 
             return (
               <Link
@@ -104,7 +105,7 @@ export function CreativePlatformAppsDrawer() {
                   "group flex items-center gap-3 rounded-lg border border-transparent p-3",
                   "transition-colors hover:border-gray-200 hover:bg-gray-50",
                   "dark:hover:border-gray-700 dark:hover:bg-gray-800/50",
-                  "isCurrent" in app && app.isCurrent &&
+                  isCurrent &&
                     "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50"
                 )}
               >
@@ -120,7 +121,7 @@ export function CreativePlatformAppsDrawer() {
                 <span className="min-w-0 flex-1">
                   <span className="flex items-center gap-2">
                     <span className="font-medium">{app.name}</span>
-                    {"isCurrent" in app && app.isCurrent && (
+                    {isCurrent && (
                       <span className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-500">
                         Current
                       </span>

--- a/components/navbar/navButtonStyles.ts
+++ b/components/navbar/navButtonStyles.ts
@@ -1,0 +1,6 @@
+import type { ButtonProps } from "@/components/ui/button";
+
+export const navIconButtonProps = {
+  variant: "outline",
+  size: "icon",
+} as const satisfies Pick<ButtonProps, "variant" | "size">;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Mobile hamburger animation**: The mobile menu button now smoothly animates from a hamburger icon into an X when the menu is open, and back when closed.
- **Creative Platform apps drawer**: A new `LayoutGrid` button in the navbar (visible on all screen sizes) opens a right slide-out drawer listing all ecosystem apps.
- **Prominent nav styling**: The apps button now uses the same `outline` icon button treatment as the theme toggle for consistent, accessible utility navigation.

## Apps included
| App | URL |
|-----|-----|
| News | https://news.creativeplatform.xyz |
| TV | https://tv.creativeplatform.xyz |
| Pixels | https://create.creativeplatform.xyz |
| Finance | https://finance.creativeplatform.xyz |
| Mixtape | https://air.creativeplatform.xyz/app |
| Beat Me | https://beatme.creativeplatform.xyz |
| Podcast | https://open.spotify.com/show/4zAsBnJwZKquxvI7oPqRam |

## Changes
- `components/navbar/AnimatedMenuIcon.tsx` — CSS-animated hamburger ↔ close icon
- `components/navbar/CreativePlatformAppsDrawer.tsx` — Sheet-based right drawer with app links; outline icon trigger matching theme toggle
- `components/Navbar.tsx` — Integrated both components into the navbar

## Testing
- [ ] On mobile, tap hamburger — icon animates to X and menu opens
- [ ] Tap again — icon animates back to hamburger and menu closes
- [ ] Apps button visually matches theme toggle (bordered outline icon button)
- [ ] On any screen size, tap the grid icon — drawer slides in from the right
- [ ] Each app link opens the correct URL in a new tab
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae2935cf-d70e-4bbe-ba7d-132bd01d2c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae2935cf-d70e-4bbe-ba7d-132bd01d2c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

