### PR TITLE
Pass explicit playbackId to Livepeer players for view metrics

### DIFF
--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -259,6 +259,7 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                 <div className="aspect-video bg-black rounded-lg overflow-hidden">
                   <Player
                     src={status.sources}
+                    playbackId={playbackId}
                     title={videoTitle || streamData?.name || "Live Stream"}
                     jwt={jwt}
                   />

--- a/components/Player/DemoPlayer.tsx
+++ b/components/Player/DemoPlayer.tsx
@@ -7,10 +7,11 @@ import { useVideo } from '../../context/VideoContext';
 import './Player.css';
 import { safelyPauseVideo } from '@/lib/utils/video-controls';
 
-export const DemoPlayer: React.FC<{ src: Src[] | null; title: string }> = ({
-  src,
-  title,
-}) => {
+export const DemoPlayer: React.FC<{
+  src: Src[] | null;
+  title: string;
+  playbackId?: string;
+}> = ({ src, title, playbackId }) => {
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -68,7 +69,7 @@ export const DemoPlayer: React.FC<{ src: Src[] | null; title: string }> = ({
   };
 
   return (
-    <Player.Root src={src} autoPlay volume={0}>
+    <Player.Root src={src} playbackId={playbackId} autoPlay volume={0}>
       <Player.Container 
         ref={containerRef}
         className="player-container relative aspect-video touch-none"

--- a/components/Player/HeroPlayer.tsx
+++ b/components/Player/HeroPlayer.tsx
@@ -7,10 +7,11 @@ import { useVideo } from '../../context/VideoContext';
 import './Player.css';
 import { safelyPauseVideo } from '@/lib/utils/video-controls';
 
-export const HeroPlayer: React.FC<{ src: Src[] | null; title: string }> = ({
-  src,
-  title,
-}) => {
+export const HeroPlayer: React.FC<{
+  src: Src[] | null;
+  title: string;
+  playbackId?: string;
+}> = ({ src, title, playbackId }) => {
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -68,7 +69,7 @@ export const HeroPlayer: React.FC<{ src: Src[] | null; title: string }> = ({
   };
 
   return (
-    <Player.Root src={src} autoPlay volume={0}>
+    <Player.Root src={src} playbackId={playbackId} autoPlay volume={0}>
       <Player.Container 
         ref={containerRef}
         className="hero-player-container relative aspect-video touch-none"

--- a/components/Player/OrbisPlayer.tsx
+++ b/components/Player/OrbisPlayer.tsx
@@ -112,7 +112,7 @@ export function OrbisPlayer({
   }
 
   return (
-    <Player.Root src={playbackSources} volume={0}>
+    <Player.Root src={playbackSources} playbackId={playbackId} volume={0}>
       <Player.Container
         ref={containerRef}
         className="player-container relative aspect-video touch-none"

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -33,11 +33,12 @@ export const PlayerLoading: React.FC<{ title: string }> = ({ title }) => {
 export function Player(props: {
   src: Src[] | null;
   title: string;
+  playbackId?: string;
   assetId?: string;
   jwt?: string;
   onPlay?: () => void;
 }) {
-  const { src, title, assetId, jwt, onPlay } = props;
+  const { src, title, playbackId, assetId, jwt, onPlay } = props;
 
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
@@ -129,6 +130,7 @@ export function Player(props: {
   return (
     <LivepeerPlayer.Root
       src={src}
+      playbackId={playbackId}
       jwt={jwt}
       autoPlay={true} // Autoplay for live streams
       volume={0.5} // Start unmuted but low volume if possible, or muted if browser blocks

--- a/components/Player/PreviewPlayer.tsx
+++ b/components/Player/PreviewPlayer.tsx
@@ -195,6 +195,7 @@ export const PreviewPlayer: React.FC<{
     >
       <Player.Root
         src={src}
+        playbackId={playbackIdProp || getPlaybackId(src) || undefined}
         autoPlay={false}
         volume={0}
         aspectRatio={16 / 9}

--- a/components/Player/TrendingPlayer.tsx
+++ b/components/Player/TrendingPlayer.tsx
@@ -121,7 +121,11 @@ export const TrendingPlayer: React.FC<{
 
   return (
     <SubtitlesProvider>
-      <Player.Root src={src} volume={0}>
+      <Player.Root
+        src={src}
+        playbackId={assetMetadata?.playbackId}
+        volume={0}
+      >
         <Player.Container
           ref={containerRef}
           className="player-container relative h-full w-full touch-none"

--- a/components/Videos/Detail/Detail.tsx
+++ b/components/Videos/Detail/Detail.tsx
@@ -2,7 +2,9 @@
 import { useEffect, useState } from "react";
 import { Player } from "@/components/Player/Player";
 import { Asset } from "livepeer/models/components";
+import { Src } from "@livepeer/react";
 import { fullLivepeer } from "@/lib/sdk/livepeer/fullClient";
+import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
 import VideoViewMetrics from "@/components/Videos/VideoViewMetrics";
 import { Skeleton } from "@/components/ui/skeleton";
 import { logger } from '@/lib/utils/logger';
@@ -14,6 +16,8 @@ export default function VideoDetailsPage({
   params: { slug: string };
 }) {
   const [asset, setAsset] = useState<any>();
+  const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
+  const [sourcesLoading, setSourcesLoading] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [assetLoading, setAssetLoading] = useState(false);
   const [error, setError] = useState("");
@@ -32,6 +36,38 @@ export default function VideoDetailsPage({
 
     fetchVideoDetails();
   }, [asset?.assetId, params.slug]);
+
+  useEffect(() => {
+    if (!asset?.playbackId) {
+      setPlaybackSources(null);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchPlaybackSources = async () => {
+      setSourcesLoading(true);
+      try {
+        const sources = await getDetailPlaybackSource(asset.playbackId);
+        if (!cancelled) {
+          setPlaybackSources(sources);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setPlaybackSources(null);
+          logger.error(err);
+        }
+      } finally {
+        if (!cancelled) {
+          setSourcesLoading(false);
+        }
+      }
+    };
+
+    fetchPlaybackSources();
+    return () => {
+      cancelled = true;
+    };
+  }, [asset?.playbackId]);
 
   const fetchAssetDetails = async (asset: Asset) => {
     setAssetLoading(true);
@@ -58,14 +94,14 @@ export default function VideoDetailsPage({
           )}
 
           <div className="w-full aspect-video flex justify-center items-center bg-black rounded-lg overflow-hidden shadow-md">
-            {isLoading || assetLoading ? (
+            {isLoading || assetLoading || sourcesLoading ? (
               <Skeleton className="w-full h-full rounded-lg" />
             ) : error ? (
               <div className="text-red-500">{error}</div>
             ) : (
               asset && (
                 <Player
-                  src={asset.playbackId}
+                  src={playbackSources}
                   playbackId={asset.playbackId}
                   title={asset?.name}
                 />

--- a/components/Videos/Detail/Detail.tsx
+++ b/components/Videos/Detail/Detail.tsx
@@ -63,7 +63,13 @@ export default function VideoDetailsPage({
             ) : error ? (
               <div className="text-red-500">{error}</div>
             ) : (
-              asset && <Player src={asset.playbackId} title={asset?.name} />
+              asset && (
+                <Player
+                  src={asset.playbackId}
+                  playbackId={asset.playbackId}
+                  title={asset?.name}
+                />
+              )
             )}
           </div>
           {asset?.playbackId && (

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -553,7 +553,11 @@ export default function VideoDetails({
             </div>
           ) : playbackSources ? (
             <>
-              <Player.Root src={playbackSources} {...conditionalProps}>
+              <Player.Root
+                src={playbackSources}
+                playbackId={asset?.playbackId}
+                {...conditionalProps}
+              >
                 <Player.Container className="aspect-video w-full overflow-hidden rounded-lg bg-gray-800">
                   <Player.Video
                     title={asset?.name}

--- a/components/home-page/HeroSection.tsx
+++ b/components/home-page/HeroSection.tsx
@@ -34,6 +34,9 @@ const PlayIcon = (props: React.SVGProps<SVGSVGElement>) => {
 const HeroSection: React.FC = () => {
   const router = useRouter();
   const [src, setSrc] = useState<Src[] | null>(null);
+  const [heroPlaybackId, setHeroPlaybackId] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,8 +62,11 @@ const HeroSection: React.FC = () => {
         if (!isMounted || signal.aborted) return;
 
         const hasSource =
-          Array.isArray(playbackSource) && playbackSource.length > 0;
-        setSrc(hasSource ? playbackSource : null);
+          playbackSource != null &&
+          Array.isArray(playbackSource.src) &&
+          playbackSource.src.length > 0;
+        setSrc(hasSource ? playbackSource.src : null);
+        setHeroPlaybackId(hasSource ? playbackSource.playbackId : undefined);
         if (!hasSource) {
           setError("No video source available.");
         }
@@ -133,7 +139,11 @@ const HeroSection: React.FC = () => {
             ) : (
               <div className="relative touch-none">
                 {src ? (
-                  <HeroPlayer src={src} title={HERO_VIDEO_TITLE} />
+                  <HeroPlayer
+                    src={src}
+                    title={HERO_VIDEO_TITLE}
+                    playbackId={heroPlaybackId}
+                  />
                 ) : (
                   <div className="text-center p-4 bg-red-100 rounded-lg">
                     No video source available.

--- a/lib/hooks/livepeer/useHeroPlaybackSource.ts
+++ b/lib/hooks/livepeer/useHeroPlaybackSource.ts
@@ -4,7 +4,12 @@ import { LIVEPEER_HERO_PLAYBACK_ID, HERO_VIDEO_ASSET_ID } from "../../../context
 import { logger } from '@/lib/utils/logger';
 
 
-export const getHeroPlaybackSource = async (): Promise<Src[] | null> => {
+export type HeroPlaybackSource = {
+  src: Src[];
+  playbackId: string;
+};
+
+export const getHeroPlaybackSource = async (): Promise<HeroPlaybackSource | null> => {
   try {
     // First, try to fetch the asset by asset ID via our API route (server-side, avoids CORS)
     let playbackId: string | null = null;
@@ -38,7 +43,10 @@ export const getHeroPlaybackSource = async (): Promise<Src[] | null> => {
 
     const playbackInfo = await playbackResponse.json();
     const src = getSrc(playbackInfo) as Src[];
-    return src;
+    if (!src?.length) {
+      return null;
+    }
+    return { src, playbackId };
   } catch (error) {
     logger.error("Error fetching playback source:", error);
     return null;


### PR DESCRIPTION
## Summary
- Pass explicit `playbackId` to every `Player.Root` / `LivepeerPlayer.Root` instance so Livepeer can register viewership events reliably
- Thread `playbackId` through shared `Player`, watch, discover, hero, and preview player call sites
- Update `getHeroPlaybackSource` to return `{ src, playbackId }` for the homepage hero player

## Test plan
- [ ] Play a VOD on `/discover/[id]` and confirm no console warning: `Not sending metrics since no playback ID parsed.`
- [ ] Play a live stream on `/watch/[playbackId]` and verify metrics network requests fire
- [ ] Confirm homepage hero video still loads and plays
- [ ] Wait ~5 minutes after playback, then verify view count updates via `/api/livepeer/views/[playbackId]`


Made with [Cursor](https://cursor.com)