### PR TITLE
Fix Discover playback and sync-views Livepeer failures

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -61,6 +61,11 @@ Your Livepeer API key for video streaming and processing.
 2. Create a new API key
 3. Copy the key
 
+#### `LIVEPEER_FULL_API_KEY`
+Full-access Livepeer API key used server-side for playback-info, asset routes, and view metrics. **Required for Discover video playback** on Vercel production. If unset, the app falls back to `LIVEPEER_API_KEY` where supported.
+
+**How to get it:** Same as `LIVEPEER_API_KEY` — use a key with playback and data API access, or create a dedicated full-access key in Livepeer Studio.
+
 #### `LIVEPEER_WEBHOOK_ID`
 Your Livepeer webhook ID for video processing callbacks.
 
@@ -285,6 +290,7 @@ NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID=your_gas_manager_policy_id_here
 
 # Livepeer Configuration
 LIVEPEER_API_KEY=your_livepeer_api_key
+LIVEPEER_FULL_API_KEY=your_livepeer_full_api_key
 LIVEPEER_WEBHOOK_ID=your_livepeer_webhook_id
 
 # Supabase Configuration

--- a/app/api/livepeer/asset/[assetId]/route.ts
+++ b/app/api/livepeer/asset/[assetId]/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
-import {
-  LIVEPEER_AUTH_FAILED,
-  LIVEPEER_NOT_CONFIGURED,
-  livepeerStudioApiBaseUrl,
-  resolveLivepeerStudioAuthToken,
-} from '@/lib/sdk/livepeer/studioAuth';
+import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
 
 export async function GET(
@@ -34,8 +29,8 @@ export async function GET(
       );
     }
 
-    const token = resolveLivepeerStudioAuthToken();
-    if (!token) {
+    const client = getFullLivepeer();
+    if (!client) {
       return NextResponse.json(
         {
           error: 'Livepeer is not configured',
@@ -45,66 +40,32 @@ export async function GET(
       );
     }
 
-    const client = getFullLivepeer();
-    if (client) {
-      const assetResponse = await client.asset.get(assetId);
+    const assetResponse = await client.asset.get(assetId);
 
-      if (
-        assetResponse &&
-        'errors' in assetResponse &&
-        Array.isArray(assetResponse.errors) &&
-        assetResponse.errors.length > 0
-      ) {
-        return NextResponse.json(
-          {
-            error: 'Asset not found',
-            details: assetResponse.errors,
-            code: 'ASSET_NOT_FOUND',
-          },
-          { status: 404 },
-        );
-      }
-
-      if (!assetResponse || !assetResponse.asset) {
-        return NextResponse.json(
-          { error: 'Asset not found', code: 'ASSET_NOT_FOUND' },
-          { status: 404 },
-        );
-      }
-
-      return NextResponse.json(assetResponse);
-    }
-
-    const base = livepeerStudioApiBaseUrl();
-    const livepeerRes = await fetch(
-      `${base}/api/asset/${encodeURIComponent(assetId)}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-      },
-    );
-
-    if (livepeerRes.status === 401 || livepeerRes.status === 403) {
-      return NextResponse.json(
-        {
-          error: 'Livepeer authentication failed',
-          code: LIVEPEER_AUTH_FAILED,
-        },
-        { status: 502 },
-      );
-    }
-
-    if (!livepeerRes.ok) {
+    if (
+      assetResponse &&
+      'errors' in assetResponse &&
+      Array.isArray(assetResponse.errors) &&
+      assetResponse.errors.length > 0
+    ) {
       return NextResponse.json(
         {
           error: 'Asset not found',
-          code: livepeerRes.status === 404 ? 'ASSET_NOT_FOUND' : 'LIVEPEER_UPSTREAM_ERROR',
+          details: assetResponse.errors,
+          code: 'ASSET_NOT_FOUND',
         },
-        { status: livepeerRes.status >= 500 ? 502 : livepeerRes.status },
+        { status: 404 },
       );
     }
 
-    return NextResponse.json(await livepeerRes.json());
+    if (!assetResponse || !assetResponse.asset) {
+      return NextResponse.json(
+        { error: 'Asset not found', code: 'ASSET_NOT_FOUND' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(assetResponse);
   } catch (error: unknown) {
     serverLogger.error('Error fetching asset:', error);
 

--- a/app/api/livepeer/asset/[assetId]/route.ts
+++ b/app/api/livepeer/asset/[assetId]/route.ts
@@ -1,69 +1,138 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { fullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import {
+  LIVEPEER_AUTH_FAILED,
+  LIVEPEER_NOT_CONFIGURED,
+  livepeerStudioApiBaseUrl,
+  resolveLivepeerStudioAuthToken,
+} from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ assetId: string }> }
+  { params }: { params: Promise<{ assetId: string }> },
 ) {
   try {
     const { assetId } = await params;
 
     if (!assetId) {
       return NextResponse.json(
-        { error: 'Asset ID is required' },
-        { status: 400 }
+        { error: 'Asset ID is required', code: 'ASSET_ID_REQUIRED' },
+        { status: 400 },
       );
     }
 
-    // Validate UUID format
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(assetId)) {
       return NextResponse.json(
-        { error: 'Invalid asset ID format. Expected UUID format.' },
-        { status: 400 }
-      );
-    }
-
-    // Fetch asset from Livepeer (server-side, no CORS issues)
-    const assetResponse = await fullLivepeer.asset.get(assetId);
-    
-    // Check if the response contains errors (Livepeer API format)
-    if (assetResponse && 'errors' in assetResponse && Array.isArray(assetResponse.errors) && assetResponse.errors.length > 0) {
-      return NextResponse.json(
-        { 
-          error: 'Asset not found',
-          details: assetResponse.errors 
+        {
+          error: 'Invalid asset ID format. Expected UUID format.',
+          code: 'INVALID_ASSET_ID',
         },
-        { status: 404 }
-      );
-    }
-    
-    if (!assetResponse || !assetResponse.asset) {
-      return NextResponse.json(
-        { error: 'Asset not found' },
-        { status: 404 }
+        { status: 400 },
       );
     }
 
-    return NextResponse.json(assetResponse);
-  } catch (error: any) {
-    serverLogger.error('Error fetching asset:', error);
-    
-    // Extract error message from Livepeer API response if available
-    let errorMessage = 'Failed to fetch asset';
-    if (error?.errors && Array.isArray(error.errors)) {
-      errorMessage = error.errors.join(', ');
-    } else if (error?.message) {
-      errorMessage = error.message;
+    const token = resolveLivepeerStudioAuthToken();
+    if (!token) {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
     }
-    
-    return NextResponse.json(
-      { 
-        error: errorMessage,
-        details: error?.errors || undefined
+
+    const client = getFullLivepeer();
+    if (client) {
+      const assetResponse = await client.asset.get(assetId);
+
+      if (
+        assetResponse &&
+        'errors' in assetResponse &&
+        Array.isArray(assetResponse.errors) &&
+        assetResponse.errors.length > 0
+      ) {
+        return NextResponse.json(
+          {
+            error: 'Asset not found',
+            details: assetResponse.errors,
+            code: 'ASSET_NOT_FOUND',
+          },
+          { status: 404 },
+        );
+      }
+
+      if (!assetResponse || !assetResponse.asset) {
+        return NextResponse.json(
+          { error: 'Asset not found', code: 'ASSET_NOT_FOUND' },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json(assetResponse);
+    }
+
+    const base = livepeerStudioApiBaseUrl();
+    const livepeerRes = await fetch(
+      `${base}/api/asset/${encodeURIComponent(assetId)}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
       },
-      { status: 500 }
+    );
+
+    if (livepeerRes.status === 401 || livepeerRes.status === 403) {
+      return NextResponse.json(
+        {
+          error: 'Livepeer authentication failed',
+          code: LIVEPEER_AUTH_FAILED,
+        },
+        { status: 502 },
+      );
+    }
+
+    if (!livepeerRes.ok) {
+      return NextResponse.json(
+        {
+          error: 'Asset not found',
+          code: livepeerRes.status === 404 ? 'ASSET_NOT_FOUND' : 'LIVEPEER_UPSTREAM_ERROR',
+        },
+        { status: livepeerRes.status >= 500 ? 502 : livepeerRes.status },
+      );
+    }
+
+    return NextResponse.json(await livepeerRes.json());
+  } catch (error: unknown) {
+    serverLogger.error('Error fetching asset:', error);
+
+    const err = error as { errors?: string[]; message?: string };
+    let errorMessage = 'Failed to fetch asset';
+    if (err?.errors && Array.isArray(err.errors)) {
+      errorMessage = err.errors.join(', ');
+    } else if (err?.message) {
+      errorMessage = err.message;
+    }
+
+    if (errorMessage === 'LIVEPEER_NOT_CONFIGURED') {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: errorMessage,
+        details: err?.errors || undefined,
+        code: 'ASSET_FETCH_ERROR',
+      },
+      { status: 500 },
     );
   }
 }

--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { fullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import {
+  LIVEPEER_AUTH_FAILED,
+  LIVEPEER_NOT_CONFIGURED,
+  livepeerStudioApiBaseUrl,
+  resolveLivepeerStudioAuthToken,
+} from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
+
+const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
 
 export async function GET(request: NextRequest) {
   try {
@@ -9,59 +17,115 @@ export async function GET(request: NextRequest) {
 
     if (!playbackId) {
       return NextResponse.json(
-        { error: 'Playback ID is required' },
-        { status: 400 }
+        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
+        { status: 400 },
       );
     }
 
-    // Validate that playbackId is not an Ethereum address
-    // Ethereum addresses start with 0x and are 42 characters long
-    const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
     if (ethereumAddressRegex.test(playbackId)) {
       return NextResponse.json(
-        { error: 'Invalid playback ID format. Expected Livepeer playback ID, received Ethereum address.' },
-        { status: 400 }
+        {
+          error:
+            'Invalid playback ID format. Expected Livepeer playback ID, received Ethereum address.',
+          code: 'INVALID_PLAYBACK_ID',
+        },
+        { status: 400 },
       );
     }
 
-    // Fetch playback info from Livepeer
-    const response = await fullLivepeer.playback.get(playbackId);
-
-    // Check if the response contains errors
-    if (response.error) {
-      // Extract error message from Livepeer API response if available
-      // The error object might differ based on the SDK version, assuming it matches ErrorT
+    const token = resolveLivepeerStudioAuthToken();
+    if (!token) {
       return NextResponse.json(
         {
-          error: 'Playback info not found',
-          details: response.error
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
         },
-        { status: 404 }
+        { status: 503 },
       );
     }
 
-    if (!response.playbackInfo) {
+    const client = getFullLivepeer();
+    if (client) {
+      const response = await client.playback.get(playbackId);
+
+      if (response.error) {
+        return NextResponse.json(
+          {
+            error: 'Playback info not found',
+            details: response.error,
+            code: 'PLAYBACK_NOT_FOUND',
+          },
+          { status: 404 },
+        );
+      }
+
+      if (!response.playbackInfo) {
+        return NextResponse.json(
+          { error: 'Playback info not found', code: 'PLAYBACK_NOT_FOUND' },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json(response.playbackInfo);
+    }
+
+    const base = livepeerStudioApiBaseUrl();
+    const livepeerRes = await fetch(
+      `${base}/api/playback/${encodeURIComponent(playbackId)}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      },
+    );
+
+    if (livepeerRes.status === 401 || livepeerRes.status === 403) {
       return NextResponse.json(
-        { error: 'Playback info not found' },
-        { status: 404 }
+        {
+          error: 'Livepeer authentication failed',
+          code: LIVEPEER_AUTH_FAILED,
+        },
+        { status: 502 },
       );
     }
 
-    return NextResponse.json(response.playbackInfo);
-  } catch (error: any) {
+    if (!livepeerRes.ok) {
+      const details = await livepeerRes.text().catch(() => '');
+      serverLogger.error(
+        `Livepeer playback-info ${livepeerRes.status} for ${playbackId}:`,
+        details.slice(0, 200),
+      );
+      return NextResponse.json(
+        {
+          error: 'Failed to fetch playback info',
+          code: 'LIVEPEER_UPSTREAM_ERROR',
+        },
+        { status: livepeerRes.status >= 500 ? 502 : livepeerRes.status },
+      );
+    }
+
+    return NextResponse.json(await livepeerRes.json());
+  } catch (error: unknown) {
     serverLogger.error('Error fetching playback info:', error);
 
-    // Extract error message from Livepeer API response if available
-    let errorMessage = 'Failed to fetch playback info';
-    if (error?.message) {
-      errorMessage = error.message;
+    const message =
+      error instanceof Error ? error.message : 'Failed to fetch playback info';
+
+    if (message === 'LIVEPEER_NOT_CONFIGURED') {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
     }
 
     return NextResponse.json(
       {
-        error: errorMessage,
+        error: message,
+        code: 'PLAYBACK_INFO_ERROR',
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
-import {
-  LIVEPEER_AUTH_FAILED,
-  LIVEPEER_NOT_CONFIGURED,
-  livepeerStudioApiBaseUrl,
-  resolveLivepeerStudioAuthToken,
-} from '@/lib/sdk/livepeer/studioAuth';
+import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
 
 const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
@@ -33,8 +28,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const token = resolveLivepeerStudioAuthToken();
-    if (!token) {
+    const client = getFullLivepeer();
+    if (!client) {
       return NextResponse.json(
         {
           error: 'Livepeer is not configured',
@@ -44,66 +39,27 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const client = getFullLivepeer();
-    if (client) {
-      const response = await client.playback.get(playbackId);
+    const response = await client.playback.get(playbackId);
 
-      if (response.error) {
-        return NextResponse.json(
-          {
-            error: 'Playback info not found',
-            details: response.error,
-            code: 'PLAYBACK_NOT_FOUND',
-          },
-          { status: 404 },
-        );
-      }
-
-      if (!response.playbackInfo) {
-        return NextResponse.json(
-          { error: 'Playback info not found', code: 'PLAYBACK_NOT_FOUND' },
-          { status: 404 },
-        );
-      }
-
-      return NextResponse.json(response.playbackInfo);
-    }
-
-    const base = livepeerStudioApiBaseUrl();
-    const livepeerRes = await fetch(
-      `${base}/api/playback/${encodeURIComponent(playbackId)}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-      },
-    );
-
-    if (livepeerRes.status === 401 || livepeerRes.status === 403) {
+    if (response.error) {
       return NextResponse.json(
         {
-          error: 'Livepeer authentication failed',
-          code: LIVEPEER_AUTH_FAILED,
+          error: 'Playback info not found',
+          details: response.error,
+          code: 'PLAYBACK_NOT_FOUND',
         },
-        { status: 502 },
+        { status: 404 },
       );
     }
 
-    if (!livepeerRes.ok) {
-      const details = await livepeerRes.text().catch(() => '');
-      serverLogger.error(
-        `Livepeer playback-info ${livepeerRes.status} for ${playbackId}:`,
-        details.slice(0, 200),
-      );
+    if (!response.playbackInfo) {
       return NextResponse.json(
-        {
-          error: 'Failed to fetch playback info',
-          code: 'LIVEPEER_UPSTREAM_ERROR',
-        },
-        { status: livepeerRes.status >= 500 ? 502 : livepeerRes.status },
+        { error: 'Playback info not found', code: 'PLAYBACK_NOT_FOUND' },
+        { status: 404 },
       );
     }
 
-    return NextResponse.json(await livepeerRes.json());
+    return NextResponse.json(response.playbackInfo);
   } catch (error: unknown) {
     serverLogger.error('Error fetching playback info:', error);
 

--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -1,57 +1,90 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchAllViews } from './views';
 import {
-  fetchAllViews,
   livepeerStudioApiBaseUrl,
   resolveLivepeerStudioAuthToken,
-} from "./views";
+} from '@/lib/sdk/livepeer/studioAuth';
 
-describe("Livepeer view metrics helpers", () => {
+describe('Livepeer view metrics helpers', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
-  it("prefers the full Livepeer API key", () => {
-    vi.stubEnv("LIVEPEER_FULL_API_KEY", "full-key");
-    vi.stubEnv("LIVEPEER_API_KEY", "standard-key");
+  it('prefers the full Livepeer API key', () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    vi.stubEnv('LIVEPEER_API_KEY', 'standard-key');
 
-    expect(resolveLivepeerStudioAuthToken()).toBe("full-key");
+    expect(resolveLivepeerStudioAuthToken()).toBe('full-key');
   });
 
-  it("normalizes the Studio API base URL", () => {
-    vi.stubEnv("LIVEPEER_FULL_API_URL", "https://livepeer.example/");
+  it('normalizes the Studio API base URL', () => {
+    vi.stubEnv('LIVEPEER_FULL_API_URL', 'https://livepeer.example/');
 
-    expect(livepeerStudioApiBaseUrl()).toBe("https://livepeer.example");
+    expect(livepeerStudioApiBaseUrl()).toBe('https://livepeer.example');
   });
 
-  it("fetches view metrics without using cache", async () => {
-    vi.stubEnv("LIVEPEER_FULL_API_KEY", "full-key");
+  it('fetches view metrics without using cache', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
     const fetchMock = vi.fn(async () =>
       Response.json({
-        playbackId: "playback-1",
+        playbackId: 'playback-1',
         viewCount: 12,
         playtimeMins: 34,
         legacyViewCount: 5,
       }),
     );
-    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal('fetch', fetchMock);
 
-    await expect(fetchAllViews("playback-1")).resolves.toEqual({
-      playbackId: "playback-1",
-      viewCount: 12,
-      playtimeMins: 34,
-      legacyViewCount: 5,
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 12,
+        playtimeMins: 34,
+        legacyViewCount: 5,
+      },
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://livepeer.studio/api/data/views/query/total/playback-1",
+      'https://livepeer.studio/api/data/views/query/total/playback-1',
       expect.objectContaining({
-        cache: "no-store",
+        cache: 'no-store',
         headers: expect.any(Headers),
       }),
     );
-    const [, options] = fetchMock.mock.calls[0];
-    expect((options?.headers as Headers).get("Authorization")).toBe(
-      "Bearer full-key",
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://livepeer.studio/api/data/views/query/total/playback-1',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
     );
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Headers).get('Authorization')).toBe(
+      'Bearer full-key',
+    );
+  });
+
+  it('returns upstream_error when Livepeer responds with 500', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 500, statusText: 'Internal Server Error' })),
+    );
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: false,
+      reason: 'upstream_error',
+      status: 500,
+    });
+  });
+
+  it('returns not_configured when no API key is set', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', '');
+    vi.stubEnv('LIVEPEER_API_KEY', '');
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: false,
+      reason: 'not_configured',
+    });
   });
 });

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -1,39 +1,45 @@
 import { serverLogger } from '@/lib/utils/logger';
+import {
+  livepeerStudioApiBaseUrl,
+  resolveLivepeerStudioAuthToken,
+} from '@/lib/sdk/livepeer/studioAuth';
 
-/** Prefer full-access key for Studio data routes; fall back to LIVEPEER_API_KEY (same key in most setups). */
-export function resolveLivepeerStudioAuthToken(): string | undefined {
-  const full = process.env.LIVEPEER_FULL_API_KEY?.trim();
-  const standard = process.env.LIVEPEER_API_KEY?.trim();
-  return full || standard || undefined;
-}
+export {
+  livepeerStudioApiBaseUrl,
+  resolveLivepeerStudioAuthToken,
+} from '@/lib/sdk/livepeer/studioAuth';
 
-export function livepeerStudioApiBaseUrl(): string {
-  const raw =
-    process.env.LIVEPEER_FULL_API_URL?.trim() || 'https://livepeer.studio';
-  return raw.replace(/\/$/, '');
-}
-
-export const fetchAllViews = async (
-  playbackId: string,
-): Promise<{
+export type LivepeerViewMetrics = {
   playbackId: string;
   viewCount: number;
   playtimeMins: number;
   legacyViewCount: number;
-} | null> => {
+};
+
+export type FetchAllViewsResult =
+  | { ok: true; metrics: LivepeerViewMetrics }
+  | {
+      ok: false;
+      reason: 'not_configured' | 'upstream_error' | 'network_error';
+      status?: number;
+    };
+
+export const fetchAllViews = async (
+  playbackId: string,
+): Promise<FetchAllViewsResult> => {
   const token = resolveLivepeerStudioAuthToken();
   if (!token) {
     serverLogger.warn(
       'Livepeer view metrics skipped: set LIVEPEER_FULL_API_KEY or LIVEPEER_API_KEY',
     );
-    return null;
+    return { ok: false, reason: 'not_configured' };
   }
 
   const myHeaders = new Headers();
   myHeaders.append('Authorization', `Bearer ${token}`);
 
   const requestOptions = {
-    method: 'GET',
+    method: 'GET' as const,
     headers: myHeaders,
     redirect: 'follow' as const,
     cache: 'no-store' as const,
@@ -47,20 +53,28 @@ export const fetchAllViews = async (
     );
 
     if (!response.ok) {
-      throw new Error(
-        `Error fetching views: ${response.status} ${response.statusText}`,
+      serverLogger.warn(
+        `Livepeer views API ${response.status} for playbackId=${playbackId}`,
       );
+      return {
+        ok: false,
+        reason: 'upstream_error',
+        status: response.status,
+      };
     }
 
     const data = (await response.json()) as Record<string, unknown>;
     return {
-      playbackId: String(data.playbackId ?? playbackId),
-      viewCount: Number(data.viewCount ?? 0) || 0,
-      playtimeMins: Number(data.playtimeMins ?? 0) || 0,
-      legacyViewCount: Number(data.legacyViewCount ?? 0) || 0,
+      ok: true,
+      metrics: {
+        playbackId: String(data.playbackId ?? playbackId),
+        viewCount: Number(data.viewCount ?? 0) || 0,
+        playtimeMins: Number(data.playtimeMins ?? 0) || 0,
+        legacyViewCount: Number(data.legacyViewCount ?? 0) || 0,
+      },
     };
   } catch (error) {
     serverLogger.error('Failed to fetch view metrics:', error);
-    return null;
+    return { ok: false, reason: 'network_error' };
   }
 };

--- a/app/api/livepeer/views/[playbackId]/route.ts
+++ b/app/api/livepeer/views/[playbackId]/route.ts
@@ -8,6 +8,10 @@ import {
 } from '@/lib/livepeer/view-count';
 import { getStoredViewsCount } from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
+import {
+  LIVEPEER_AUTH_FAILED,
+  LIVEPEER_NOT_CONFIGURED,
+} from '@/lib/sdk/livepeer/studioAuth';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -24,20 +28,47 @@ const noStoreHeaders = {
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ playbackId: string }> }
+  { params }: { params: Promise<{ playbackId: string }> },
 ) {
   try {
     const { playbackId } = await params;
 
     if (!playbackId) {
       return NextResponse.json(
-        { error: 'Playback ID is required' },
-        { status: 400, headers: noStoreHeaders }
+        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
+        { status: 400, headers: noStoreHeaders },
       );
     }
 
-    const metrics = await fetchAllViews(playbackId);
-    const livepeerTotal = metrics ? sumLivepeerViewMetrics(metrics) : 0;
+    const viewsResult = await fetchAllViews(playbackId);
+    const livepeerAvailable = viewsResult.ok;
+    const livepeerTotal = viewsResult.ok
+      ? sumLivepeerViewMetrics(viewsResult.metrics)
+      : 0;
+
+    if (!viewsResult.ok && viewsResult.reason === 'not_configured') {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503, headers: noStoreHeaders },
+      );
+    }
+
+    if (
+      !viewsResult.ok &&
+      viewsResult.reason === 'upstream_error' &&
+      (viewsResult.status === 401 || viewsResult.status === 403)
+    ) {
+      return NextResponse.json(
+        {
+          error: 'Livepeer authentication failed',
+          code: LIVEPEER_AUTH_FAILED,
+        },
+        { status: 502, headers: noStoreHeaders },
+      );
+    }
 
     const supabase = createServiceClient();
     const dbViewCount = await getStoredViewsCount(supabase, playbackId);
@@ -50,17 +81,20 @@ export async function GET(
         source,
         playbackId,
         viewCount: displayTotal,
-        playtimeMins: metrics?.playtimeMins ?? 0,
+        playtimeMins: viewsResult.ok ? viewsResult.metrics.playtimeMins : 0,
         legacyViewCount: 0,
+        livepeerAvailable,
+        ...(!livepeerAvailable
+          ? { code: 'LIVEPEER_VIEWS_UNAVAILABLE' as const }
+          : {}),
       },
-      { headers: noStoreHeaders }
+      { headers: noStoreHeaders },
     );
-
   } catch (error) {
     serverLogger.error('Error fetching view metrics:', error);
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500, headers: noStoreHeaders }
+      { error: 'Internal server error', code: 'VIEW_METRICS_ERROR' },
+      { status: 500, headers: noStoreHeaders },
     );
   }
 }

--- a/app/api/video-assets/sync-views/[playbackId]/route.test.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 
 const mockFetchAllViews = vi.fn();
 const mockSyncStoredViewsCount = vi.fn();
+const mockGetStoredViewsCount = vi.fn();
 const mockCreateServiceClient = vi.fn();
 
 vi.mock('botid/server', () => ({
@@ -21,6 +22,7 @@ vi.mock('@/app/api/livepeer/views', () => ({
 
 vi.mock('@/lib/livepeer/sync-view-count', () => ({
   syncStoredViewsCount: (...args: unknown[]) => mockSyncStoredViewsCount(...args),
+  getStoredViewsCount: (...args: unknown[]) => mockGetStoredViewsCount(...args),
 }));
 
 vi.mock('@/lib/sdk/supabase/service', () => ({
@@ -28,20 +30,25 @@ vi.mock('@/lib/sdk/supabase/service', () => ({
 }));
 
 vi.mock('@/lib/utils/logger', () => ({
-  serverLogger: { error: vi.fn(), debug: vi.fn() },
+  serverLogger: { error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
-import { POST } from './route';
+import { GET, POST } from './route';
 
 describe('sync-views POST security', () => {
   beforeEach(() => {
     mockCreateServiceClient.mockReturnValue({});
     mockFetchAllViews.mockResolvedValue({
-      playbackId: 'playback-1',
-      viewCount: 12,
-      legacyViewCount: 5,
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 12,
+        playtimeMins: 0,
+        legacyViewCount: 5,
+      },
     });
     mockSyncStoredViewsCount.mockResolvedValue({ viewCount: 17, updated: true });
+    mockGetStoredViewsCount.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -68,6 +75,7 @@ describe('sync-views POST security', () => {
       success: true,
       playbackId: 'playback-1',
       viewCount: 17,
+      livepeerSynced: true,
     });
     expect(mockFetchAllViews).toHaveBeenCalledWith('playback-1');
     expect(mockSyncStoredViewsCount).toHaveBeenCalledWith(
@@ -75,5 +83,34 @@ describe('sync-views POST security', () => {
       'playback-1',
       17,
     );
+  });
+
+  it('returns stored view count when Livepeer metrics are unavailable', async () => {
+    mockFetchAllViews.mockResolvedValue({
+      ok: false,
+      reason: 'upstream_error',
+      status: 500,
+    });
+    mockGetStoredViewsCount.mockResolvedValue(42);
+
+    const request = new NextRequest(
+      'http://localhost/api/video-assets/sync-views/playback-1',
+      { method: 'GET' },
+    );
+
+    const response = await GET(request, {
+      params: Promise.resolve({ playbackId: 'playback-1' }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({
+      success: true,
+      playbackId: 'playback-1',
+      viewCount: 42,
+      livepeerSynced: false,
+      code: 'LIVEPEER_VIEWS_UNAVAILABLE',
+    });
+    expect(mockSyncStoredViewsCount).not.toHaveBeenCalled();
   });
 });

--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -4,31 +4,48 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { createServiceClient } from '@/lib/sdk/supabase/service';
 import { fetchAllViews } from '@/app/api/livepeer/views';
 import { sumLivepeerViewMetrics } from '@/lib/livepeer/view-count';
-import { syncStoredViewsCount } from '@/lib/livepeer/sync-view-count';
+import {
+  getStoredViewsCount,
+  syncStoredViewsCount,
+} from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
+import {
+  LIVEPEER_NOT_CONFIGURED,
+  LIVEPEER_AUTH_FAILED,
+} from '@/lib/sdk/livepeer/studioAuth';
 
 function syncViewsErrorResponse(error: unknown) {
   serverLogger.error('Error syncing view count:', error);
 
   if (error instanceof Error) {
-    if (error.message.includes('Livepeer') || error.message.includes('playback')) {
+    if (
+      error.message.includes('Livepeer') ||
+      error.message.includes('playback')
+    ) {
       return NextResponse.json(
         {
           error: 'Livepeer API error',
-          details: 'Unable to fetch view metrics from Livepeer. Please try again later.',
+          code: 'LIVEPEER_SYNC_ERROR',
+          details:
+            'Unable to fetch view metrics from Livepeer. Please try again later.',
         },
-        { status: 503 }
+        { status: 503 },
       );
     }
 
-    if (error.message.includes('database') || error.message.includes('connection')) {
+    if (
+      error.message.includes('database') ||
+      error.message.includes('connection')
+    ) {
       return NextResponse.json(
         {
           error: 'Database error',
-          details: 'Unable to update view count in database. Please try again later.',
+          code: 'DATABASE_ERROR',
+          details:
+            'Unable to update view count in database. Please try again later.',
         },
-        { status: 503 }
+        { status: 503 },
       );
     }
   }
@@ -36,9 +53,10 @@ function syncViewsErrorResponse(error: unknown) {
   return NextResponse.json(
     {
       error: 'Internal server error',
+      code: 'SYNC_VIEWS_ERROR',
       details: error instanceof Error ? error.message : 'Unknown error',
     },
-    { status: 500 }
+    { status: 500 },
   );
 }
 
@@ -46,15 +64,48 @@ async function syncViewsForPlayback(
   supabase: SupabaseClient,
   playbackId: string,
 ) {
-  const metrics = await fetchAllViews(playbackId);
-  if (!metrics) {
-    return NextResponse.json(
-      { error: 'Failed to fetch view metrics from Livepeer' },
-      { status: 500 }
+  const viewsResult = await fetchAllViews(playbackId);
+
+  if (!viewsResult.ok) {
+    const storedCount = await getStoredViewsCount(supabase, playbackId);
+
+    if (viewsResult.reason === 'not_configured') {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
+    }
+
+    if (
+      viewsResult.reason === 'upstream_error' &&
+      (viewsResult.status === 401 || viewsResult.status === 403)
+    ) {
+      return NextResponse.json(
+        {
+          error: 'Livepeer authentication failed',
+          code: LIVEPEER_AUTH_FAILED,
+        },
+        { status: 502 },
+      );
+    }
+
+    serverLogger.warn(
+      `View sync skipped for ${playbackId}: Livepeer metrics unavailable (${viewsResult.reason})`,
     );
+
+    return NextResponse.json({
+      success: true,
+      playbackId,
+      viewCount: storedCount,
+      livepeerSynced: false,
+      code: 'LIVEPEER_VIEWS_UNAVAILABLE',
+    });
   }
 
-  const livepeerTotal = sumLivepeerViewMetrics(metrics);
+  const livepeerTotal = sumLivepeerViewMetrics(viewsResult.metrics);
   const { viewCount } = await syncStoredViewsCount(
     supabase,
     playbackId,
@@ -65,12 +116,13 @@ async function syncViewsForPlayback(
     success: true,
     playbackId,
     viewCount,
+    livepeerSynced: true,
   });
 }
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ playbackId: string }> }
+  { params }: { params: Promise<{ playbackId: string }> },
 ) {
   const verification = await checkBotId();
   if (verification.isBot) {
@@ -84,8 +136,8 @@ export async function POST(
 
     if (!playbackId) {
       return NextResponse.json(
-        { error: 'Playback ID is required' },
-        { status: 400 }
+        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
+        { status: 400 },
       );
     }
 
@@ -98,15 +150,15 @@ export async function POST(
 
 export async function GET(
   _request: NextRequest,
-  { params }: { params: Promise<{ playbackId: string }> }
+  { params }: { params: Promise<{ playbackId: string }> },
 ) {
   try {
     const { playbackId } = await params;
 
     if (!playbackId) {
       return NextResponse.json(
-        { error: 'Playback ID is required' },
-        { status: 400 }
+        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
+        { status: 400 },
       );
     }
 

--- a/app/api/video-assets/sync-views/cron/route.ts
+++ b/app/api/video-assets/sync-views/cron/route.ts
@@ -73,10 +73,10 @@ export async function GET(request: NextRequest) {
       await Promise.all(
         batch.map(async (video) => {
           try {
-            const metrics = await fetchAllViews(video.playback_id);
-            
-            if (metrics) {
-              const livepeerTotal = sumLivepeerViewMetrics(metrics);
+            const viewsResult = await fetchAllViews(video.playback_id);
+
+            if (viewsResult.ok) {
+              const livepeerTotal = sumLivepeerViewMetrics(viewsResult.metrics);
               const merged = mergeViewCounts(video.views_count ?? 0, livepeerTotal);
 
               if (merged !== video.views_count) {

--- a/components/Videos/VideoCard.tsx
+++ b/components/Videos/VideoCard.tsx
@@ -152,7 +152,7 @@ const VideoCard: React.FC<VideoCardProps> = ({ asset, playbackSources, priority 
     if (dbStatus === 'published') {
       syncViewCount();
     }
-  }, [asset?.playbackId, dbStatus, playbackSources]);
+  }, [asset?.playbackId, dbStatus, playbackSources?.length]);
 
   // Early return if asset is not provided or invalid
   if (!asset) {

--- a/components/Videos/VideoCard.tsx
+++ b/components/Videos/VideoCard.tsx
@@ -114,6 +114,7 @@ const VideoCard: React.FC<VideoCardProps> = ({ asset, playbackSources, priority 
   useEffect(() => {
     async function syncViewCount() {
       if (!asset?.playbackId || dbStatus !== 'published') return;
+      if (!playbackSources?.length) return;
 
       // Check last sync time from localStorage to avoid excessive API calls
       const lastSyncKey = `view-sync-${asset.playbackId}`;
@@ -151,7 +152,7 @@ const VideoCard: React.FC<VideoCardProps> = ({ asset, playbackSources, priority 
     if (dbStatus === 'published') {
       syncViewCount();
     }
-  }, [asset?.playbackId, dbStatus]);
+  }, [asset?.playbackId, dbStatus, playbackSources]);
 
   // Early return if asset is not provided or invalid
   if (!asset) {

--- a/components/Videos/VideoCardGrid.tsx
+++ b/components/Videos/VideoCardGrid.tsx
@@ -9,6 +9,9 @@ import { Pagination } from "@/components/ui/pagination";
 import { fetchPublishedVideos } from "@/lib/utils/published-videos-client";
 import type { VideoAsset } from "@/lib/types/video-asset";
 import { logger } from '@/lib/utils/logger';
+import { mapInBatches } from '@/lib/utils/map-in-batches';
+
+const PLAYBACK_FETCH_CONCURRENCY = 4;
 
 
 const ITEMS_PER_PAGE = 12; // Number of videos per page
@@ -99,29 +102,33 @@ const VideoCardGrid: React.FC<VideoCardGridProps> = ({
         return;
       }
 
-      // 2. Fetch playback sources from Livepeer only for the videos we need
-      const videosWithPlayback = await Promise.all(
-        videos.map(async (video) => {
-          const detailedSrc = await fetchPlaybackSourceWithRetry(video.playback_id);
+      // 2. Fetch playback sources with bounded concurrency
+      const videosWithPlayback = await mapInBatches(
+        videos,
+        PLAYBACK_FETCH_CONCURRENCY,
+        async (video) => {
+          const detailedSrc = await fetchPlaybackSourceWithRetry(
+            video.playback_id,
+          );
           return {
             ...video,
-            // Map to Asset-like structure for compatibility with VideoCard
             id: video.asset_id,
             playbackId: video.playback_id,
             name: video.title,
-            // Add required Asset fields for VideoCard compatibility
             status: {
-              phase: "ready" as const,
+              phase: 'ready' as const,
             },
             creatorId: {
               value: video.creator_id,
             },
             createdAt: video.created_at,
-            // Include thumbnail_url for VideoThumbnail component
-            thumbnail_url: (video as any).thumbnail_url || video.thumbnailUri || null,
+            thumbnail_url:
+              (video as { thumbnail_url?: string }).thumbnail_url ||
+              video.thumbnailUri ||
+              null,
             detailedSrc,
           };
-        })
+        },
       );
 
       // Filter out videos with failed playback sources

--- a/lib/sdk/livepeer/fullClient.ts
+++ b/lib/sdk/livepeer/fullClient.ts
@@ -1,5 +1,33 @@
-import { Livepeer } from "livepeer";
+import { Livepeer } from 'livepeer';
+import { resolveLivepeerStudioAuthToken } from './studioAuth';
 
-export const fullLivepeer = new Livepeer({
-  apiKey: process.env.LIVEPEER_FULL_API_KEY,
+let cachedClient: Livepeer | null | undefined;
+
+/** Lazily construct the Livepeer SDK client (full key, then LIVEPEER_API_KEY). */
+export function getFullLivepeer(): Livepeer | null {
+  if (cachedClient !== undefined) {
+    return cachedClient;
+  }
+  const apiKey = resolveLivepeerStudioAuthToken();
+  if (!apiKey) {
+    cachedClient = null;
+    return null;
+  }
+  cachedClient = new Livepeer({ apiKey });
+  return cachedClient;
+}
+
+/** Backward-compatible accessor; throws if Livepeer is not configured. */
+export const fullLivepeer = new Proxy({} as Livepeer, {
+  get(_target, prop) {
+    const client = getFullLivepeer();
+    if (!client) {
+      throw new Error('LIVEPEER_NOT_CONFIGURED');
+    }
+    const value = (client as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof value === 'function') {
+      return (value as (...args: unknown[]) => unknown).bind(client);
+    }
+    return value;
+  },
 });

--- a/lib/sdk/livepeer/studioAuth.ts
+++ b/lib/sdk/livepeer/studioAuth.ts
@@ -1,0 +1,19 @@
+/** Prefer full-access key for Studio routes; fall back to LIVEPEER_API_KEY. */
+export function resolveLivepeerStudioAuthToken(): string | undefined {
+  const full = process.env.LIVEPEER_FULL_API_KEY?.trim();
+  const standard = process.env.LIVEPEER_API_KEY?.trim();
+  return full || standard || undefined;
+}
+
+export function livepeerStudioApiBaseUrl(): string {
+  const raw =
+    process.env.LIVEPEER_FULL_API_URL?.trim() || 'https://livepeer.studio';
+  return raw.replace(/\/$/, '');
+}
+
+export const LIVEPEER_NOT_CONFIGURED = 'LIVEPEER_NOT_CONFIGURED' as const;
+export const LIVEPEER_AUTH_FAILED = 'LIVEPEER_AUTH_FAILED' as const;
+
+export function isLivepeerConfigured(): boolean {
+  return Boolean(resolveLivepeerStudioAuthToken());
+}

--- a/lib/utils/map-in-batches.ts
+++ b/lib/utils/map-in-batches.ts
@@ -1,0 +1,19 @@
+/** Run async work in fixed-size parallel batches to limit concurrency. */
+export async function mapInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (batchSize < 1) {
+    throw new RangeError('batchSize must be at least 1');
+  }
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(
+      batch.map((item, j) => fn(item, i + j)),
+    );
+    results.push(...batchResults);
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- Unify Livepeer Studio auth (`LIVEPEER_FULL_API_KEY` with `LIVEPEER_API_KEY` fallback) via lazy SDK init and shared `studioAuth` helpers.
- Harden playback-info and asset routes with stable `503`/`502` error codes and fetch fallbacks when the SDK is unavailable.
- Stop sync-views from returning 500 when Livepeer view metrics fail; return DB `views_count` with `livepeerSynced: false` instead.
- Reduce Discover load: batch playback-info fetches (4 at a time) and skip view sync when playback sources are missing.

## Test plan
- [ ] `curl` production/preview: `/api/livepeer/playback-info`, `/api/video-assets/sync-views/{id}`, `/api/livepeer/views/{id}` return 200 for a valid playback ID
- [ ] Open `/discover` — videos play (not posters only); no flood of sync-views 500s in console
- [ ] Home hero and trending row load (`HeroSection`, `TopVideos`)
- [ ] Run `npx vitest run app/api/livepeer/views.test.ts app/api/video-assets/sync-views/[playbackId]/route.test.ts`


Made with [Cursor](https://cursor.com)