### PR TITLE
feat(auth): hide Orb app deep link on desktop

### DIFF
--- a/components/auth/OrbLoginModal.tsx
+++ b/components/auth/OrbLoginModal.tsx
@@ -116,7 +116,7 @@ export function OrbLoginModal() {
             </div>
           )}
           {deepLink && !displayError && (
-            <Button variant="outline" size="sm" asChild>
+            <Button variant="outline" size="sm" className="lg:hidden" asChild>
               <a href={deepLink} target="_blank" rel="noopener noreferrer">
                 Open in Orb app
               </a>


### PR DESCRIPTION
## Summary

- Hide the “Open in Orb app” deep link on viewports from the Tailwind `lg` breakpoint upward (desktop), since Orb is mobile-only and desktop users rely on the QR flow.
- Keep the deep link visible below `lg` so phones and typical tablets can still open the native app via the universal link.

## Test plan

- [ ] Open “Link Lens with Orb” at width `<1024px`: deep link button still appears when available.
- [ ] Open the same modal at width `≥1024px`: QR and copy unchanged; deep link button absent.

Made with [Cursor](https://cursor.com)