### PR TITLE
Fix Orb login: missing lens_account_id on creator_profiles

### DIFF
--- a/SUPABASE_SETUP_INSTRUCTIONS.md
+++ b/SUPABASE_SETUP_INSTRUCTIONS.md
@@ -86,7 +86,7 @@ The app stores Orb/Lens identity on `creator_profiles`, but those columns were n
 ### Fix
 
 1. Open [Supabase Dashboard](https://supabase.com/dashboard) → your project → **SQL Editor**
-2. Run the script from `scripts/add-orb-lens-columns-to-creator-profiles.sql` (or migration `supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql`)
+2. Run `scripts/add-orb-lens-columns-to-creator-profiles.sql` in the SQL Editor, **or** apply `supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql` via `supabase db push`
 3. Retry Orb sign-in / **Sync profile**
 
 Alternatively, with the Supabase CLI linked to your project:

--- a/SUPABASE_SETUP_INSTRUCTIONS.md
+++ b/SUPABASE_SETUP_INSTRUCTIONS.md
@@ -75,6 +75,35 @@ After running the migration, you can verify the table was created by:
    - `created_at` (Timestamp)
    - `updated_at` (Timestamp)
 
+## Issue: Missing `lens_account_id` column (Orb sign-in)
+
+After signing in with Orb, you may see:
+
+> Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache
+
+The app stores Orb/Lens identity on `creator_profiles`, but those columns were not applied to your Supabase database yet.
+
+### Fix
+
+1. Open [Supabase Dashboard](https://supabase.com/dashboard) → your project → **SQL Editor**
+2. Run the script from `scripts/add-orb-lens-columns-to-creator-profiles.sql` (or migration `supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql`)
+3. Retry Orb sign-in / **Sync profile**
+
+Alternatively, with the Supabase CLI linked to your project:
+
+```bash
+supabase db push
+```
+
+PostgREST refreshes the schema cache automatically after `ALTER TABLE`; if the error persists, wait a minute or restart the API from Project Settings.
+
+Expected new columns on `creator_profiles`:
+
+- `orb_account_id`
+- `lens_account_id`
+- `lens_handle`
+- `lens_avatar_uri`
+
 ## Fallback Behavior
 
 The application has been updated to handle the missing table gracefully:

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -18,4 +18,12 @@ describe('formatOrbAuthError', () => {
       /Get Started/i,
     );
   });
+
+  it('maps missing lens_account_id schema cache errors', () => {
+    expect(
+      formatOrbAuthError(
+        "Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache",
+      ),
+    ).toMatch(/add-orb-lens-columns/i);
+  });
 });

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -33,6 +33,12 @@ export function formatOrbAuthError(error: unknown): string {
   if (lower.includes('user rejected') || lower.includes('denied')) {
     return 'Wallet signature was cancelled. Approve the signature to link your profile.';
   }
+  if (
+    lower.includes('lens_account_id') &&
+    (lower.includes('schema cache') || lower.includes('could not find'))
+  ) {
+    return 'Database is missing Orb/Lens profile columns. Run scripts/add-orb-lens-columns-to-creator-profiles.sql in the Supabase SQL Editor, then try again.';
+  }
 
   return msg.length > 160 ? `${msg.slice(0, 157)}…` : msg;
 }

--- a/lib/sdk/supabase/schema.sql
+++ b/lib/sdk/supabase/schema.sql
@@ -55,10 +55,10 @@ CREATE TABLE IF NOT EXISTS creator_profiles (
   username TEXT,
   bio TEXT,
   avatar_url TEXT, -- URL to avatar image in Supabase Storage
-  orb_account_id TEXT,
-  lens_account_id TEXT,
-  lens_handle TEXT,
-  lens_avatar_uri TEXT,
+  orb_account_id TEXT, -- Orb sovereign account id from QR sign-in
+  lens_account_id TEXT, -- Lens account address linked via Orb
+  lens_handle TEXT, -- Lens username/handle for display
+  lens_avatar_uri TEXT, -- Lens profile picture URI (ipfs/lens)
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -101,6 +101,12 @@ CREATE INDEX IF NOT EXISTS idx_metokens_tvl ON metokens(tvl DESC);
 -- Creator profiles indexes
 CREATE INDEX IF NOT EXISTS idx_creator_profiles_owner ON creator_profiles(owner_address);
 CREATE INDEX IF NOT EXISTS idx_creator_profiles_username ON creator_profiles(username);
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
 
 -- Video assets indexes
 CREATE INDEX IF NOT EXISTS idx_video_assets_creator ON video_assets(creator_id);

--- a/lib/sdk/supabase/schema.sql
+++ b/lib/sdk/supabase/schema.sql
@@ -55,6 +55,10 @@ CREATE TABLE IF NOT EXISTS creator_profiles (
   username TEXT,
   bio TEXT,
   avatar_url TEXT, -- URL to avatar image in Supabase Storage
+  orb_account_id TEXT,
+  lens_account_id TEXT,
+  lens_handle TEXT,
+  lens_avatar_uri TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/scripts/add-orb-lens-columns-to-creator-profiles.sql
+++ b/scripts/add-orb-lens-columns-to-creator-profiles.sql
@@ -1,0 +1,23 @@
+-- Orb / Lens columns for creator_profiles (required for Orb sign-in / link-orb API)
+-- Run in Supabase Dashboard → SQL Editor if you see:
+--   "Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache"
+-- Same as: supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
+
+ALTER TABLE public.creator_profiles
+  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
+  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON public.creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON public.creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
+
+COMMENT ON COLUMN public.creator_profiles.orb_account_id IS 'Orb sovereign account id from QR sign-in';
+COMMENT ON COLUMN public.creator_profiles.lens_account_id IS 'Lens account address linked via Orb';
+COMMENT ON COLUMN public.creator_profiles.lens_handle IS 'Lens username/handle for display';
+COMMENT ON COLUMN public.creator_profiles.lens_avatar_uri IS 'Lens profile picture URI (ipfs/lens)';

--- a/scripts/add-orb-lens-columns-to-creator-profiles.sql
+++ b/scripts/add-orb-lens-columns-to-creator-profiles.sql
@@ -1,7 +1,7 @@
--- Orb / Lens columns for creator_profiles (required for Orb sign-in / link-orb API)
+-- Standalone script: add Orb/Lens columns to creator_profiles (existing databases) (required for Orb sign-in / link-orb API)
 -- Run in Supabase Dashboard → SQL Editor if you see:
 --   "Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache"
--- Same as: supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
+-- Canonical migration: supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
 
 ALTER TABLE public.creator_profiles
   ADD COLUMN IF NOT EXISTS orb_account_id TEXT,

--- a/scripts/setup-creator-profiles-table.sql
+++ b/scripts/setup-creator-profiles-table.sql
@@ -37,6 +37,21 @@ CREATE TRIGGER update_creator_profiles_updated_at
   BEFORE UPDATE ON creator_profiles 
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+-- Orb / Lens identity (required for Orb sign-in)
+ALTER TABLE public.creator_profiles
+  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
+  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON public.creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON public.creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
+
 -- Verify the table was created
 SELECT 
   table_name, 

--- a/scripts/setup-creator-profiles-table.sql
+++ b/scripts/setup-creator-profiles-table.sql
@@ -8,6 +8,10 @@ CREATE TABLE IF NOT EXISTS creator_profiles (
   username TEXT,
   bio TEXT,
   avatar_url TEXT, -- URL to avatar image stored on IPFS via Lighthouse
+  orb_account_id TEXT, -- Orb sovereign account id from QR sign-in
+  lens_account_id TEXT, -- Lens account address linked via Orb
+  lens_handle TEXT, -- Lens username/handle for display
+  lens_avatar_uri TEXT, -- Lens profile picture URI (ipfs/lens)
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -15,6 +19,12 @@ CREATE TABLE IF NOT EXISTS creator_profiles (
 -- Creator profiles indexes
 CREATE INDEX IF NOT EXISTS idx_creator_profiles_owner ON creator_profiles(owner_address);
 CREATE INDEX IF NOT EXISTS idx_creator_profiles_username ON creator_profiles(username);
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
 
 -- Enable Row Level Security
 ALTER TABLE creator_profiles ENABLE ROW LEVEL SECURITY;
@@ -36,21 +46,6 @@ CREATE POLICY "Users can delete their own profile" ON creator_profiles
 CREATE TRIGGER update_creator_profiles_updated_at 
   BEFORE UPDATE ON creator_profiles 
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
--- Orb / Lens identity (required for Orb sign-in)
-ALTER TABLE public.creator_profiles
-  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
-  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
-  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
-  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
-
-CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
-  ON public.creator_profiles (orb_account_id)
-  WHERE orb_account_id IS NOT NULL;
-
-CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
-  ON public.creator_profiles (lens_account_id)
-  WHERE lens_account_id IS NOT NULL;
 
 -- Verify the table was created
 SELECT 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Orb sign-in fails when linking profile:

> Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache

## Operational fix

Run `scripts/add-orb-lens-columns-to-creator-profiles.sql` in Supabase SQL Editor (or `supabase db push`).

## PR changes

- Standalone SQL script + docs
- Setup/schema include Orb/Lens columns
- Friendlier Orb error message when schema is stale
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

