### PR TITLE
Fix account menu not updating after Orb sign-in

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -48,6 +48,7 @@ import {
   type AccountDropdownHandle,
 } from "@/components/account-dropdown/AccountDropdown";
 import { MobileOrbSection } from "@/components/account-dropdown/MobileOrbSection";
+import { useOrbSession } from "@/context/OrbSessionContext";
 import { shortenAddress } from "@/lib/utils/utils";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
@@ -187,6 +188,8 @@ export default function Navbar() {
   }, [modularAccount?.address, user?.address]);
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { isAuthenticated: isOrbAuthenticated, accountMenuRefreshSignal } =
+    useOrbSession();
   const accountDropdownRef = useRef<AccountDropdownHandle>(null);
   const [copySuccess, setCopySuccess] = useState(false);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
@@ -198,6 +201,12 @@ export default function Navbar() {
     logger.debug("Current Chain ID:", currentChain.id);
     setCurrentChainName(currentChain?.name || "Unknown Chain");
   }, [currentChain]);
+
+  // Surface Orb / Lens linked state in the mobile account menu after sign-in.
+  useEffect(() => {
+    if (!accountMenuRefreshSignal || !isOrbAuthenticated) return;
+    setIsMenuOpen(true);
+  }, [accountMenuRefreshSignal, isOrbAuthenticated]);
 
   // Add scroll effect for sticky navbar
   useEffect(() => {

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1353,7 +1353,6 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            key={`account-menu-orb-${accountMenuRefreshSignal}-${isOrbAuthenticated ? lensAccount ?? "auth" : "guest"}`}
             className="w-[320px] md:w-80 max-h-[80vh] overflow-y-auto"
             align="end"
           >

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -271,6 +271,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
     logout: logoutOrb,
     linkStatus: orbLinkStatus,
     loginError: orbLoginError,
+    accountMenuRefreshSignal,
   } = useOrbSession();
   const user = useUser();
   const { logout } = useLogout();
@@ -374,6 +375,12 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
   useEffect(() => {
     setIsDialogOpen(false);
   }, [user]);
+
+  // Reopen account menu after Orb sign-in so the Orb / Lens section shows linked state.
+  useEffect(() => {
+    if (!accountMenuRefreshSignal || !isOrbAuthenticated) return;
+    setIsDropdownOpen(true);
+  }, [accountMenuRefreshSignal, isOrbAuthenticated]);
 
   // Fetch token balances when dialog opens with send action
   useEffect(() => {
@@ -1346,6 +1353,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
+            key={`account-menu-orb-${accountMenuRefreshSignal}-${isOrbAuthenticated ? lensAccount ?? "auth" : "guest"}`}
             className="w-[320px] md:w-80 max-h-[80vh] overflow-y-auto"
             align="end"
           >

--- a/components/account-dropdown/MobileOrbSection.tsx
+++ b/components/account-dropdown/MobileOrbSection.tsx
@@ -16,16 +16,12 @@ export function MobileOrbSection() {
     linkProfile,
     isLinking: isOrbLinking,
     logout: logoutOrb,
-    accountMenuRefreshSignal,
   } = useOrbSession();
 
   const walletAddress = modularAccount?.address || user?.address;
 
   return (
-    <div
-      key={`mobile-orb-${accountMenuRefreshSignal}-${isOrbAuthenticated ? lensAccount ?? "auth" : "guest"}`}
-      className="space-y-2"
-    >
+    <div className="space-y-2">
       <p className="text-xs text-muted-foreground font-semibold">Orb / Lens</p>
       {isOrbAuthenticated ? (
         <div className="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-700">

--- a/components/account-dropdown/MobileOrbSection.tsx
+++ b/components/account-dropdown/MobileOrbSection.tsx
@@ -16,12 +16,16 @@ export function MobileOrbSection() {
     linkProfile,
     isLinking: isOrbLinking,
     logout: logoutOrb,
+    accountMenuRefreshSignal,
   } = useOrbSession();
 
   const walletAddress = modularAccount?.address || user?.address;
 
   return (
-    <div className="space-y-2">
+    <div
+      key={`mobile-orb-${accountMenuRefreshSignal}-${isOrbAuthenticated ? lensAccount ?? "auth" : "guest"}`}
+      className="space-y-2"
+    >
       <p className="text-xs text-muted-foreground font-semibold">Orb / Lens</p>
       {isOrbAuthenticated ? (
         <div className="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-700">

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import { useUser } from '@account-kit/react';
 import useModularAccount from '@/lib/hooks/accountkit/useModularAccount';
@@ -14,6 +15,8 @@ import {
   getOrbLogin,
   loadStoredOrbSession,
   saveStoredOrbSession,
+  subscribeOrbSession,
+  getOrbSessionServerSnapshot,
   type StoredOrbSession,
 } from '@/lib/sdk/orb/login';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
@@ -38,16 +41,23 @@ type OrbSessionContextValue = {
   logout: () => Promise<void>;
   syncSession: () => Promise<StoredOrbSession | null>;
   linkProfile: (ownerAddress?: string) => Promise<void>;
+  /** Bumped after Orb sign-in so account menus can reopen with fresh state. */
+  accountMenuRefreshSignal: number;
 };
 
 const OrbSessionContext = createContext<OrbSessionContextValue | null>(null);
 
 export function OrbSessionProvider({ children }: { children: React.ReactNode }) {
-  const [session, setSession] = useState<StoredOrbSession | null>(null);
+  const session = useSyncExternalStore(
+    subscribeOrbSession,
+    loadStoredOrbSession,
+    getOrbSessionServerSnapshot,
+  );
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [isLinking, setIsLinking] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
   const [linkStatus, setLinkStatus] = useState<OrbLinkStatus>('idle');
+  const [accountMenuRefreshSignal, setAccountMenuRefreshSignal] = useState(0);
   const user = useUser();
   const { account: modularAccount } = useModularAccount();
   const { getAuthHeaders } = useWalletAuth();
@@ -61,13 +71,12 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
     return orb.getAccountFromAccessToken(session.accessToken);
   }, [session, orb]);
 
-  useEffect(() => {
-    setSession(loadStoredOrbSession());
-  }, []);
-
   const persistSession = useCallback((next: StoredOrbSession | null) => {
     saveStoredOrbSession(next);
-    setSession(next);
+  }, []);
+
+  const bumpAccountMenuRefresh = useCallback(() => {
+    setAccountMenuRefreshSignal((n) => n + 1);
   }, []);
 
   const syncSession = useCallback(async () => {
@@ -182,6 +191,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         };
         persistSession(stored);
         setIsLoginModalOpen(false);
+        bumpAccountMenuRefresh();
         toast.success('Signed in with Orb');
 
         const wallet = modularAccount?.address || user?.address;
@@ -199,7 +209,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         throw new Error(message);
       }
     },
-    [orb, persistSession, modularAccount?.address, user?.address, linkProfile],
+    [orb, persistSession, bumpAccountMenuRefresh, modularAccount?.address, user?.address, linkProfile],
   );
 
   const logout = useCallback(async () => {
@@ -248,6 +258,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       logout,
       syncSession,
       linkProfile,
+      accountMenuRefreshSignal,
     }),
     [
       session,
@@ -262,6 +273,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       logout,
       syncSession,
       linkProfile,
+      accountMenuRefreshSignal,
     ],
   );
 

--- a/lib/sdk/orb/login.test.ts
+++ b/lib/sdk/orb/login.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ORB_SESSION_CHANGE_EVENT,
+  ORB_SESSION_STORAGE_KEY,
+  loadStoredOrbSession,
+  saveStoredOrbSession,
+  subscribeOrbSession,
+} from './login';
+
+describe('orb session storage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('notifies subscribers when session is saved', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeOrbSession(listener);
+
+    saveStoredOrbSession({
+      accessToken: 'test-token',
+      authenticationId: 'auth-1',
+    });
+
+    expect(loadStoredOrbSession()?.accessToken).toBe('test-token');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it('dispatches a session change event on save and clear', () => {
+    const handler = vi.fn();
+    window.addEventListener(ORB_SESSION_CHANGE_EVENT, handler);
+
+    saveStoredOrbSession({ accessToken: 'a' });
+    saveStoredOrbSession(null);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).toBeNull();
+
+    window.removeEventListener(ORB_SESSION_CHANGE_EVENT, handler);
+  });
+});

--- a/lib/sdk/orb/login.test.ts
+++ b/lib/sdk/orb/login.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ORB_SESSION_CHANGE_EVENT,
   ORB_SESSION_STORAGE_KEY,
+  invalidateOrbSessionCache,
   loadStoredOrbSession,
   saveStoredOrbSession,
   subscribeOrbSession,
@@ -11,6 +12,7 @@ import {
 describe('orb session storage', () => {
   afterEach(() => {
     localStorage.clear();
+    invalidateOrbSessionCache();
   });
 
   it('notifies subscribers when session is saved', () => {
@@ -39,5 +41,20 @@ describe('orb session storage', () => {
     expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).toBeNull();
 
     window.removeEventListener(ORB_SESSION_CHANGE_EVENT, handler);
+  });
+
+  it('returns a referentially stable snapshot until the session changes', () => {
+    saveStoredOrbSession({ accessToken: 'stable-token' });
+
+    const first = loadStoredOrbSession();
+    const second = loadStoredOrbSession();
+
+    expect(first).toBe(second);
+
+    saveStoredOrbSession({ accessToken: 'updated-token' });
+
+    const third = loadStoredOrbSession();
+    expect(third).not.toBe(first);
+    expect(third?.accessToken).toBe('updated-token');
   });
 });

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -22,17 +22,30 @@ export const ORB_SESSION_STORAGE_KEY = 'crtv_orb_session';
 /** Dispatched on the same tab when Orb session is saved or cleared. */
 export const ORB_SESSION_CHANGE_EVENT = 'crtv:orb-session-change';
 
+let cachedSession: StoredOrbSession | null = null;
+let isSessionCacheValid = false;
+
+export function invalidateOrbSessionCache(): void {
+  isSessionCacheValid = false;
+}
+
 export function loadStoredOrbSession(): StoredOrbSession | null {
   if (typeof window === 'undefined') return null;
+  if (isSessionCacheValid) return cachedSession;
+
   try {
     const raw = localStorage.getItem(ORB_SESSION_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as StoredOrbSession;
-    if (!parsed?.accessToken) return null;
-    return parsed;
+    if (!raw) {
+      cachedSession = null;
+    } else {
+      const parsed = JSON.parse(raw) as StoredOrbSession;
+      cachedSession = parsed?.accessToken ? parsed : null;
+    }
   } catch {
-    return null;
+    cachedSession = null;
   }
+  isSessionCacheValid = true;
+  return cachedSession;
 }
 
 function notifyOrbSessionChange(): void {
@@ -42,7 +55,10 @@ function notifyOrbSessionChange(): void {
 
 export function subscribeOrbSession(onStoreChange: () => void): () => void {
   if (typeof window === 'undefined') return () => {};
-  const handler = () => onStoreChange();
+  const handler = () => {
+    invalidateOrbSessionCache();
+    onStoreChange();
+  };
   window.addEventListener(ORB_SESSION_CHANGE_EVENT, handler);
   window.addEventListener('storage', handler);
   return () => {
@@ -62,5 +78,6 @@ export function saveStoredOrbSession(session: StoredOrbSession | null): void {
   } else {
     localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(session));
   }
+  invalidateOrbSessionCache();
   notifyOrbSessionChange();
 }

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -19,6 +19,9 @@ export type StoredOrbSession = {
 
 export const ORB_SESSION_STORAGE_KEY = 'crtv_orb_session';
 
+/** Dispatched on the same tab when Orb session is saved or cleared. */
+export const ORB_SESSION_CHANGE_EVENT = 'crtv:orb-session-change';
+
 export function loadStoredOrbSession(): StoredOrbSession | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -32,11 +35,32 @@ export function loadStoredOrbSession(): StoredOrbSession | null {
   }
 }
 
+function notifyOrbSessionChange(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(ORB_SESSION_CHANGE_EVENT));
+}
+
+export function subscribeOrbSession(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const handler = () => onStoreChange();
+  window.addEventListener(ORB_SESSION_CHANGE_EVENT, handler);
+  window.addEventListener('storage', handler);
+  return () => {
+    window.removeEventListener(ORB_SESSION_CHANGE_EVENT, handler);
+    window.removeEventListener('storage', handler);
+  };
+}
+
+export function getOrbSessionServerSnapshot(): StoredOrbSession | null {
+  return null;
+}
+
 export function saveStoredOrbSession(session: StoredOrbSession | null): void {
   if (typeof window === 'undefined') return;
   if (!session?.accessToken) {
     localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
-    return;
+  } else {
+    localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(session));
   }
-  localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(session));
+  notifyOrbSessionChange();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After signing in with Orb, the session was saved to `localStorage` but the account dropdown still showed **Sign in with Orb** until a full page refresh.

## Root cause

Orb session lived in React `useState` inside `OrbSessionProvider`, while persistence went through `localStorage`. In practice, consumers (especially the Radix dropdown portal) did not always re-render when the session was written.

## Solution

1. **`useSyncExternalStore`** — Orb session is now read from `localStorage` via `subscribeOrbSession`, so any save/clear triggers a consistent re-render across the app.
2. **Session change event** — `saveStoredOrbSession` dispatches `crtv:orb-session-change` (same-tab) and listens for `storage` (other tabs).
3. **Account menu UX** — After successful QR login, bump `accountMenuRefreshSignal` to reopen the account menu (desktop dropdown + mobile drawer) and remount menu content with the updated Orb / Lens section.

## Files changed

- `lib/sdk/orb/login.ts` — subscribe/notify helpers
- `context/OrbSessionContext.tsx` — external store + refresh signal
- `components/account-dropdown/AccountDropdown.tsx` — auto-open + content key
- `components/account-dropdown/MobileOrbSection.tsx` — remount on session change
- `components/Navbar.tsx` — open mobile menu after Orb login
- `lib/sdk/orb/login.test.ts` — unit tests

## Testing

- `pnpm exec vitest run lib/sdk/orb/login.test.ts`
- Manual: sign in with Orb → account menu should show **Linked** without refreshing the page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ed3684c-6d97-43dd-b549-58e05132104c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ed3684c-6d97-43dd-b549-58e05132104c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

