### PR TITLE
Remediate Supabase Security Advisor warnings

### DIFF
--- a/SUPABASE_SETUP_INSTRUCTIONS.md
+++ b/SUPABASE_SETUP_INSTRUCTIONS.md
@@ -75,6 +75,35 @@ After running the migration, you can verify the table was created by:
    - `created_at` (Timestamp)
    - `updated_at` (Timestamp)
 
+## Issue: Missing `lens_account_id` column (Orb sign-in)
+
+After signing in with Orb, you may see:
+
+> Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache
+
+The app stores Orb/Lens identity on `creator_profiles`, but those columns were not applied to your Supabase database yet.
+
+### Fix
+
+1. Open [Supabase Dashboard](https://supabase.com/dashboard) → your project → **SQL Editor**
+2. Run the script from `scripts/add-orb-lens-columns-to-creator-profiles.sql` (or migration `supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql`)
+3. Retry Orb sign-in / **Sync profile**
+
+Alternatively, with the Supabase CLI linked to your project:
+
+```bash
+supabase db push
+```
+
+PostgREST refreshes the schema cache automatically after `ALTER TABLE`; if the error persists, wait a minute or restart the API from Project Settings.
+
+Expected new columns on `creator_profiles`:
+
+- `orb_account_id`
+- `lens_account_id`
+- `lens_handle`
+- `lens_avatar_uri`
+
 ## Fallback Behavior
 
 The application has been updated to handle the missing table gracefully:

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -18,4 +18,12 @@ describe('formatOrbAuthError', () => {
       /Get Started/i,
     );
   });
+
+  it('maps missing lens_account_id schema cache errors', () => {
+    expect(
+      formatOrbAuthError(
+        "Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache",
+      ),
+    ).toMatch(/add-orb-lens-columns/i);
+  });
 });

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -33,6 +33,12 @@ export function formatOrbAuthError(error: unknown): string {
   if (lower.includes('user rejected') || lower.includes('denied')) {
     return 'Wallet signature was cancelled. Approve the signature to link your profile.';
   }
+  if (
+    lower.includes('lens_account_id') &&
+    (lower.includes('schema cache') || lower.includes('could not find'))
+  ) {
+    return 'Database is missing Orb/Lens profile columns. Run scripts/add-orb-lens-columns-to-creator-profiles.sql in the Supabase SQL Editor, then try again.';
+  }
 
   return msg.length > 160 ? `${msg.slice(0, 157)}…` : msg;
 }

--- a/lib/sdk/supabase/schema.sql
+++ b/lib/sdk/supabase/schema.sql
@@ -55,6 +55,10 @@ CREATE TABLE IF NOT EXISTS creator_profiles (
   username TEXT,
   bio TEXT,
   avatar_url TEXT, -- URL to avatar image in Supabase Storage
+  orb_account_id TEXT,
+  lens_account_id TEXT,
+  lens_handle TEXT,
+  lens_avatar_uri TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/scripts/add-orb-lens-columns-to-creator-profiles.sql
+++ b/scripts/add-orb-lens-columns-to-creator-profiles.sql
@@ -1,0 +1,23 @@
+-- Orb / Lens columns for creator_profiles (required for Orb sign-in / link-orb API)
+-- Run in Supabase Dashboard → SQL Editor if you see:
+--   "Could not find the 'lens_account_id' column of 'creator_profiles' in the schema cache"
+-- Same as: supabase/migrations/20260519170000_add_orb_lens_to_creator_profiles.sql
+
+ALTER TABLE public.creator_profiles
+  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
+  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON public.creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON public.creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
+
+COMMENT ON COLUMN public.creator_profiles.orb_account_id IS 'Orb sovereign account id from QR sign-in';
+COMMENT ON COLUMN public.creator_profiles.lens_account_id IS 'Lens account address linked via Orb';
+COMMENT ON COLUMN public.creator_profiles.lens_handle IS 'Lens username/handle for display';
+COMMENT ON COLUMN public.creator_profiles.lens_avatar_uri IS 'Lens profile picture URI (ipfs/lens)';

--- a/scripts/fix-security-advisor-warnings.sql
+++ b/scripts/fix-security-advisor-warnings.sql
@@ -1,90 +1,269 @@
--- Supabase Security Advisor remediation
+-- Supabase Security Advisor remediation (all 8 warnings)
 -- Run in Supabase Dashboard → SQL Editor
--- See also: supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+--
+-- After running, verify with scripts/verify-security-advisor-state.sql
 
--- 1) Function search_path
+-- =============================================================================
+-- 1) function_search_path_mutable — SET search_path = '' + schema-qualified refs
+--    https://supabase.com/docs/guides/database/database-linter?lint=0011
+-- =============================================================================
+
 CREATE OR REPLACE FUNCTION public.search_video_assets(
   search_query text,
   result_limit integer DEFAULT 20,
   result_offset integer DEFAULT 0
 )
 RETURNS TABLE (
-  id integer, title text, asset_id text, category text, location text,
-  playback_id text, description text, creator_id text, status text,
-  thumbnail_url text, duration integer, views_count integer, likes_count integer,
-  is_minted boolean, created_at timestamptz, updated_at timestamptz, rank real
+  id integer,
+  title text,
+  asset_id text,
+  category text,
+  location text,
+  playback_id text,
+  description text,
+  creator_id text,
+  status text,
+  thumbnail_url text,
+  duration integer,
+  views_count integer,
+  likes_count integer,
+  is_minted boolean,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  rank real
 )
 LANGUAGE plpgsql
 SECURITY INVOKER
-SET search_path = public, pg_temp
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT va.id, va.title, va.asset_id, va.category, va.location, va.playback_id,
-    va.description, va.creator_id, va.status, va.thumbnail_url, va.duration,
-    va.views_count, va.likes_count, va.is_minted, va.created_at, va.updated_at,
-    ts_rank(va.search_vector, websearch_to_tsquery('english', search_query)) AS rank
-  FROM video_assets va
-  WHERE va.status = 'published'
-    AND va.search_vector @@ websearch_to_tsquery('english', search_query)
+  SELECT
+    va.id,
+    va.title,
+    va.asset_id,
+    va.category,
+    va.location,
+    va.playback_id,
+    va.description,
+    va.creator_id,
+    va.status,
+    va.thumbnail_url,
+    va.duration,
+    va.views_count,
+    va.likes_count,
+    va.is_minted,
+    va.created_at,
+    va.updated_at,
+    pg_catalog.ts_rank(
+      va.search_vector,
+      pg_catalog.websearch_to_tsquery('english', search_query)
+    ) AS rank
+  FROM public.video_assets AS va
+  WHERE
+    va.status = 'published'
+    AND va.search_vector @@ pg_catalog.websearch_to_tsquery('english', search_query)
   ORDER BY rank DESC, va.created_at DESC
-  LIMIT result_limit OFFSET result_offset;
+  LIMIT result_limit
+  OFFSET result_offset;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr TEXT)
+CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr text)
 RETURNS TABLE (
-  total_transactions BIGINT, unique_holders BIGINT,
-  total_volume NUMERIC, avg_transaction_size NUMERIC
+  total_transactions bigint,
+  unique_holders bigint,
+  total_volume numeric,
+  avg_transaction_size numeric
 )
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT COUNT(mt.id),
-    COUNT(DISTINCT mb.user_address),
-    COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0),
-    CASE WHEN COUNT(mt.id) > 0 THEN
-      COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0) / COUNT(mt.id)
-    ELSE 0 END
-  FROM metoken_transactions mt
-  LEFT JOIN metoken_balances mb ON mb.metoken_id = mt.metoken_id
-  WHERE mt.metoken_id = (SELECT id FROM metokens WHERE address = metoken_addr);
+  SELECT
+    pg_catalog.count(mt.id) AS total_transactions,
+    pg_catalog.count(DISTINCT mb.user_address) AS unique_holders,
+    pg_catalog.coalesce(
+      pg_catalog.sum(
+        CASE
+          WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
+          ELSE mt.amount
+        END
+      ),
+      0
+    ) AS total_volume,
+    CASE
+      WHEN pg_catalog.count(mt.id) > 0 THEN
+        pg_catalog.coalesce(
+          pg_catalog.sum(
+            CASE
+              WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
+              ELSE mt.amount
+            END
+          ),
+          0
+        ) / pg_catalog.count(mt.id)
+      ELSE 0
+    END AS avg_transaction_size
+  FROM public.metoken_transactions AS mt
+  LEFT JOIN public.metoken_balances AS mb ON mb.metoken_id = mt.metoken_id
+  WHERE mt.metoken_id = (
+    SELECT m.id FROM public.metokens AS m WHERE m.address = metoken_addr
+  );
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION public.search_metokens(search_query TEXT, result_limit INTEGER DEFAULT 20)
-RETURNS TABLE (
-  id UUID, address TEXT, owner_address TEXT, name TEXT, symbol TEXT,
-  total_supply NUMERIC, tvl NUMERIC, hub_id INTEGER, balance_pooled NUMERIC,
-  balance_locked NUMERIC, start_time TIMESTAMPTZ, end_time TIMESTAMPTZ,
-  end_cooldown TIMESTAMPTZ, target_hub_id INTEGER, migration_address TEXT,
-  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, rank REAL
+CREATE OR REPLACE FUNCTION public.search_metokens(
+  search_query text,
+  result_limit integer DEFAULT 20
 )
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+RETURNS TABLE (
+  id uuid,
+  address text,
+  owner_address text,
+  name text,
+  symbol text,
+  total_supply numeric,
+  tvl numeric,
+  hub_id integer,
+  balance_pooled numeric,
+  balance_locked numeric,
+  start_time timestamp with time zone,
+  end_time timestamp with time zone,
+  end_cooldown timestamp with time zone,
+  target_hub_id integer,
+  migration_address text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  rank real
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT m.*, ts_rank(to_tsvector('english', m.name || ' ' || m.symbol), plainto_tsquery('english', search_query)) AS rank
-  FROM metokens m
-  WHERE to_tsvector('english', m.name || ' ' || m.symbol) @@ plainto_tsquery('english', search_query)
-  ORDER BY rank DESC, m.tvl DESC LIMIT result_limit;
+  SELECT
+    m.id,
+    m.address,
+    m.owner_address,
+    m.name,
+    m.symbol,
+    m.total_supply,
+    m.tvl,
+    m.hub_id,
+    m.balance_pooled,
+    m.balance_locked,
+    m.start_time,
+    m.end_time,
+    m.end_cooldown,
+    m.target_hub_id,
+    m.migration_address,
+    m.created_at,
+    m.updated_at,
+    pg_catalog.ts_rank(
+      pg_catalog.to_tsvector('english', m.name || ' ' || m.symbol),
+      pg_catalog.plainto_tsquery('english', search_query)
+    ) AS rank
+  FROM public.metokens AS m
+  WHERE pg_catalog.to_tsvector('english', m.name || ' ' || m.symbol)
+    @@ pg_catalog.plainto_tsquery('english', search_query)
+  ORDER BY rank DESC, m.tvl DESC
+  LIMIT result_limit;
 END;
 $$;
 
--- 2) Move pg_trgm out of public
+GRANT EXECUTE ON FUNCTION public.search_video_assets(text, integer, integer) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_metoken_stats(text) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.search_metokens(text, integer) TO anon, authenticated;
+
+-- =============================================================================
+-- 2) extension_in_public — move pg_trgm to extensions schema
+--    https://supabase.com/docs/guides/database/database-linter?lint=0014
+-- =============================================================================
+
 CREATE SCHEMA IF NOT EXISTS extensions;
 ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
 
--- 3) Revoke public RPC on get_wallet_address (unused by app RLS)
-REVOKE ALL ON FUNCTION public.get_wallet_address() FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.get_wallet_address() FROM anon, authenticated;
+-- =============================================================================
+-- 3) get_wallet_address — SECURITY INVOKER + no anon/authenticated EXECUTE
+--    https://supabase.com/docs/guides/database/database-linter?lint=0028 / 0029
+-- =============================================================================
 
--- 4) comment_likes: public SELECT only (writes use service role)
+CREATE OR REPLACE FUNCTION public.get_wallet_address()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT pg_catalog.nullif(
+    pg_catalog.coalesce(
+      pg_catalog.current_setting('request.jwt.claim.address', true),
+      pg_catalog.current_setting('request.jwt.claim.sub', true)
+    ),
+    ''
+  )::text;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM authenticated;
+
+-- =============================================================================
+-- 4) rls_policy_always_true — remove permissive INSERT/UPDATE/DELETE/ALL
+--    https://supabase.com/docs/guides/database/database-linter?lint=0024
+--    SELECT with USING (true) is allowed by the linter (public read).
+--    App writes use service_role (bypasses RLS).
+-- =============================================================================
+
+-- Known policy names (idempotent)
 DROP POLICY IF EXISTS "Public access for comment likes" ON public.comment_likes;
 DROP POLICY IF EXISTS "Anyone can read comment likes" ON public.comment_likes;
 DROP POLICY IF EXISTS "Anyone can like comments" ON public.comment_likes;
-CREATE POLICY "Likes - select public" ON public.comment_likes FOR SELECT TO public USING (true);
+DROP POLICY IF EXISTS "Likes - insert own" ON public.comment_likes;
+DROP POLICY IF EXISTS "Likes - delete own" ON public.comment_likes;
 
--- 5) video_comments: remove open UPDATE (updates use service role)
 DROP POLICY IF EXISTS "Anyone can update comments" ON public.video_comments;
+DROP POLICY IF EXISTS "Anyone can create comments" ON public.video_comments;
+DROP POLICY IF EXISTS "Users can insert their own comments" ON public.video_comments;
+
+-- Drop any remaining permissive write policies (catches renames / drift)
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT schemaname, tablename, policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename IN ('comment_likes', 'video_comments')
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND (
+        cmd = 'ALL'
+        OR qual IS NOT DISTINCT FROM 'true'
+        OR with_check IS NOT DISTINCT FROM 'true'
+      )
+  LOOP
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON %I.%I',
+      pol.policyname,
+      pol.schemaname,
+      pol.tablename
+    );
+  END LOOP;
+END
+$$;
+
+-- comment_likes: public read only (SELECT + true is OK per linter)
+DROP POLICY IF EXISTS "Likes - select public" ON public.comment_likes;
+CREATE POLICY "Likes - select public"
+  ON public.comment_likes
+  FOR SELECT
+  TO public
+  USING (true);
+
+-- video_comments: keep secure INSERT if present; ensure no open UPDATE remains
+-- (Comments - insert own uses JWT ownership — not lint-flagged)

--- a/scripts/fix-security-advisor-warnings.sql
+++ b/scripts/fix-security-advisor-warnings.sql
@@ -185,7 +185,18 @@ GRANT EXECUTE ON FUNCTION public.search_metokens(text, integer) TO anon, authent
 -- =============================================================================
 
 CREATE SCHEMA IF NOT EXISTS extensions;
-ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_extension
+    WHERE extname = 'pg_trgm'
+  ) THEN
+    EXECUTE 'ALTER EXTENSION pg_trgm SET SCHEMA extensions';
+  END IF;
+END;
+$$;
 
 -- =============================================================================
 -- 3) get_wallet_address — SECURITY INVOKER + no anon/authenticated EXECUTE

--- a/scripts/fix-security-advisor-warnings.sql
+++ b/scripts/fix-security-advisor-warnings.sql
@@ -85,27 +85,27 @@ BEGIN
   SELECT
     pg_catalog.count(mt.id) AS total_transactions,
     pg_catalog.count(DISTINCT mb.user_address) AS unique_holders,
-    pg_catalog.coalesce(
+    coalesce(
       pg_catalog.sum(
         CASE
           WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
           ELSE mt.amount
         END
       ),
-      0
+      0::numeric
     ) AS total_volume,
     CASE
       WHEN pg_catalog.count(mt.id) > 0 THEN
-        pg_catalog.coalesce(
+        coalesce(
           pg_catalog.sum(
             CASE
               WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
               ELSE mt.amount
             END
           ),
-          0
-        ) / pg_catalog.count(mt.id)
-      ELSE 0
+          0::numeric
+        ) / pg_catalog.count(mt.id)::numeric
+      ELSE 0::numeric
     END AS avg_transaction_size
   FROM public.metoken_transactions AS mt
   LEFT JOIN public.metoken_balances AS mb ON mb.metoken_id = mt.metoken_id
@@ -210,12 +210,12 @@ STABLE
 SECURITY INVOKER
 SET search_path = ''
 AS $$
-  SELECT pg_catalog.nullif(
-    pg_catalog.coalesce(
-      pg_catalog.current_setting('request.jwt.claim.address', true),
-      pg_catalog.current_setting('request.jwt.claim.sub', true)
+  SELECT nullif(
+    coalesce(
+      current_setting('request.jwt.claim.address', true)::text,
+      current_setting('request.jwt.claim.sub', true)::text
     ),
-    ''
+    ''::text
   )::text;
 $$;
 

--- a/scripts/fix-security-advisor-warnings.sql
+++ b/scripts/fix-security-advisor-warnings.sql
@@ -1,0 +1,90 @@
+-- Supabase Security Advisor remediation
+-- Run in Supabase Dashboard → SQL Editor
+-- See also: supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+
+-- 1) Function search_path
+CREATE OR REPLACE FUNCTION public.search_video_assets(
+  search_query text,
+  result_limit integer DEFAULT 20,
+  result_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+  id integer, title text, asset_id text, category text, location text,
+  playback_id text, description text, creator_id text, status text,
+  thumbnail_url text, duration integer, views_count integer, likes_count integer,
+  is_minted boolean, created_at timestamptz, updated_at timestamptz, rank real
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT va.id, va.title, va.asset_id, va.category, va.location, va.playback_id,
+    va.description, va.creator_id, va.status, va.thumbnail_url, va.duration,
+    va.views_count, va.likes_count, va.is_minted, va.created_at, va.updated_at,
+    ts_rank(va.search_vector, websearch_to_tsquery('english', search_query)) AS rank
+  FROM video_assets va
+  WHERE va.status = 'published'
+    AND va.search_vector @@ websearch_to_tsquery('english', search_query)
+  ORDER BY rank DESC, va.created_at DESC
+  LIMIT result_limit OFFSET result_offset;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr TEXT)
+RETURNS TABLE (
+  total_transactions BIGINT, unique_holders BIGINT,
+  total_volume NUMERIC, avg_transaction_size NUMERIC
+)
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT COUNT(mt.id),
+    COUNT(DISTINCT mb.user_address),
+    COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0),
+    CASE WHEN COUNT(mt.id) > 0 THEN
+      COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0) / COUNT(mt.id)
+    ELSE 0 END
+  FROM metoken_transactions mt
+  LEFT JOIN metoken_balances mb ON mb.metoken_id = mt.metoken_id
+  WHERE mt.metoken_id = (SELECT id FROM metokens WHERE address = metoken_addr);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.search_metokens(search_query TEXT, result_limit INTEGER DEFAULT 20)
+RETURNS TABLE (
+  id UUID, address TEXT, owner_address TEXT, name TEXT, symbol TEXT,
+  total_supply NUMERIC, tvl NUMERIC, hub_id INTEGER, balance_pooled NUMERIC,
+  balance_locked NUMERIC, start_time TIMESTAMPTZ, end_time TIMESTAMPTZ,
+  end_cooldown TIMESTAMPTZ, target_hub_id INTEGER, migration_address TEXT,
+  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, rank REAL
+)
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT m.*, ts_rank(to_tsvector('english', m.name || ' ' || m.symbol), plainto_tsquery('english', search_query)) AS rank
+  FROM metokens m
+  WHERE to_tsvector('english', m.name || ' ' || m.symbol) @@ plainto_tsquery('english', search_query)
+  ORDER BY rank DESC, m.tvl DESC LIMIT result_limit;
+END;
+$$;
+
+-- 2) Move pg_trgm out of public
+CREATE SCHEMA IF NOT EXISTS extensions;
+ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
+
+-- 3) Revoke public RPC on get_wallet_address (unused by app RLS)
+REVOKE ALL ON FUNCTION public.get_wallet_address() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_wallet_address() FROM anon, authenticated;
+
+-- 4) comment_likes: public SELECT only (writes use service role)
+DROP POLICY IF EXISTS "Public access for comment likes" ON public.comment_likes;
+DROP POLICY IF EXISTS "Anyone can read comment likes" ON public.comment_likes;
+DROP POLICY IF EXISTS "Anyone can like comments" ON public.comment_likes;
+CREATE POLICY "Likes - select public" ON public.comment_likes FOR SELECT TO public USING (true);
+
+-- 5) video_comments: remove open UPDATE (updates use service role)
+DROP POLICY IF EXISTS "Anyone can update comments" ON public.video_comments;

--- a/scripts/patch-get-wallet-address.sql
+++ b/scripts/patch-get-wallet-address.sql
@@ -1,0 +1,20 @@
+-- Run this alone if fix-security-advisor-warnings.sql failed at get_wallet_address()
+CREATE OR REPLACE FUNCTION public.get_wallet_address()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT nullif(
+    coalesce(
+      current_setting('request.jwt.claim.address', true)::text,
+      current_setting('request.jwt.claim.sub', true)::text
+    ),
+    ''::text
+  )::text;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM authenticated;

--- a/scripts/setup-creator-profiles-table.sql
+++ b/scripts/setup-creator-profiles-table.sql
@@ -37,6 +37,21 @@ CREATE TRIGGER update_creator_profiles_updated_at
   BEFORE UPDATE ON creator_profiles 
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+-- Orb / Lens identity (required for Orb sign-in)
+ALTER TABLE public.creator_profiles
+  ADD COLUMN IF NOT EXISTS orb_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_account_id TEXT,
+  ADD COLUMN IF NOT EXISTS lens_handle TEXT,
+  ADD COLUMN IF NOT EXISTS lens_avatar_uri TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_orb_account_id_key
+  ON public.creator_profiles (orb_account_id)
+  WHERE orb_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS creator_profiles_lens_account_id_idx
+  ON public.creator_profiles (lens_account_id)
+  WHERE lens_account_id IS NOT NULL;
+
 -- Verify the table was created
 SELECT 
   table_name, 

--- a/scripts/verify-security-advisor-state.sql
+++ b/scripts/verify-security-advisor-state.sql
@@ -1,0 +1,40 @@
+-- Run after fix-security-advisor-warnings.sql to confirm all 8 warnings should clear
+
+-- 1) Functions: expect proconfig containing search_path= (empty)
+SELECT
+  p.proname AS function_name,
+  pg_get_function_identity_arguments(p.oid) AS args,
+  p.prosecdef AS security_definer,
+  p.proconfig AS function_options
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN ('search_video_assets', 'search_metokens', 'get_metoken_stats', 'get_wallet_address')
+ORDER BY p.proname;
+
+-- 2) pg_trgm schema (expect extensions, not public)
+SELECT e.extname, n.nspname AS schema
+FROM pg_extension e
+JOIN pg_namespace n ON n.oid = e.extnamespace
+WHERE e.extname = 'pg_trgm';
+
+-- 3) Permissive write RLS (expect zero rows)
+SELECT tablename, policyname, cmd, qual, with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND tablename IN ('comment_likes', 'video_comments')
+  AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+  AND (
+    cmd = 'ALL'
+    OR qual IS NOT DISTINCT FROM 'true'
+    OR with_check IS NOT DISTINCT FROM 'true'
+  );
+
+-- 4) EXECUTE on get_wallet_address (anon/authenticated should be false)
+SELECT
+  p.proname,
+  has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_execute,
+  has_function_privilege('authenticated', p.oid, 'EXECUTE') AS authenticated_execute
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'get_wallet_address';

--- a/scripts/verify-security-advisor-state.sql
+++ b/scripts/verify-security-advisor-state.sql
@@ -13,10 +13,9 @@ WHERE n.nspname = 'public'
 ORDER BY p.proname;
 
 -- 2) pg_trgm schema (expect extensions, not public)
-SELECT e.extname, n.nspname AS schema
-FROM pg_extension e
-JOIN pg_namespace n ON n.oid = e.extnamespace
-WHERE e.extname = 'pg_trgm';
+SELECT extname, extnamespace::regnamespace AS schema
+FROM pg_extension
+WHERE extname = 'pg_trgm';
 
 -- 3) Permissive write RLS (expect zero rows)
 SELECT tablename, policyname, cmd, qual, with_check

--- a/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+++ b/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
@@ -1,0 +1,87 @@
+-- Supabase Security Advisor remediation
+-- 1) Function search_path
+CREATE OR REPLACE FUNCTION public.search_video_assets(
+  search_query text,
+  result_limit integer DEFAULT 20,
+  result_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+  id integer, title text, asset_id text, category text, location text,
+  playback_id text, description text, creator_id text, status text,
+  thumbnail_url text, duration integer, views_count integer, likes_count integer,
+  is_minted boolean, created_at timestamptz, updated_at timestamptz, rank real
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT va.id, va.title, va.asset_id, va.category, va.location, va.playback_id,
+    va.description, va.creator_id, va.status, va.thumbnail_url, va.duration,
+    va.views_count, va.likes_count, va.is_minted, va.created_at, va.updated_at,
+    ts_rank(va.search_vector, websearch_to_tsquery('english', search_query)) AS rank
+  FROM video_assets va
+  WHERE va.status = 'published'
+    AND va.search_vector @@ websearch_to_tsquery('english', search_query)
+  ORDER BY rank DESC, va.created_at DESC
+  LIMIT result_limit OFFSET result_offset;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr TEXT)
+RETURNS TABLE (
+  total_transactions BIGINT, unique_holders BIGINT,
+  total_volume NUMERIC, avg_transaction_size NUMERIC
+)
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT COUNT(mt.id),
+    COUNT(DISTINCT mb.user_address),
+    COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0),
+    CASE WHEN COUNT(mt.id) > 0 THEN
+      COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0) / COUNT(mt.id)
+    ELSE 0 END
+  FROM metoken_transactions mt
+  LEFT JOIN metoken_balances mb ON mb.metoken_id = mt.metoken_id
+  WHERE mt.metoken_id = (SELECT id FROM metokens WHERE address = metoken_addr);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.search_metokens(search_query TEXT, result_limit INTEGER DEFAULT 20)
+RETURNS TABLE (
+  id UUID, address TEXT, owner_address TEXT, name TEXT, symbol TEXT,
+  total_supply NUMERIC, tvl NUMERIC, hub_id INTEGER, balance_pooled NUMERIC,
+  balance_locked NUMERIC, start_time TIMESTAMPTZ, end_time TIMESTAMPTZ,
+  end_cooldown TIMESTAMPTZ, target_hub_id INTEGER, migration_address TEXT,
+  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, rank REAL
+)
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT m.*, ts_rank(to_tsvector('english', m.name || ' ' || m.symbol), plainto_tsquery('english', search_query)) AS rank
+  FROM metokens m
+  WHERE to_tsvector('english', m.name || ' ' || m.symbol) @@ plainto_tsquery('english', search_query)
+  ORDER BY rank DESC, m.tvl DESC LIMIT result_limit;
+END;
+$$;
+
+-- 2) Move pg_trgm out of public
+CREATE SCHEMA IF NOT EXISTS extensions;
+ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
+
+-- 3) Revoke public RPC on get_wallet_address (unused by app RLS)
+REVOKE ALL ON FUNCTION public.get_wallet_address() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_wallet_address() FROM anon, authenticated;
+
+-- 4) comment_likes: public SELECT only (writes use service role)
+DROP POLICY IF EXISTS "Public access for comment likes" ON public.comment_likes;
+DROP POLICY IF EXISTS "Anyone can read comment likes" ON public.comment_likes;
+DROP POLICY IF EXISTS "Anyone can like comments" ON public.comment_likes;
+CREATE POLICY "Likes - select public" ON public.comment_likes FOR SELECT TO public USING (true);
+
+-- 5) video_comments: remove open UPDATE (updates use service role)
+DROP POLICY IF EXISTS "Anyone can update comments" ON public.video_comments;

--- a/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+++ b/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
@@ -181,7 +181,18 @@ GRANT EXECUTE ON FUNCTION public.search_metokens(text, integer) TO anon, authent
 -- =============================================================================
 
 CREATE SCHEMA IF NOT EXISTS extensions;
-ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_extension
+    WHERE extname = 'pg_trgm'
+  ) THEN
+    EXECUTE 'ALTER EXTENSION pg_trgm SET SCHEMA extensions';
+  END IF;
+END;
+$$;
 
 -- =============================================================================
 -- 3) get_wallet_address — SECURITY INVOKER + no anon/authenticated EXECUTE

--- a/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+++ b/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
@@ -1,87 +1,265 @@
--- Supabase Security Advisor remediation
--- 1) Function search_path
+-- Supabase Security Advisor remediation (all 8 warnings)
+-- =============================================================================
+-- 1) function_search_path_mutable — SET search_path = '' + schema-qualified refs
+--    https://supabase.com/docs/guides/database/database-linter?lint=0011
+-- =============================================================================
+
 CREATE OR REPLACE FUNCTION public.search_video_assets(
   search_query text,
   result_limit integer DEFAULT 20,
   result_offset integer DEFAULT 0
 )
 RETURNS TABLE (
-  id integer, title text, asset_id text, category text, location text,
-  playback_id text, description text, creator_id text, status text,
-  thumbnail_url text, duration integer, views_count integer, likes_count integer,
-  is_minted boolean, created_at timestamptz, updated_at timestamptz, rank real
+  id integer,
+  title text,
+  asset_id text,
+  category text,
+  location text,
+  playback_id text,
+  description text,
+  creator_id text,
+  status text,
+  thumbnail_url text,
+  duration integer,
+  views_count integer,
+  likes_count integer,
+  is_minted boolean,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  rank real
 )
 LANGUAGE plpgsql
 SECURITY INVOKER
-SET search_path = public, pg_temp
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT va.id, va.title, va.asset_id, va.category, va.location, va.playback_id,
-    va.description, va.creator_id, va.status, va.thumbnail_url, va.duration,
-    va.views_count, va.likes_count, va.is_minted, va.created_at, va.updated_at,
-    ts_rank(va.search_vector, websearch_to_tsquery('english', search_query)) AS rank
-  FROM video_assets va
-  WHERE va.status = 'published'
-    AND va.search_vector @@ websearch_to_tsquery('english', search_query)
+  SELECT
+    va.id,
+    va.title,
+    va.asset_id,
+    va.category,
+    va.location,
+    va.playback_id,
+    va.description,
+    va.creator_id,
+    va.status,
+    va.thumbnail_url,
+    va.duration,
+    va.views_count,
+    va.likes_count,
+    va.is_minted,
+    va.created_at,
+    va.updated_at,
+    pg_catalog.ts_rank(
+      va.search_vector,
+      pg_catalog.websearch_to_tsquery('english', search_query)
+    ) AS rank
+  FROM public.video_assets AS va
+  WHERE
+    va.status = 'published'
+    AND va.search_vector @@ pg_catalog.websearch_to_tsquery('english', search_query)
   ORDER BY rank DESC, va.created_at DESC
-  LIMIT result_limit OFFSET result_offset;
+  LIMIT result_limit
+  OFFSET result_offset;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr TEXT)
+CREATE OR REPLACE FUNCTION public.get_metoken_stats(metoken_addr text)
 RETURNS TABLE (
-  total_transactions BIGINT, unique_holders BIGINT,
-  total_volume NUMERIC, avg_transaction_size NUMERIC
+  total_transactions bigint,
+  unique_holders bigint,
+  total_volume numeric,
+  avg_transaction_size numeric
 )
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT COUNT(mt.id),
-    COUNT(DISTINCT mb.user_address),
-    COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0),
-    CASE WHEN COUNT(mt.id) > 0 THEN
-      COALESCE(SUM(CASE WHEN mt.transaction_type IN ('mint','burn') THEN mt.collateral_amount ELSE mt.amount END), 0) / COUNT(mt.id)
-    ELSE 0 END
-  FROM metoken_transactions mt
-  LEFT JOIN metoken_balances mb ON mb.metoken_id = mt.metoken_id
-  WHERE mt.metoken_id = (SELECT id FROM metokens WHERE address = metoken_addr);
+  SELECT
+    pg_catalog.count(mt.id) AS total_transactions,
+    pg_catalog.count(DISTINCT mb.user_address) AS unique_holders,
+    pg_catalog.coalesce(
+      pg_catalog.sum(
+        CASE
+          WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
+          ELSE mt.amount
+        END
+      ),
+      0
+    ) AS total_volume,
+    CASE
+      WHEN pg_catalog.count(mt.id) > 0 THEN
+        pg_catalog.coalesce(
+          pg_catalog.sum(
+            CASE
+              WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
+              ELSE mt.amount
+            END
+          ),
+          0
+        ) / pg_catalog.count(mt.id)
+      ELSE 0
+    END AS avg_transaction_size
+  FROM public.metoken_transactions AS mt
+  LEFT JOIN public.metoken_balances AS mb ON mb.metoken_id = mt.metoken_id
+  WHERE mt.metoken_id = (
+    SELECT m.id FROM public.metokens AS m WHERE m.address = metoken_addr
+  );
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION public.search_metokens(search_query TEXT, result_limit INTEGER DEFAULT 20)
-RETURNS TABLE (
-  id UUID, address TEXT, owner_address TEXT, name TEXT, symbol TEXT,
-  total_supply NUMERIC, tvl NUMERIC, hub_id INTEGER, balance_pooled NUMERIC,
-  balance_locked NUMERIC, start_time TIMESTAMPTZ, end_time TIMESTAMPTZ,
-  end_cooldown TIMESTAMPTZ, target_hub_id INTEGER, migration_address TEXT,
-  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, rank REAL
+CREATE OR REPLACE FUNCTION public.search_metokens(
+  search_query text,
+  result_limit integer DEFAULT 20
 )
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp
+RETURNS TABLE (
+  id uuid,
+  address text,
+  owner_address text,
+  name text,
+  symbol text,
+  total_supply numeric,
+  tvl numeric,
+  hub_id integer,
+  balance_pooled numeric,
+  balance_locked numeric,
+  start_time timestamp with time zone,
+  end_time timestamp with time zone,
+  end_cooldown timestamp with time zone,
+  target_hub_id integer,
+  migration_address text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  rank real
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
 AS $$
 BEGIN
   RETURN QUERY
-  SELECT m.*, ts_rank(to_tsvector('english', m.name || ' ' || m.symbol), plainto_tsquery('english', search_query)) AS rank
-  FROM metokens m
-  WHERE to_tsvector('english', m.name || ' ' || m.symbol) @@ plainto_tsquery('english', search_query)
-  ORDER BY rank DESC, m.tvl DESC LIMIT result_limit;
+  SELECT
+    m.id,
+    m.address,
+    m.owner_address,
+    m.name,
+    m.symbol,
+    m.total_supply,
+    m.tvl,
+    m.hub_id,
+    m.balance_pooled,
+    m.balance_locked,
+    m.start_time,
+    m.end_time,
+    m.end_cooldown,
+    m.target_hub_id,
+    m.migration_address,
+    m.created_at,
+    m.updated_at,
+    pg_catalog.ts_rank(
+      pg_catalog.to_tsvector('english', m.name || ' ' || m.symbol),
+      pg_catalog.plainto_tsquery('english', search_query)
+    ) AS rank
+  FROM public.metokens AS m
+  WHERE pg_catalog.to_tsvector('english', m.name || ' ' || m.symbol)
+    @@ pg_catalog.plainto_tsquery('english', search_query)
+  ORDER BY rank DESC, m.tvl DESC
+  LIMIT result_limit;
 END;
 $$;
 
--- 2) Move pg_trgm out of public
+GRANT EXECUTE ON FUNCTION public.search_video_assets(text, integer, integer) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_metoken_stats(text) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.search_metokens(text, integer) TO anon, authenticated;
+
+-- =============================================================================
+-- 2) extension_in_public — move pg_trgm to extensions schema
+--    https://supabase.com/docs/guides/database/database-linter?lint=0014
+-- =============================================================================
+
 CREATE SCHEMA IF NOT EXISTS extensions;
 ALTER EXTENSION IF EXISTS pg_trgm SET SCHEMA extensions;
 
--- 3) Revoke public RPC on get_wallet_address (unused by app RLS)
-REVOKE ALL ON FUNCTION public.get_wallet_address() FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.get_wallet_address() FROM anon, authenticated;
+-- =============================================================================
+-- 3) get_wallet_address — SECURITY INVOKER + no anon/authenticated EXECUTE
+--    https://supabase.com/docs/guides/database/database-linter?lint=0028 / 0029
+-- =============================================================================
 
--- 4) comment_likes: public SELECT only (writes use service role)
+CREATE OR REPLACE FUNCTION public.get_wallet_address()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT pg_catalog.nullif(
+    pg_catalog.coalesce(
+      pg_catalog.current_setting('request.jwt.claim.address', true),
+      pg_catalog.current_setting('request.jwt.claim.sub', true)
+    ),
+    ''
+  )::text;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_wallet_address() FROM authenticated;
+
+-- =============================================================================
+-- 4) rls_policy_always_true — remove permissive INSERT/UPDATE/DELETE/ALL
+--    https://supabase.com/docs/guides/database/database-linter?lint=0024
+--    SELECT with USING (true) is allowed by the linter (public read).
+--    App writes use service_role (bypasses RLS).
+-- =============================================================================
+
+-- Known policy names (idempotent)
 DROP POLICY IF EXISTS "Public access for comment likes" ON public.comment_likes;
 DROP POLICY IF EXISTS "Anyone can read comment likes" ON public.comment_likes;
 DROP POLICY IF EXISTS "Anyone can like comments" ON public.comment_likes;
-CREATE POLICY "Likes - select public" ON public.comment_likes FOR SELECT TO public USING (true);
+DROP POLICY IF EXISTS "Likes - insert own" ON public.comment_likes;
+DROP POLICY IF EXISTS "Likes - delete own" ON public.comment_likes;
 
--- 5) video_comments: remove open UPDATE (updates use service role)
 DROP POLICY IF EXISTS "Anyone can update comments" ON public.video_comments;
+DROP POLICY IF EXISTS "Anyone can create comments" ON public.video_comments;
+DROP POLICY IF EXISTS "Users can insert their own comments" ON public.video_comments;
+
+-- Drop any remaining permissive write policies (catches renames / drift)
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT schemaname, tablename, policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename IN ('comment_likes', 'video_comments')
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND (
+        cmd = 'ALL'
+        OR qual IS NOT DISTINCT FROM 'true'
+        OR with_check IS NOT DISTINCT FROM 'true'
+      )
+  LOOP
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON %I.%I',
+      pol.policyname,
+      pol.schemaname,
+      pol.tablename
+    );
+  END LOOP;
+END
+$$;
+
+-- comment_likes: public read only (SELECT + true is OK per linter)
+DROP POLICY IF EXISTS "Likes - select public" ON public.comment_likes;
+CREATE POLICY "Likes - select public"
+  ON public.comment_likes
+  FOR SELECT
+  TO public
+  USING (true);
+
+-- video_comments: keep secure INSERT if present; ensure no open UPDATE remains
+-- (Comments - insert own uses JWT ownership — not lint-flagged)

--- a/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
+++ b/supabase/migrations/20260525120000_fix_security_advisor_warnings.sql
@@ -81,27 +81,27 @@ BEGIN
   SELECT
     pg_catalog.count(mt.id) AS total_transactions,
     pg_catalog.count(DISTINCT mb.user_address) AS unique_holders,
-    pg_catalog.coalesce(
+    coalesce(
       pg_catalog.sum(
         CASE
           WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
           ELSE mt.amount
         END
       ),
-      0
+      0::numeric
     ) AS total_volume,
     CASE
       WHEN pg_catalog.count(mt.id) > 0 THEN
-        pg_catalog.coalesce(
+        coalesce(
           pg_catalog.sum(
             CASE
               WHEN mt.transaction_type IN ('mint', 'burn') THEN mt.collateral_amount
               ELSE mt.amount
             END
           ),
-          0
-        ) / pg_catalog.count(mt.id)
-      ELSE 0
+          0::numeric
+        ) / pg_catalog.count(mt.id)::numeric
+      ELSE 0::numeric
     END AS avg_transaction_size
   FROM public.metoken_transactions AS mt
   LEFT JOIN public.metoken_balances AS mb ON mb.metoken_id = mt.metoken_id
@@ -206,12 +206,12 @@ STABLE
 SECURITY INVOKER
 SET search_path = ''
 AS $$
-  SELECT pg_catalog.nullif(
-    pg_catalog.coalesce(
-      pg_catalog.current_setting('request.jwt.claim.address', true),
-      pg_catalog.current_setting('request.jwt.claim.sub', true)
+  SELECT nullif(
+    coalesce(
+      current_setting('request.jwt.claim.address', true)::text,
+      current_setting('request.jwt.claim.sub', true)::text
     ),
-    ''
+    ''::text
   )::text;
 $$;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Update

Addresses review feedback: previous script only partially fixed warnings.

### Now fixes all 8 warnings

1. **function_search_path_mutable (×3)** — `SET search_path = ''` with `public.*` tables and `pg_catalog.*` builtins
2. **extension_in_public** — `pg_trgm` → `extensions` schema
3. **rls_policy_always_true (×2)** — explicit drops + dynamic loop for permissive INSERT/UPDATE/DELETE/ALL; only SELECT `USING (true)` on `comment_likes`
4. **get_wallet_address (×2)** — recreated as `SECURITY INVOKER`; `REVOKE EXECUTE` from PUBLIC, anon, authenticated

### How to apply

Run `scripts/fix-security-advisor-warnings.sql` in Supabase SQL Editor, then `scripts/verify-security-advisor-state.sql` to confirm.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

