### PR TITLE
Fix discover page showing no videos when Livepeer playback fails

### DIFF
--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -4,6 +4,13 @@ import { serverLogger } from '@/lib/utils/logger';
 
 export async function GET(request: NextRequest) {
   try {
+    if (!process.env.LIVEPEER_FULL_API_KEY?.trim()) {
+      return NextResponse.json(
+        { error: 'Livepeer playback is not configured on this deployment' },
+        { status: 503 },
+      );
+    }
+
     const { searchParams } = new URL(request.url);
     const playbackId = searchParams.get('playbackId');
 

--- a/components/Videos/VideoCardGrid.tsx
+++ b/components/Videos/VideoCardGrid.tsx
@@ -44,11 +44,13 @@ const VideoCardGrid: React.FC<VideoCardGridProps> = ({
   const [totalAssets, setTotalAssets] = useState<number>(0);
   const [hasNextPage, setHasNextPage] = useState<boolean>(false);
   const [validVideosCount, setValidVideosCount] = useState<number>(0);
+  const [playbackWarning, setPlaybackWarning] = useState<string | null>(null);
 
   const fetchSources = useCallback(async (page: number) => {
     try {
       setLoading(true);
       setError(null);
+      setPlaybackWarning(null);
 
       // Calculate offset based on current page
       const offset = (page - 1) * ITEMS_PER_PAGE;
@@ -124,28 +126,21 @@ const VideoCardGrid: React.FC<VideoCardGridProps> = ({
         })
       );
 
-      // Filter out videos with failed playback sources
-      const validPlaybackSources = videosWithPlayback.filter(
-        (video) => video.detailedSrc !== null
-      );
+      const playbackReadyCount = videosWithPlayback.filter(
+        (video) => video.detailedSrc !== null && video.detailedSrc.length > 0,
+      ).length;
 
-      // Update the count of valid videos that actually rendered
-      setValidVideosCount(validPlaybackSources.length);
+      setValidVideosCount(videosWithPlayback.length);
+      setHasNextPage(hasMore);
 
-      // Update hasMore based on actual valid videos returned
-      // If we got fewer videos than requested, we've reached the end
-      // Also check if API says there are no more pages
-      const actualHasMore = hasMore && validPlaybackSources.length >= ITEMS_PER_PAGE;
-      setHasNextPage(actualHasMore);
-
-      if (validPlaybackSources.length === 0 && page === 1) {
-        setError("Unable to load video playback. Please try again later.");
-        setPlaybackSources([]);
-        setValidVideosCount(0);
-        return;
+      if (playbackReadyCount === 0 && videosWithPlayback.length > 0) {
+        setPlaybackWarning(
+          "Playback is temporarily unavailable. Videos are shown with poster images until streaming recovers.",
+        );
       }
 
-      setPlaybackSources(validPlaybackSources);
+      // Keep all published videos — VideoThumbnail falls back to posters when src is missing
+      setPlaybackSources(videosWithPlayback);
     } catch (err) {
       logger.error("Error fetching videos:", err);
       setError("Failed to load videos. Please try again later.");
@@ -258,6 +253,11 @@ const VideoCardGrid: React.FC<VideoCardGridProps> = ({
 
   return (
     <div>
+      {playbackWarning && (
+        <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          {playbackWarning}
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-y-4 sm:grid-cols-1 sm:gap-4 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
         {playbackSources.map((video, index) => (
           <VideoCard

--- a/components/Videos/VideoCardGrid.tsx
+++ b/components/Videos/VideoCardGrid.tsx
@@ -127,7 +127,7 @@ const VideoCardGrid: React.FC<VideoCardGridProps> = ({
       );
 
       const playbackReadyCount = videosWithPlayback.filter(
-        (video) => video.detailedSrc !== null && video.detailedSrc.length > 0,
+        (video) => (video.detailedSrc?.length ?? 0) > 0,
       ).length;
 
       setValidVideosCount(videosWithPlayback.length);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Discover showed **"Unable to load video playback"** with **0 videos on this page** even though Supabase reported **23 total videos**. Published videos loaded, but every Livepeer `playback-info` fetch failed, and `VideoCardGrid` filtered out all rows without a playback `src`.

## Solution

- Keep all published videos in the grid; `VideoThumbnail` uses poster fallback when `src` is null.
- Non-blocking warning when playback is unavailable for the page.
- Pagination uses the published-videos API `hasMore` flag.
- `playback-info` returns `503` when `LIVEPEER_FULL_API_KEY` is missing.

## Testing

Manual: `/discover` with Livepeer down — expect poster cards + warning, not a full-page error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ed3684c-6d97-43dd-b549-58e05132104c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ed3684c-6d97-43dd-b549-58e05132104c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

