### PR TITLE
fix: fetch view counts via Livepeer metrics.getViewership SDK

### DIFF
--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -36,7 +36,7 @@ describe('Livepeer view metrics helpers', () => {
     expect(livepeerStudioApiBaseUrl()).toBe('https://livepeer.example');
   });
 
-  it('prefers SDK getViewership when configured', async () => {
+  it('prefers SDK getViewership when a private API key is configured', async () => {
     vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
     const getViewership = vi.fn(async () => ({
       data: [
@@ -69,6 +69,68 @@ describe('Livepeer view metrics helpers', () => {
       to: expect.any(Date),
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips SDK getViewership and uses HTTP when only a standard API key is configured', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', '');
+    vi.stubEnv('LIVEPEER_API_KEY', 'standard-key');
+    const getViewership = vi.fn();
+    vi.mocked(getFullLivepeer).mockReturnValue({
+      metrics: { getViewership },
+    } as never);
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        playbackId: 'playback-1',
+        viewCount: 4,
+        playtimeMins: 1,
+        legacyViewCount: 0,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 4,
+        playtimeMins: 1,
+        legacyViewCount: 0,
+      },
+    });
+    expect(getViewership).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('falls back to HTTP when SDK getViewership fails', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    const getViewership = vi.fn(async () => ({
+      error: { message: 'upstream unavailable' },
+      statusCode: 500,
+    }));
+    vi.mocked(getFullLivepeer).mockReturnValue({
+      metrics: { getViewership },
+    } as never);
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        playbackId: 'playback-1',
+        viewCount: 9,
+        playtimeMins: 2,
+        legacyViewCount: 0,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 9,
+        playtimeMins: 2,
+        legacyViewCount: 0,
+      },
+    });
+    expect(getViewership).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   it('fetches view metrics without using cache (single object response)', async () => {

--- a/app/api/livepeer/views.test.ts
+++ b/app/api/livepeer/views.test.ts
@@ -4,6 +4,7 @@ import {
   livepeerStudioApiBaseUrl,
   resolveLivepeerStudioAuthToken,
 } from '@/lib/sdk/livepeer/studioAuth';
+import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
 
 vi.mock('@/lib/sdk/livepeer/fullClient', () => ({
   getFullLivepeer: vi.fn(() => null),
@@ -33,6 +34,41 @@ describe('Livepeer view metrics helpers', () => {
     vi.stubEnv('LIVEPEER_FULL_API_URL', 'https://livepeer.example/');
 
     expect(livepeerStudioApiBaseUrl()).toBe('https://livepeer.example');
+  });
+
+  it('prefers SDK getViewership when configured', async () => {
+    vi.stubEnv('LIVEPEER_FULL_API_KEY', 'full-key');
+    const getViewership = vi.fn(async () => ({
+      data: [
+        {
+          playbackId: 'playback-1',
+          viewCount: 7,
+          playtimeMins: 2.5,
+        },
+      ],
+      statusCode: 200,
+    }));
+    vi.mocked(getFullLivepeer).mockReturnValue({
+      metrics: { getViewership },
+    } as never);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchAllViews('playback-1')).resolves.toEqual({
+      ok: true,
+      metrics: {
+        playbackId: 'playback-1',
+        viewCount: 7,
+        playtimeMins: 2.5,
+        legacyViewCount: 0,
+      },
+    });
+    expect(getViewership).toHaveBeenCalledWith({
+      playbackId: 'playback-1',
+      from: expect.any(Date),
+      to: expect.any(Date),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('fetches view metrics without using cache (single object response)', async () => {

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -185,14 +185,18 @@ async function fetchAllViewsViaHttp(
   return totalResult;
 }
 
-async function fetchTotalViewsViaSdk(
+async function fetchViewsViaSdk(
   playbackId: string,
 ): Promise<FetchAllViewsResult | null> {
   const client = getFullLivepeer();
   if (!client) return null;
 
   try {
-    const response = await client.metrics.getPublicViewership(playbackId);
+    const response = await client.metrics.getViewership({
+      playbackId,
+      from: new Date(0),
+      to: new Date(),
+    });
 
     if (response.data) {
       const parsed = parseLivepeerViewMetricsBody(response.data, playbackId);
@@ -203,7 +207,7 @@ async function fetchTotalViewsViaSdk(
 
     if (response.error) {
       serverLogger.warn(
-        `Livepeer SDK view metrics error for playbackId=${playbackId}`,
+        `Livepeer SDK getViewership error for playbackId=${playbackId}`,
       );
       return {
         ok: false,
@@ -214,7 +218,7 @@ async function fetchTotalViewsViaSdk(
   } catch (error) {
     const status = getSdkErrorStatus(error);
     serverLogger.warn(
-      `Livepeer SDK view metrics failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
+      `Livepeer SDK getViewership failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
     );
     return {
       ok: false,
@@ -237,7 +241,7 @@ export const fetchAllViews = async (
     return { ok: false, reason: 'not_configured' };
   }
 
-  const sdkResult = await fetchTotalViewsViaSdk(playbackId);
+  const sdkResult = await fetchViewsViaSdk(playbackId);
   if (sdkResult?.ok && !isZeroMetrics(sdkResult.metrics)) {
     return sdkResult;
   }

--- a/app/api/livepeer/views.ts
+++ b/app/api/livepeer/views.ts
@@ -6,6 +6,7 @@ import {
   type ParsedViewMetrics,
 } from '@/lib/livepeer/parse-view-metrics';
 import {
+  hasLivepeerPrivateApiKey,
   livepeerStudioApiBaseUrl,
   resolveLivepeerStudioAuthToken,
 } from '@/lib/sdk/livepeer/studioAuth';
@@ -29,6 +30,10 @@ export type FetchAllViewsResult =
       reason: 'not_configured' | 'upstream_error' | 'network_error';
       status?: number;
     };
+
+function isSdkAuthFailure(status?: number): boolean {
+  return status === 401 || status === 403;
+}
 
 function getSdkErrorStatus(error: unknown): number | undefined {
   if (error && typeof error === 'object') {
@@ -206,6 +211,12 @@ async function fetchViewsViaSdk(
     }
 
     if (response.error) {
+      if (isSdkAuthFailure(response.statusCode)) {
+        serverLogger.debug(
+          `Livepeer SDK getViewership auth rejected for playbackId=${playbackId}, will try HTTP fallback`,
+        );
+        return null;
+      }
       serverLogger.warn(
         `Livepeer SDK getViewership error for playbackId=${playbackId}`,
       );
@@ -217,6 +228,12 @@ async function fetchViewsViaSdk(
     }
   } catch (error) {
     const status = getSdkErrorStatus(error);
+    if (isSdkAuthFailure(status)) {
+      serverLogger.debug(
+        `Livepeer SDK getViewership auth rejected for playbackId=${playbackId}, will try HTTP fallback`,
+      );
+      return null;
+    }
     serverLogger.warn(
       `Livepeer SDK getViewership failed for playbackId=${playbackId}: ${error instanceof Error ? error.message : error}`,
     );
@@ -241,12 +258,16 @@ export const fetchAllViews = async (
     return { ok: false, reason: 'not_configured' };
   }
 
-  const sdkResult = await fetchViewsViaSdk(playbackId);
+  const sdkResult = hasLivepeerPrivateApiKey()
+    ? await fetchViewsViaSdk(playbackId)
+    : null;
   if (sdkResult?.ok && !isZeroMetrics(sdkResult.metrics)) {
     return sdkResult;
   }
   if (sdkResult && !sdkResult.ok) {
-    return sdkResult;
+    serverLogger.debug(
+      `Livepeer SDK getViewership unavailable (status=${sdkResult.status ?? 'unknown'}), falling back to HTTP for playbackId=${playbackId}`,
+    );
   }
 
   try {

--- a/lib/sdk/livepeer/studioAuth.ts
+++ b/lib/sdk/livepeer/studioAuth.ts
@@ -12,6 +12,11 @@ export function resolveLivepeerStudioAuthToken(): string | undefined {
   return full || standard || undefined;
 }
 
+/** Private (non-CORS) key required for metrics.getViewership. */
+export function hasLivepeerPrivateApiKey(): boolean {
+  return Boolean(normalizeEnvSecret(process.env.LIVEPEER_FULL_API_KEY));
+}
+
 export function livepeerStudioApiBaseUrl(): string {
   const raw =
     process.env.LIVEPEER_FULL_API_URL?.trim() || 'https://livepeer.studio';


### PR DESCRIPTION
## Summary
- Switch the server-side SDK path from `metrics.getPublicViewership` to `metrics.getViewership` with `playbackId`, `from`, and `to` so totals align with Livepeer Studio viewership metrics
- Keep existing HTTP fallbacks (`/query/total` and `/query`) when the SDK returns zero or fails
- Add a unit test confirming the SDK `getViewership` path is preferred when configured

## Test plan
- [ ] Run `npx vitest run app/api/livepeer/views.test.ts`
- [ ] Verify `GET /api/livepeer/views/{playbackId}` returns non-zero counts for a video with known Studio viewership
- [ ] Confirm view counts still display on video detail and watch pages
- [ ] Confirm fallback behavior when `LIVEPEER_FULL_API_KEY` is unset (database-only counts)


Made with [Cursor](https://cursor.com)