### PR TITLE
fix: harden Livepeer view metrics parsing and livestream UI display

### DIFF
--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -5,6 +5,10 @@ import {
   resolveLivepeerStudioAuthToken,
 } from '@/lib/sdk/livepeer/studioAuth';
 
+vi.mock('@/lib/sdk/livepeer/fullClient', () => ({
+  getFullLivepeer: vi.fn(() => null),
+}));
+
 describe('Livepeer view metrics helpers', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -76,6 +80,22 @@ describe('Livepeer view metrics helpers', () => {
         playtimeMins: 34,
         legacyViewCount: 5,
       },
+    });
+  });
+
+  it('returns upstream_error when Livepeer responds with errors in JSON body', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({ errors: [['id not provided', 'Account not found']] }),
+      ),
+    );
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: false,
+      reason: 'upstream_error',
+      status: 200,
     });
   });
 

--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -22,6 +22,13 @@ describe('Livepeer view metrics helpers', () => {
     expect(resolveLivepeerStudioAuthToken()).toBe('full-key');
   });
 
+  it('strips surrounding quotes from Livepeer API keys', () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', '"quoted-full-key"');
+    vi.stubEnv('LIVEPEER_API_KEY', '');
+
+    expect(resolveLivepeerStudioAuthToken()).toBe('quoted-full-key');
+  });
+
   it('normalizes the Studio API base URL', () => {
     vi.stubEnv('LIVEPEER_FULL_API_URL', 'https://livepeer.example/');
 

--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -83,6 +83,33 @@ describe('Livepeer view metrics helpers', () => {
     });
   });
 
+  it('falls back to viewership query when total endpoint returns zero views', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/query/total/')) {
+        return Response.json({ playbackId: 'playback-1', viewCount: 0, playtimeMins: 0 });
+      }
+      if (url.includes('/query?')) {
+        return Response.json([
+          { playbackId: 'playback-1', viewCount: 3, playtimeMins: 1.5 },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 3,
+        playtimeMins: 1.5,
+        legacyViewCount: 0,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns upstream_error when Livepeer responds with errors in JSON body', async () => {
     vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
     vi.stubGlobal(

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -30,9 +30,10 @@ export type FetchAllViewsResult =
     };
 
 function getSdkErrorStatus(error: unknown): number | undefined {
-  if (error && typeof error === 'object' && 'statusCode' in error) {
-    const status = Number((error as { statusCode: number }).statusCode);
-    return Number.isFinite(status) ? status : undefined;
+  if (error && typeof error === 'object') {
+    const obj = error as Record<string, unknown>;
+    const status = Number(obj.statusCode ?? obj.status);
+    if (Number.isFinite(status)) return status;
   }
   if (error instanceof Error) {
     const match = error.message.match(/Status (\d{3})/);

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -3,6 +3,7 @@ import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
 import {
   hasLivepeerErrors,
   parseLivepeerViewMetricsBody,
+  type ParsedViewMetrics,
 } from '@/lib/livepeer/parse-view-metrics';
 import {
   livepeerStudioApiBaseUrl,
@@ -42,58 +43,187 @@ function getSdkErrorStatus(error: unknown): number | undefined {
   return undefined;
 }
 
-async function fetchAllViewsViaHttp(
-  playbackId: string,
+function isZeroMetrics(metrics: ParsedViewMetrics): boolean {
+  return (
+    metrics.viewCount === 0 &&
+    metrics.legacyViewCount === 0 &&
+    metrics.playtimeMins === 0
+  );
+}
+
+function toLivepeerViewMetrics(parsed: ParsedViewMetrics): LivepeerViewMetrics {
+  return {
+    playbackId: parsed.playbackId,
+    viewCount: parsed.viewCount,
+    playtimeMins: parsed.playtimeMins,
+    legacyViewCount: parsed.legacyViewCount,
+  };
+}
+
+async function livepeerAuthedGet(
+  path: string,
   token: string,
-): Promise<FetchAllViewsResult> {
+): Promise<
+  | { ok: true; status: number; rawData: unknown }
+  | { ok: false; status: number }
+> {
   const myHeaders = new Headers();
   myHeaders.append('Authorization', `Bearer ${token}`);
 
   const base = livepeerStudioApiBaseUrl();
-  const response = await fetch(
-    `${base}/api/data/views/query/total/${encodeURIComponent(playbackId)}`,
-    {
-      method: 'GET',
-      headers: myHeaders,
-      redirect: 'follow',
-      cache: 'no-store',
-    },
-  );
+  const response = await fetch(`${base}${path}`, {
+    method: 'GET',
+    headers: myHeaders,
+    redirect: 'follow',
+    cache: 'no-store',
+  });
 
   if (!response.ok) {
-    serverLogger.warn(
-      `Livepeer views API ${response.status} for playbackId=${playbackId}`,
-    );
-    return {
-      ok: false,
-      reason: 'upstream_error',
-      status: response.status,
-    };
+    return { ok: false, status: response.status };
   }
 
   const rawData = await response.json();
-
   if (hasLivepeerErrors(rawData)) {
+    return { ok: false, status: response.status };
+  }
+
+  return { ok: true, status: response.status, rawData };
+}
+
+async function fetchTotalViewsViaHttp(
+  playbackId: string,
+  token: string,
+): Promise<FetchAllViewsResult> {
+  const result = await livepeerAuthedGet(
+    `/api/data/views/query/total/${encodeURIComponent(playbackId)}`,
+    token,
+  );
+
+  if (!result.ok) {
     serverLogger.warn(
-      `Livepeer views API returned errors for playbackId=${playbackId}`,
+      `Livepeer total views API ${result.status} for playbackId=${playbackId}`,
     );
     return {
       ok: false,
       reason: 'upstream_error',
-      status: response.status,
+      status: result.status,
     };
   }
 
-  const parsed = parseLivepeerViewMetricsBody(rawData, playbackId);
+  const parsed = parseLivepeerViewMetricsBody(result.rawData, playbackId);
   if (!parsed) {
     return {
       ok: false,
       reason: 'upstream_error',
-      status: response.status,
+      status: result.status,
     };
   }
 
-  return { ok: true, metrics: parsed };
+  return { ok: true, metrics: toLivepeerViewMetrics(parsed) };
+}
+
+/** Studio dashboard can show views before the /total endpoint reflects them. */
+async function fetchViewershipQueryViaHttp(
+  playbackId: string,
+  token: string,
+): Promise<FetchAllViewsResult> {
+  const params = new URLSearchParams({
+    playbackId,
+    from: new Date(0).toISOString(),
+    to: new Date().toISOString(),
+  });
+
+  const result = await livepeerAuthedGet(
+    `/api/data/views/query?${params.toString()}`,
+    token,
+  );
+
+  if (!result.ok) {
+    serverLogger.warn(
+      `Livepeer viewership query API ${result.status} for playbackId=${playbackId}`,
+    );
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status: result.status,
+    };
+  }
+
+  const parsed = parseLivepeerViewMetricsBody(result.rawData, playbackId);
+  if (!parsed) {
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status: result.status,
+    };
+  }
+
+  return { ok: true, metrics: toLivepeerViewMetrics(parsed) };
+}
+
+async function fetchAllViewsViaHttp(
+  playbackId: string,
+  token: string,
+): Promise<FetchAllViewsResult> {
+  const totalResult = await fetchTotalViewsViaHttp(playbackId, token);
+  if (!totalResult.ok) {
+    return totalResult;
+  }
+
+  if (!isZeroMetrics(totalResult.metrics)) {
+    return totalResult;
+  }
+
+  const queryResult = await fetchViewershipQueryViaHttp(playbackId, token);
+  if (queryResult.ok && !isZeroMetrics(queryResult.metrics)) {
+    serverLogger.debug(
+      `Livepeer viewership query fallback used for playbackId=${playbackId} (total=0, query=${queryResult.metrics.viewCount + queryResult.metrics.legacyViewCount})`,
+    );
+    return queryResult;
+  }
+
+  return totalResult;
+}
+
+async function fetchTotalViewsViaSdk(
+  playbackId: string,
+): Promise<FetchAllViewsResult | null> {
+  const client = getFullLivepeer();
+  if (!client) return null;
+
+  try {
+    const response = await client.metrics.getPublicViewership(playbackId);
+
+    if (response.data) {
+      const parsed = parseLivepeerViewMetricsBody(response.data, playbackId);
+      if (parsed) {
+        return { ok: true, metrics: toLivepeerViewMetrics(parsed) };
+      }
+    }
+
+    if (response.error) {
+      serverLogger.warn(
+        `Livepeer SDK view metrics error for playbackId=${playbackId}`,
+      );
+      return {
+        ok: false,
+        reason: 'upstream_error',
+        status: response.statusCode,
+      };
+    }
+  } catch (error) {
+    const status = getSdkErrorStatus(error);
+    serverLogger.warn(
+      `Livepeer SDK view metrics failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
+    );
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status,
+    };
+  }
+
+  return null;
 }
 
 export const fetchAllViews = async (
@@ -107,40 +237,12 @@ export const fetchAllViews = async (
     return { ok: false, reason: 'not_configured' };
   }
 
-  const client = getFullLivepeer();
-
-  if (client) {
-    try {
-      const response = await client.metrics.getPublicViewership(playbackId);
-
-      if (response.data) {
-        const parsed = parseLivepeerViewMetricsBody(response.data, playbackId);
-        if (parsed) {
-          return { ok: true, metrics: parsed };
-        }
-      }
-
-      if (response.error) {
-        serverLogger.warn(
-          `Livepeer SDK view metrics error for playbackId=${playbackId}`,
-        );
-        return {
-          ok: false,
-          reason: 'upstream_error',
-          status: response.statusCode,
-        };
-      }
-    } catch (error) {
-      const status = getSdkErrorStatus(error);
-      serverLogger.warn(
-        `Livepeer SDK view metrics failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
-      );
-      return {
-        ok: false,
-        reason: 'upstream_error',
-        status,
-      };
-    }
+  const sdkResult = await fetchTotalViewsViaSdk(playbackId);
+  if (sdkResult?.ok && !isZeroMetrics(sdkResult.metrics)) {
+    return sdkResult;
+  }
+  if (sdkResult && !sdkResult.ok) {
+    return sdkResult;
   }
 
   try {

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -1,4 +1,9 @@
 import { serverLogger } from '@/lib/utils/logger';
+import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import {
+  hasLivepeerErrors,
+  parseLivepeerViewMetricsBody,
+} from '@/lib/livepeer/parse-view-metrics';
 import {
   livepeerStudioApiBaseUrl,
   resolveLivepeerStudioAuthToken,
@@ -24,6 +29,72 @@ export type FetchAllViewsResult =
       status?: number;
     };
 
+function getSdkErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'statusCode' in error) {
+    const status = Number((error as { statusCode: number }).statusCode);
+    return Number.isFinite(status) ? status : undefined;
+  }
+  if (error instanceof Error) {
+    const match = error.message.match(/Status (\d{3})/);
+    if (match) return Number(match[1]);
+  }
+  return undefined;
+}
+
+async function fetchAllViewsViaHttp(
+  playbackId: string,
+  token: string,
+): Promise<FetchAllViewsResult> {
+  const myHeaders = new Headers();
+  myHeaders.append('Authorization', `Bearer ${token}`);
+
+  const base = livepeerStudioApiBaseUrl();
+  const response = await fetch(
+    `${base}/api/data/views/query/total/${encodeURIComponent(playbackId)}`,
+    {
+      method: 'GET',
+      headers: myHeaders,
+      redirect: 'follow',
+      cache: 'no-store',
+    },
+  );
+
+  if (!response.ok) {
+    serverLogger.warn(
+      `Livepeer views API ${response.status} for playbackId=${playbackId}`,
+    );
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status: response.status,
+    };
+  }
+
+  const rawData = await response.json();
+
+  if (hasLivepeerErrors(rawData)) {
+    serverLogger.warn(
+      `Livepeer views API returned errors for playbackId=${playbackId}`,
+    );
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status: response.status,
+    };
+  }
+
+  const parsed = parseLivepeerViewMetricsBody(rawData, playbackId);
+  if (!parsed) {
+    return {
+      ok: false,
+      reason: 'upstream_error',
+      status: response.status,
+    };
+  }
+
+  return { ok: true, metrics: parsed };
+}
+
 export const fetchAllViews = async (
   playbackId: string,
 ): Promise<FetchAllViewsResult> => {
@@ -35,47 +106,44 @@ export const fetchAllViews = async (
     return { ok: false, reason: 'not_configured' };
   }
 
-  const myHeaders = new Headers();
-  myHeaders.append('Authorization', `Bearer ${token}`);
+  const client = getFullLivepeer();
 
-  const requestOptions = {
-    method: 'GET' as const,
-    headers: myHeaders,
-    redirect: 'follow' as const,
-    cache: 'no-store' as const,
-  };
+  if (client) {
+    try {
+      const response = await client.metrics.getPublicViewership(playbackId);
 
-  try {
-    const base = livepeerStudioApiBaseUrl();
-    const response = await fetch(
-      `${base}/api/data/views/query/total/${encodeURIComponent(playbackId)}`,
-      requestOptions,
-    );
+      if (response.data) {
+        const parsed = parseLivepeerViewMetricsBody(response.data, playbackId);
+        if (parsed) {
+          return { ok: true, metrics: parsed };
+        }
+      }
 
-    if (!response.ok) {
+      if (response.error) {
+        serverLogger.warn(
+          `Livepeer SDK view metrics error for playbackId=${playbackId}`,
+        );
+        return {
+          ok: false,
+          reason: 'upstream_error',
+          status: response.statusCode,
+        };
+      }
+    } catch (error) {
+      const status = getSdkErrorStatus(error);
       serverLogger.warn(
-        `Livepeer views API ${response.status} for playbackId=${playbackId}`,
+        `Livepeer SDK view metrics failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
       );
       return {
         ok: false,
         reason: 'upstream_error',
-        status: response.status,
+        status,
       };
     }
+  }
 
-    const rawData = await response.json();
-    const metricsObj = Array.isArray(rawData) ? rawData[0] : rawData;
-    const targetMetrics = metricsObj || {};
-
-    return {
-      ok: true,
-      metrics: {
-        playbackId: String(targetMetrics.playbackId ?? playbackId),
-        viewCount: Number(targetMetrics.viewCount ?? 0) || 0,
-        playtimeMins: Number(targetMetrics.playtimeMins ?? 0) || 0,
-        legacyViewCount: Number(targetMetrics.legacyViewCount ?? 0) || 0,
-      },
-    };
+  try {
+    return await fetchAllViewsViaHttp(playbackId, token);
   } catch (error) {
     serverLogger.error('Failed to fetch view metrics:', error);
     return { ok: false, reason: 'network_error' };

--- a/app/api/livepeer/views/[playbackId]/route.ts
+++ b/app/api/livepeer/views/[playbackId]/route.ts
@@ -8,10 +8,7 @@ import {
 } from '@/lib/livepeer/view-count';
 import { getStoredViewsCount } from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
-import {
-  LIVEPEER_AUTH_FAILED,
-  LIVEPEER_NOT_CONFIGURED,
-} from '@/lib/sdk/livepeer/studioAuth';
+import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -40,6 +37,9 @@ export async function GET(
       );
     }
 
+    const supabase = createServiceClient();
+    const dbViewCount = await getStoredViewsCount(supabase, playbackId);
+
     const viewsResult = await fetchAllViews(playbackId);
     const livepeerAvailable = viewsResult.ok;
     const livepeerTotal = viewsResult.ok
@@ -47,6 +47,23 @@ export async function GET(
       : 0;
 
     if (!viewsResult.ok && viewsResult.reason === 'not_configured') {
+      if (dbViewCount > 0) {
+        return NextResponse.json(
+          {
+            success: true,
+            source: 'database' as const,
+            playbackId,
+            totalViews: dbViewCount,
+            viewCount: dbViewCount,
+            playtimeMins: 0,
+            legacyViewCount: 0,
+            livepeerAvailable: false,
+            code: LIVEPEER_NOT_CONFIGURED,
+          },
+          { headers: noStoreHeaders },
+        );
+      }
+
       return NextResponse.json(
         {
           error: 'Livepeer is not configured',
@@ -56,22 +73,6 @@ export async function GET(
       );
     }
 
-    if (
-      !viewsResult.ok &&
-      viewsResult.reason === 'upstream_error' &&
-      (viewsResult.status === 401 || viewsResult.status === 403)
-    ) {
-      return NextResponse.json(
-        {
-          error: 'Livepeer authentication failed',
-          code: LIVEPEER_AUTH_FAILED,
-        },
-        { status: 502, headers: noStoreHeaders },
-      );
-    }
-
-    const supabase = createServiceClient();
-    const dbViewCount = await getStoredViewsCount(supabase, playbackId);
     const displayTotal = mergeViewCounts(dbViewCount, livepeerTotal);
     const source = resolveViewCountSource(livepeerTotal, dbViewCount);
 
@@ -80,6 +81,7 @@ export async function GET(
         success: true,
         source,
         playbackId,
+        totalViews: displayTotal,
         viewCount: displayTotal,
         playtimeMins: viewsResult.ok ? viewsResult.metrics.playtimeMins : 0,
         legacyViewCount: 0,

--- a/app/api/livepeer/views/realtime/[playbackId]/route.ts
+++ b/app/api/livepeer/views/realtime/[playbackId]/route.ts
@@ -3,6 +3,7 @@ import {
   livepeerStudioApiBaseUrl,
   resolveLivepeerStudioAuthToken,
 } from '@/lib/sdk/livepeer/studioAuth';
+import { hasLivepeerErrors } from '@/lib/livepeer/parse-view-metrics';
 import { serverLogger } from '@/lib/utils/logger';
 
 export const dynamic = 'force-dynamic';
@@ -60,6 +61,15 @@ export async function GET(
     }
 
     const data = await response.json();
+
+    if (hasLivepeerErrors(data)) {
+      serverLogger.warn(`Livepeer real-time views API returned errors for playbackId=${playbackId}`);
+      return NextResponse.json(
+        { error: 'Failed to fetch real-time viewership', code: 'UPSTREAM_ERROR' },
+        { status: 502, headers: noStoreHeaders },
+      );
+    }
+
     const stats = Array.isArray(data) ? data : [];
     
     // Sum viewCount from returned dimensions (should match our playbackId query filter)

--- a/app/api/video-assets/sync-views/[playbackId]/route.test.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.test.ts
@@ -85,6 +85,34 @@ describe('sync-views POST security', () => {
     );
   });
 
+  it('returns stored view count when Livepeer auth fails', async () => {
+    mockFetchAllViews.mockResolvedValue({
+      ok: false,
+      reason: 'upstream_error',
+      status: 401,
+    });
+    mockGetStoredViewsCount.mockResolvedValue(42);
+
+    const request = new NextRequest(
+      'http://localhost/api/video-assets/sync-views/playback-1',
+      { method: 'GET' },
+    );
+
+    const response = await GET(request, {
+      params: Promise.resolve({ playbackId: 'playback-1' }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({
+      success: true,
+      playbackId: 'playback-1',
+      viewCount: 42,
+      livepeerSynced: false,
+      code: 'LIVEPEER_VIEWS_UNAVAILABLE',
+    });
+  });
+
   it('returns stored view count when Livepeer metrics are unavailable', async () => {
     mockFetchAllViews.mockResolvedValue({
       ok: false,

--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -85,19 +85,11 @@ async function syncViewsForPlayback(
       serverLogger.warn(
         `View sync auth failed for ${playbackId}: falling back to stored count`,
       );
-
-      return NextResponse.json({
-        success: true,
-        playbackId,
-        viewCount: storedCount,
-        livepeerSynced: false,
-        code: 'LIVEPEER_VIEWS_UNAVAILABLE',
-      });
+    } else {
+      serverLogger.warn(
+        `View sync skipped for ${playbackId}: Livepeer metrics unavailable (${viewsResult.reason})`,
+      );
     }
-
-    serverLogger.warn(
-      `View sync skipped for ${playbackId}: Livepeer metrics unavailable (${viewsResult.reason})`,
-    );
 
     return NextResponse.json({
       success: true,

--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -12,7 +12,6 @@ import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import {
   LIVEPEER_NOT_CONFIGURED,
-  LIVEPEER_AUTH_FAILED,
 } from '@/lib/sdk/livepeer/studioAuth';
 
 function syncViewsErrorResponse(error: unknown) {
@@ -83,13 +82,17 @@ async function syncViewsForPlayback(
       viewsResult.reason === 'upstream_error' &&
       (viewsResult.status === 401 || viewsResult.status === 403)
     ) {
-      return NextResponse.json(
-        {
-          error: 'Livepeer authentication failed',
-          code: LIVEPEER_AUTH_FAILED,
-        },
-        { status: 502 },
+      serverLogger.warn(
+        `View sync auth failed for ${playbackId}: falling back to stored count`,
       );
+
+      return NextResponse.json({
+        success: true,
+        playbackId,
+        viewCount: storedCount,
+        livepeerSynced: false,
+        code: 'LIVEPEER_VIEWS_UNAVAILABLE',
+      });
     }
 
     serverLogger.warn(

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { RealtimeViewsComponent } from "@/components/Player/RealtimeViewsComponent";
+import { ViewsComponent } from "@/components/Player/ViewsComponent";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -272,8 +273,9 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                       Broadcasting Live
                     </p>
                   </div>
-                  {/* Realtime concurrent viewers */}
+                  {/* Total + realtime concurrent viewers */}
                   <div className="flex items-center gap-4">
+                    {playbackId && <ViewsComponent playbackId={playbackId} />}
                     {playbackId && <RealtimeViewsComponent playbackId={playbackId} />}
                   </div>
                 </div>

--- a/lib/hooks/livepeer/useLivepeerViewMetrics.test.ts
+++ b/lib/hooks/livepeer/useLivepeerViewMetrics.test.ts
@@ -14,6 +14,7 @@ describe("fetchLivepeerViewMetrics", () => {
         Response.json({
           success: true,
           playbackId: "playback-1",
+          totalViews: 5,
           viewCount: 3,
           playtimeMins: 10,
           legacyViewCount: 2,
@@ -26,6 +27,7 @@ describe("fetchLivepeerViewMetrics", () => {
       viewCount: 3,
       playtimeMins: 10,
       legacyViewCount: 2,
+      totalViews: 5,
     });
   });
 

--- a/lib/hooks/livepeer/useLivepeerViewMetrics.ts
+++ b/lib/hooks/livepeer/useLivepeerViewMetrics.ts
@@ -7,6 +7,7 @@ export interface LivepeerViewMetrics {
   viewCount: number;
   playtimeMins: number;
   legacyViewCount: number;
+  totalViews: number;
 }
 
 interface UseLivepeerViewMetricsOptions {
@@ -59,6 +60,10 @@ export async function fetchLivepeerViewMetrics(
     viewCount: Number(data.viewCount ?? 0) || 0,
     playtimeMins: Number(data.playtimeMins ?? 0) || 0,
     legacyViewCount: Number(data.legacyViewCount ?? 0) || 0,
+    totalViews:
+      Number(data.totalViews ?? 0) ||
+      (Number(data.viewCount ?? 0) || 0) +
+        (Number(data.legacyViewCount ?? 0) || 0),
   };
 }
 
@@ -85,6 +90,7 @@ export function useLivepeerViewMetrics(
 
   const viewMetrics = query.data ?? null;
   const totalViews =
+    viewMetrics?.totalViews ??
     (viewMetrics?.viewCount ?? 0) + (viewMetrics?.legacyViewCount ?? 0);
 
   const errorMsg =

--- a/lib/livepeer/parse-view-metrics.test.ts
+++ b/lib/livepeer/parse-view-metrics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasLivepeerErrors,
+  parseLivepeerViewMetricsBody,
+} from './parse-view-metrics';
+
+describe('parseLivepeerViewMetricsBody', () => {
+  it('parses a single object response', () => {
+    expect(
+      parseLivepeerViewMetricsBody(
+        {
+          playbackId: 'p1',
+          viewCount: 12,
+          playtimeMins: 34,
+          legacyViewCount: 5,
+        },
+        'p1',
+      ),
+    ).toEqual({
+      playbackId: 'p1',
+      viewCount: 12,
+      playtimeMins: 34,
+      legacyViewCount: 5,
+    });
+  });
+
+  it('sums metrics when Livepeer returns an array', () => {
+    expect(
+      parseLivepeerViewMetricsBody(
+        [
+          { viewCount: 8, playtimeMins: 10 },
+          { viewCount: 4, playtimeMins: 6, legacyViewCount: 2 },
+        ],
+        'p1',
+      ),
+    ).toEqual({
+      playbackId: 'p1',
+      viewCount: 12,
+      playtimeMins: 16,
+      legacyViewCount: 2,
+    });
+  });
+
+  it('returns zero metrics for an empty array', () => {
+    expect(parseLivepeerViewMetricsBody([], 'p1')).toEqual({
+      playbackId: 'p1',
+      viewCount: 0,
+      playtimeMins: 0,
+      legacyViewCount: 0,
+    });
+  });
+
+  it('unwraps SDK-style data payloads', () => {
+    expect(
+      parseLivepeerViewMetricsBody(
+        { data: { playbackId: 'p1', viewCount: 9, playtimeMins: 1 } },
+        'p1',
+      ),
+    ).toEqual({
+      playbackId: 'p1',
+      viewCount: 9,
+      playtimeMins: 1,
+      legacyViewCount: 0,
+    });
+  });
+
+  it('returns null for Livepeer error payloads', () => {
+    expect(
+      parseLivepeerViewMetricsBody({ errors: [['id not provided']] }, 'p1'),
+    ).toBeNull();
+    expect(hasLivepeerErrors({ errors: ['no token found'] })).toBe(true);
+  });
+});

--- a/lib/livepeer/parse-view-metrics.ts
+++ b/lib/livepeer/parse-view-metrics.ts
@@ -1,0 +1,83 @@
+export type ParsedViewMetrics = {
+  playbackId: string;
+  viewCount: number;
+  playtimeMins: number;
+  legacyViewCount: number;
+};
+
+/** Livepeer error payloads may appear in JSON even when HTTP status is 200. */
+export function hasLivepeerErrors(rawData: unknown): boolean {
+  if (!rawData || typeof rawData !== 'object') return false;
+  const errors = (rawData as { errors?: unknown }).errors;
+  if (errors == null) return false;
+  if (Array.isArray(errors)) return errors.length > 0;
+  return true;
+}
+
+/**
+ * Normalize Livepeer viewership payloads (object, array, or SDK `{ data }` wrapper).
+ */
+export function parseLivepeerViewMetricsBody(
+  rawData: unknown,
+  playbackId: string,
+): ParsedViewMetrics | null {
+  if (rawData == null) return null;
+
+  if (hasLivepeerErrors(rawData)) return null;
+
+  if (
+    typeof rawData === 'object' &&
+    'data' in rawData &&
+    (rawData as { data?: unknown }).data != null &&
+    typeof (rawData as { data?: unknown }).data === 'object'
+  ) {
+    return parseLivepeerViewMetricsBody(
+      (rawData as { data: unknown }).data,
+      playbackId,
+    );
+  }
+
+  if (Array.isArray(rawData)) {
+    if (rawData.length === 0) {
+      return {
+        playbackId,
+        viewCount: 0,
+        playtimeMins: 0,
+        legacyViewCount: 0,
+      };
+    }
+
+    const items = rawData.filter(
+      (item): item is Record<string, unknown> =>
+        item != null && typeof item === 'object',
+    );
+
+    return {
+      playbackId,
+      viewCount: items.reduce(
+        (sum, item) => sum + (Number(item.viewCount ?? 0) || 0),
+        0,
+      ),
+      playtimeMins: items.reduce(
+        (sum, item) => sum + (Number(item.playtimeMins ?? 0) || 0),
+        0,
+      ),
+      legacyViewCount: items.reduce(
+        (sum, item) => sum + (Number(item.legacyViewCount ?? 0) || 0),
+        0,
+      ),
+    };
+  }
+
+  if (typeof rawData === 'object') {
+    const record = rawData as Record<string, unknown>;
+    return {
+      playbackId: String(record.playbackId ?? playbackId),
+      viewCount: Number(record.viewCount ?? 0) || 0,
+      playtimeMins: Number(record.playtimeMins ?? 0) || 0,
+      legacyViewCount: Number(record.legacyViewCount ?? 0) || 0,
+    };
+  }
+
+  return null;
+}

--- a/lib/sdk/livepeer/studioAuth.ts
+++ b/lib/sdk/livepeer/studioAuth.ts
@@ -1,7 +1,14 @@
+/** Strip whitespace and optional surrounding quotes from env values. */
+export function normalizeEnvSecret(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^["']|["']$/g, '') || undefined;
+}
+
 /** Prefer full-access key for Studio routes; fall back to LIVEPEER_API_KEY. */
 export function resolveLivepeerStudioAuthToken(): string | undefined {
-  const full = process.env.LIVEPEER_FULL_API_KEY?.trim();
-  const standard = process.env.LIVEPEER_API_KEY?.trim();
+  const full = normalizeEnvSecret(process.env.LIVEPEER_FULL_API_KEY);
+  const standard = normalizeEnvSecret(process.env.LIVEPEER_API_KEY);
   return full || standard || undefined;
 }
 


### PR DESCRIPTION
## Summary
- Add robust Livepeer viewership response parsing for object, array, SDK-wrapped, and error payloads
- Use the Livepeer SDK for total views with HTTP fallback, and fall back to stored Supabase counts when Studio auth/config fails
- Show cumulative total views alongside realtime concurrent viewers on livestream watch pages

## Test plan
- [ ] Verify `npm test -- app/api/livepeer/views.test.ts lib/livepeer/parse-view-metrics.test.ts lib/hooks/livepeer/useLivepeerViewMetrics.test.ts app/api/video-assets/sync-views/ app/api/livepeer/views/realtime/` passes
- [ ] Confirm a valid `LIVEPEER_FULL_API_KEY` returns updated view counts on video cards and discover pages
- [ ] Open a live stream watch page and confirm both total views and "X watching" update
- [ ] Confirm invalid/expired Livepeer keys show stored DB counts instead of hard errors in the UI


Made with [Cursor](https://cursor.com)