### PR TITLE
Fix Vercel build: missing HypelabSdkScript import in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -102,13 +102,7 @@ export default async function RootLayout({
         </Providers>
         <Toaster />
         <Analytics />
-        {/* HypeLab SDK: required for @hypelab/sdk-react Banner/Native. Property slug: 33e2e4fa10 */}
-        <Script
-          id="hypelab-sdk"
-          src="https://api.hypelab.com/v1/scripts/sdk.js"
-          strategy="afterInteractive"
-          data-property-slug="33e2e4fa10"
-        />
+        <HypelabSdkScript />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ import { Toaster } from "@/components/ui/toaster";
 import Footer from "@/components/Footer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Analytics } from "@vercel/analytics/next";
-import Script from "next/script";
+import { HypelabSdkScript } from "@/components/ads/HypelabSdkScript";
 import { LayoutClientChunks } from "@/components/LayoutClientChunks";
 
 const inter = Inter({
@@ -102,7 +102,13 @@ export default async function RootLayout({
         </Providers>
         <Toaster />
         <Analytics />
-        <HypelabSdkScript />
+        {/* HypeLab SDK: required for @hypelab/sdk-react Banner/Native. Property slug: 33e2e4fa10 */}
+        <Script
+          id="hypelab-sdk"
+          src="https://api.hypelab.com/v1/scripts/sdk.js"
+          strategy="afterInteractive"
+          data-property-slug="33e2e4fa10"
+        />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ import { Toaster } from "@/components/ui/toaster";
 import Footer from "@/components/Footer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Analytics } from "@vercel/analytics/next";
-import { HypelabSdkScript } from "@/components/ads/HypelabSdkScript";
+import Script from "next/script";
 import { LayoutClientChunks } from "@/components/LayoutClientChunks";
 
 const inter = Inter({
@@ -102,13 +102,7 @@ export default async function RootLayout({
         </Providers>
         <Toaster />
         <Analytics />
-        {/* HypeLab SDK: required for @hypelab/sdk-react Banner/Native. Property slug: 33e2e4fa10 */}
-        <Script
-          id="hypelab-sdk"
-          src="https://api.hypelab.com/v1/scripts/sdk.js"
-          strategy="afterInteractive"
-          data-property-slug="33e2e4fa10"
-        />
+        <HypelabSdkScript />
       </body>
     </html>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `Cannot find name 'HypelabSdkScript'` on Vercel build at b81c884.

- Import `HypelabSdkScript` from `@/components/ads/HypelabSdkScript`
- Replace hardcoded `<Script>` with `<HypelabSdkScript />`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54237c39-512f-470e-b3e8-a1d085b68419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

