### PR TITLE
Fix homepage videos not loading (playback fetch + poster fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,13 @@ NEXT_PUBLIC_ORB_ARWEAVE_GATEWAY=
 NEXT_PUBLIC_IPFS_GATEWAY=
 NEXT_PUBLIC_GROVE_API_URL=
 
+# --- HypeLab ads (optional; off by default to avoid 422 on unallowlisted domains) ---
+# In HypeLab dashboard, allowlist your production origin (e.g. https://tv.creativeplatform.xyz).
+# Then set ENABLED=true and your property/placement slugs.
+NEXT_PUBLIC_HYPELAB_ENABLED=
+NEXT_PUBLIC_HYPELAB_PROPERTY_SLUG=
+NEXT_PUBLIC_HYPELAB_PLACEMENT_SLUG=
+
 # --- Optional / feature flags ---
 NEXT_PUBLIC_STACK_API_KEY=
 NEXT_PUBLIC_LENS_ENV=

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ import { Toaster } from "@/components/ui/toaster";
 import Footer from "@/components/Footer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Analytics } from "@vercel/analytics/next";
-import Script from "next/script";
+import { HypelabSdkScript } from "@/components/ads/HypelabSdkScript";
 import { LayoutClientChunks } from "@/components/LayoutClientChunks";
 
 const inter = Inter({

--- a/components/Videos/VideoThumbnail.tsx
+++ b/components/Videos/VideoThumbnail.tsx
@@ -292,12 +292,9 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
 
   const handleThumbnailClick = (e: React.MouseEvent) => {
     if (enablePreview) {
-      return;
-    }
-    if (!src?.length) {
-      logger.warn(
-        `[VideoThumbnail] No playback source for ${playbackId}; showing poster only`,
-      );
+      // If preview is enabled, we don't want to expand the player inline.
+      // The parent Link component will handle navigation.
+      // We might want to stop propagation if there was logic here, but for now we just let it bubble.
       return;
     }
     setShowPlayer(true);
@@ -320,7 +317,7 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
   const mp4Source = src?.find(s => (s.type as string) === 'video/mp4' || (s.src as string).endsWith('.mp4'))?.src;
 
   // Show inline full player if clicked (and not in preview mode context usually, but kept for backward compat)
-  if (showPlayer) {
+  if (showPlayer && src?.length) {
     return (
       <div ref={containerCallbackRef} className={className}>
         <Player

--- a/components/Videos/VideoThumbnail.tsx
+++ b/components/Videos/VideoThumbnail.tsx
@@ -292,9 +292,12 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
 
   const handleThumbnailClick = (e: React.MouseEvent) => {
     if (enablePreview) {
-      // If preview is enabled, we don't want to expand the player inline.
-      // The parent Link component will handle navigation.
-      // We might want to stop propagation if there was logic here, but for now we just let it bubble.
+      return;
+    }
+    if (!src?.length) {
+      logger.warn(
+        `[VideoThumbnail] No playback source for ${playbackId}; showing poster only`,
+      );
       return;
     }
     setShowPlayer(true);

--- a/components/ads/HypelabSdkScript.tsx
+++ b/components/ads/HypelabSdkScript.tsx
@@ -1,0 +1,17 @@
+import Script from 'next/script';
+import { getHypelabConfig } from '@/lib/ads/hypelab';
+
+/** Loads HypeLab SDK only when explicitly enabled (avoids 422 on unallowlisted domains). */
+export function HypelabSdkScript() {
+  const hypelab = getHypelabConfig();
+  if (!hypelab.enabled) return null;
+
+  return (
+    <Script
+      id="hypelab-sdk"
+      src={hypelab.sdkUrl}
+      strategy="afterInteractive"
+      data-property-slug={hypelab.propertySlug}
+    />
+  );
+}

--- a/components/home-page/HeroSection.tsx
+++ b/components/home-page/HeroSection.tsx
@@ -58,8 +58,10 @@ const HeroSection: React.FC = () => {
 
         if (!isMounted || signal.aborted) return;
 
-        setSrc(playbackSource);
-        if (!playbackSource) {
+        const hasSource =
+          Array.isArray(playbackSource) && playbackSource.length > 0;
+        setSrc(hasSource ? playbackSource : null);
+        if (!hasSource) {
           setError("No video source available.");
         }
       } catch (err) {

--- a/components/home-page/HypelabHeroBanner.tsx
+++ b/components/home-page/HypelabHeroBanner.tsx
@@ -2,14 +2,16 @@
 
 import React from "react";
 import { Banner } from "@hypelab/sdk-react";
-
-const PLACEMENT_SLUG = "bea40b1af2";
+import { getHypelabConfig } from "@/lib/ads/hypelab";
 
 /**
  * Slim HypeLab banner between hero and Trending Videos.
- * Placement slug: bea40b1af2. Property slug for SDK init: 33e2e4fa10 (in layout script).
+ * Requires NEXT_PUBLIC_HYPELAB_ENABLED=true and allowlisted domain in HypeLab dashboard.
  */
 export function HypelabHeroBanner() {
+  const hypelab = getHypelabConfig();
+  if (!hypelab.enabled) return null;
+
   return (
     <div className="w-full max-w-7xl mx-auto py-3 px-4 sm:px-6">
       <div className="min-h-[50px] flex items-center justify-center rounded-md border border-border/50 bg-muted/30">

--- a/components/home-page/TopVideos.tsx
+++ b/components/home-page/TopVideos.tsx
@@ -76,81 +76,38 @@ export function TopVideos() {
 
         logger.debug(`Found ${filteredVideos.length} trending videos (excluding hero video)`);
 
-        // Step 2: Fetch playback sources for each video
-        // Don't set videos state until playback sources are ready to avoid rendering videos without sources
-        const sources: Record<string, Src[] | null> = {};
+        // Step 2: Fetch playback sources in parallel (no shared AbortSignal — avoids
+        // React Strict Mode / fast navigation aborting the whole batch)
         logger.debug("Starting to fetch playback sources...");
-
-        for (const video of filteredVideos) {
-          if (!isMounted || signal.aborted) {
-            // If aborted, don't set any state - component is unmounting
-            return;
-          }
-          
-          if (!video.playback_id) {
-            logger.warn(`Video ${video.asset_id} has no playback_id`);
-            sources[video.asset_id] = null;
-            continue;
-          }
-
-          try {
-            logger.debug(
-              `Fetching playback source for video ${video.playback_id}...`
-            );
-
-            // Get the playback source with abort signal support
-            const src = await getDetailPlaybackSource(video.playback_id, { 
-              signal 
-            });
-            
-            if (!isMounted || signal.aborted) {
-              // If aborted, don't set any state - component is unmounting
-              return;
+        const sourceEntries = await Promise.all(
+          filteredVideos.map(async (video) => {
+            if (!video.playback_id) {
+              logger.warn(`Video ${video.asset_id} has no playback_id`);
+              return [video.asset_id, null] as const;
             }
-            
-            logger.debug(`Playback source for ${video.playback_id}:`, src);
-
-            if (!src || src.length === 0) {
+            try {
+              const src = await getDetailPlaybackSource(video.playback_id);
+              if (!src?.length) {
+                logger.warn(`No valid source for ${video.playback_id}`);
+                return [video.asset_id, null] as const;
+              }
+              return [video.asset_id, src] as const;
+            } catch (error) {
               logger.error(
-                `No valid source found for video ${video.playback_id}`
+                `Error fetching playback source for ${video.playback_id}:`,
+                error,
               );
-              sources[video.asset_id] = null;
-              continue;
+              return [video.asset_id, null] as const;
             }
+          }),
+        );
 
-            sources[video.asset_id] = src;
-          } catch (error) {
-            if (!isMounted || signal.aborted) {
-              // If aborted, don't set any state - component is unmounting
-              return;
-            }
-            
-            // Check if it's an abort error
-            if (error instanceof Error && (
-              error.name === 'AbortError' || 
-              error.message.includes('aborted') ||
-              error.message.includes('signal is aborted')
-            )) {
-              logger.warn(`Video ${video.playback_id} fetch was aborted:`, error.message);
-              // If aborted, don't set any state - component is unmounting
-              return;
-            }
-            
-            logger.error(
-              `Error fetching playback source for video ${video.playback_id}:`,
-              error
-            );
-            sources[video.asset_id] = null;
-          }
-        }
+        if (!isMounted) return;
 
-        if (!isMounted || signal.aborted) {
-          // If aborted, don't set any state - component is unmounting
-          return;
-        }
-        
-        // Only set both videos and playback sources together after all sources are fetched
-        // This ensures videos are never rendered without their playback sources
+        const sources = Object.fromEntries(sourceEntries) as Record<
+          string,
+          Src[] | null
+        >;
         logger.debug("Final playback sources:", sources);
         setVideos(filteredVideos);
         setPlaybackSources(sources);

--- a/lib/ads/hypelab.ts
+++ b/lib/ads/hypelab.ts
@@ -1,0 +1,23 @@
+/**
+ * HypeLab ad SDK config.
+ *
+ * api.hypelab.com returns 422 when the request Referer/Origin is not allowlisted
+ * for the property in the HypeLab dashboard. Opt in with NEXT_PUBLIC_HYPELAB_ENABLED=true
+ * after adding your site (e.g. https://tv.creativeplatform.xyz) in HypeLab.
+ */
+export function getHypelabConfig() {
+  const propertySlug = process.env.NEXT_PUBLIC_HYPELAB_PROPERTY_SLUG?.trim() ?? '';
+  const placementSlug =
+    process.env.NEXT_PUBLIC_HYPELAB_PLACEMENT_SLUG?.trim() ?? '';
+  const enabled =
+    process.env.NEXT_PUBLIC_HYPELAB_ENABLED === 'true' &&
+    propertySlug.length > 0 &&
+    placementSlug.length > 0;
+
+  return {
+    enabled,
+    propertySlug,
+    placementSlug,
+    sdkUrl: 'https://api.hypelab.com/v1/scripts/sdk.js',
+  } as const;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Production APIs return published videos and Livepeer playback info; the homepage failed to attach sources client-side.

- Fetch trending playback sources in parallel without a shared AbortSignal (fixes Strict Mode / navigation aborting the whole batch)
- Pass `thumbnail_url` so carousel cards show posters when playback src is null
- Treat empty hero src arrays as missing
- Do not mount inline Player without valid src

**Unrelated:** HypeLab 422 is separate; disable via PR #127 or omit `NEXT_PUBLIC_HYPELAB_ENABLED`.

**Verify after deploy:** Network tab should show 200 on `/api/livepeer/playback-info?playbackId=...` from the browser.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

