### PR TITLE
Fix membership menu skeleton and show Buy Membership CTA

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -519,7 +519,7 @@ export default function Navbar() {
 
                       {/* Membership Status Section */}
                       <div className="mt-4">
-                        <MembershipSection />
+                        <MembershipSection onNavigate={handleLinkClick} />
                       </div>
 
                       {isVerified && hasMembership && (

--- a/components/account-dropdown/MembershipSection.tsx
+++ b/components/account-dropdown/MembershipSection.tsx
@@ -52,11 +52,11 @@ function BuyMembershipCta({
       <p className="text-xs text-muted-foreground">
         View pricing and purchase Unlock memberships on Base with USDC.
       </p>
-      <Link href="/memberships" className="w-full block" onClick={onNavigate}>
-        <Button className="w-full bg-black hover:bg-gray-900 text-white">
+      <Button asChild className="w-full bg-black hover:bg-gray-900 text-white">
+        <Link href="/memberships" className="w-full" onClick={onNavigate}>
           Buy Membership
-        </Button>
-      </Link>
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/components/account-dropdown/MembershipSection.tsx
+++ b/components/account-dropdown/MembershipSection.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -12,9 +14,11 @@ import {
   type LockAddressValue,
 } from "../../lib/sdk/unlock/services";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useUser } from "@account-kit/react";
 
 interface MembershipSectionProps {
   className?: string;
+  onNavigate?: () => void;
 }
 
 const MEMBERSHIP_NAMES: Record<LockAddressValue, string> = {
@@ -36,7 +40,32 @@ const ERROR_MESSAGES: Record<string, string> = {
   DEFAULT: "An error occurred while verifying membership.",
 };
 
-export function MembershipSection({ className }: MembershipSectionProps) {
+function BuyMembershipCta({
+  className,
+  onNavigate,
+}: {
+  className?: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <div className={`space-y-2 ${className || ""}`}>
+      <p className="text-xs text-muted-foreground">
+        View pricing and purchase Unlock memberships on Base with USDC.
+      </p>
+      <Link href="/memberships" className="w-full block" onClick={onNavigate}>
+        <Button className="w-full bg-black hover:bg-gray-900 text-white">
+          Buy Membership
+        </Button>
+      </Link>
+    </div>
+  );
+}
+
+export function MembershipSection({
+  className,
+  onNavigate,
+}: MembershipSectionProps) {
+  const user = useUser();
   const { isVerified, hasMembership, isLoading, error, membershipDetails } =
     useMembershipVerification();
 
@@ -59,17 +88,33 @@ export function MembershipSection({ className }: MembershipSectionProps) {
   if (error) {
     const errorMessage = ERROR_MESSAGES[error.code] || ERROR_MESSAGES.DEFAULT;
     return (
-      <div className="p-4 space-y-4">
+      <div className={`px-2 py-2 space-y-2 ${className || ""}`}>
         <Alert variant="destructive">
           <AlertTriangle className="h-4 w-4" />
           <AlertDescription>{errorMessage}</AlertDescription>
         </Alert>
-        <LoginWithEthereumButton />
+        {user ? (
+          <BuyMembershipCta onNavigate={onNavigate} />
+        ) : (
+          <LoginWithEthereumButton />
+        )}
       </div>
     );
   }
 
   if (!isVerified) {
+    if (user) {
+      return (
+        <div className={`px-2 py-2 space-y-2 ${className || ""}`}>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <ShieldX className="h-4 w-4" />
+            <span>No active membership</span>
+          </div>
+          <BuyMembershipCta onNavigate={onNavigate} />
+        </div>
+      );
+    }
+
     return (
       <div className="p-4 space-y-4">
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -88,11 +133,7 @@ export function MembershipSection({ className }: MembershipSectionProps) {
           <LockKeyhole className="h-4 w-4" />
           <span>No active membership</span>
         </div>
-        <Link href="/memberships" className="w-full block">
-          <Button className="w-full bg-black hover:bg-gray-900 text-white">
-            Get Membership
-          </Button>
-        </Link>
+        <BuyMembershipCta onNavigate={onNavigate} />
       </div>
     );
   }
@@ -107,7 +148,7 @@ export function MembershipSection({ className }: MembershipSectionProps) {
         <div className="space-y-2">
           {membershipDetails
             .filter(({ isValid }: MembershipDetails) => isValid)
-            .map(({ name, address, lock }: MembershipDetails) => (
+            .map(({ address, lock }: MembershipDetails) => (
               <div
                 key={address}
                 className="flex items-center justify-between text-xs"

--- a/components/auth/MembershipGuard.tsx
+++ b/components/auth/MembershipGuard.tsx
@@ -33,6 +33,7 @@ export function MembershipGuard({ children }: MembershipGuardProps) {
     '/profile',
     '/upload',
     '/creator',
+    '/memberships',
   ];
 
   const isPublicPath = PUBLIC_PATHS.some(path => pathname?.startsWith(path));

--- a/lib/hooks/unlock/useMembershipVerification.ts
+++ b/lib/hooks/unlock/useMembershipVerification.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser } from "@account-kit/react";
 
 import {
   unlockService,
@@ -34,12 +34,10 @@ export interface MembershipStatus {
 export function useMembershipVerification() {
   const user = useUser();
   const {
-    client,
-    address: clientAddress,
-    isLoadingClient,
-  } = useSmartAccountClient({});
-  const { address: modularAddress, loading: isModularLoading } =
-    useModularAccount();
+    smartAccountClient: client,
+    address: modularAddress,
+    loading: isModularLoading,
+  } = useModularAccount();
 
   const [status, setStatus] = useState<MembershipStatus>({
     isVerified: false,
@@ -100,8 +98,8 @@ export function useMembershipVerification() {
         }
 
         const scaAddress =
-          client?.account?.address ?? clientAddress ?? modularAddress ?? null;
-        const waitingForClient = isLoadingClient || isModularLoading;
+          client?.account?.address ?? modularAddress ?? null;
+        const waitingForClient = isModularLoading;
 
         if (!scaAddress) {
           if (waitingForClient) {
@@ -139,9 +137,7 @@ export function useMembershipVerification() {
     user?.address,
     user?.type,
     client?.account?.address,
-    clientAddress,
     modularAddress,
-    isLoadingClient,
     isModularLoading,
     verifyMembership,
   ]);

--- a/lib/hooks/unlock/useMembershipVerification.ts
+++ b/lib/hooks/unlock/useMembershipVerification.ts
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useUser, useSmartAccountClient } from "@account-kit/react";
-import type { UseSmartAccountClientResult } from "@account-kit/react";
-import { logger } from '@/lib/utils/logger';
 
 import {
   unlockService,
@@ -12,6 +10,7 @@ import {
   type MembershipError,
   fetchLockAndKey,
 } from "../../sdk/unlock/services";
+import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 
 export interface MembershipDetails {
   name: LockAddress;
@@ -34,7 +33,14 @@ export interface MembershipStatus {
 
 export function useMembershipVerification() {
   const user = useUser();
-  const accountKit = useSmartAccountClient({});
+  const {
+    client,
+    address: clientAddress,
+    isLoadingClient,
+  } = useSmartAccountClient({});
+  const { address: modularAddress, loading: isModularLoading } =
+    useModularAccount();
+
   const [status, setStatus] = useState<MembershipStatus>({
     isVerified: false,
     hasMembership: false,
@@ -45,15 +51,8 @@ export function useMembershipVerification() {
   const verifyMembership = useCallback(
     async (address: string, walletType: "eoa" | "sca") => {
       try {
-        // Get all memberships using Unlock Protocol's Web3Service
         const memberships = await unlockService.getAllMemberships(address);
-
         const hasMembership = memberships.some(({ isValid }) => isValid);
-
-        // Log valid memberships for debugging
-        if (hasMembership) {
-          const validMemberships = memberships.filter(({ isValid }) => isValid);
-        }
 
         setStatus({
           isVerified: true,
@@ -82,7 +81,6 @@ export function useMembershipVerification() {
 
   useEffect(() => {
     const checkMembership = async () => {
-      // If no user address is available (not logged in), reset status
       const userAddress = user?.address;
 
       if (!userAddress) {
@@ -96,32 +94,35 @@ export function useMembershipVerification() {
       }
 
       try {
-        // For EOA users, check their address directly
         if (user?.type === "eoa") {
           await verifyMembership(userAddress, "eoa");
           return;
         }
 
-        // For Account Kit users, check the SCA address
-        const scaAddress = accountKit?.client?.account?.address;
+        const scaAddress =
+          client?.account?.address ?? clientAddress ?? modularAddress ?? null;
+        const waitingForClient = isLoadingClient || isModularLoading;
 
         if (!scaAddress) {
+          if (waitingForClient) {
+            setStatus((prev) => ({ ...prev, isLoading: true }));
+            return;
+          }
+
+          setStatus({
+            isVerified: false,
+            hasMembership: false,
+            isLoading: false,
+            error: {
+              name: "Error",
+              message: "No valid address found for verification",
+              code: "NO_VALID_ADDRESS",
+            } as MembershipError,
+          });
           return;
         }
 
         await verifyMembership(scaAddress, "sca");
-        return;
-
-        setStatus({
-          isVerified: false,
-          hasMembership: false,
-          isLoading: false,
-          error: {
-            name: "Error",
-            message: "No valid address found for verification",
-            code: "NO_VALID_ADDRESS",
-          } as MembershipError,
-        });
       } catch (error) {
         const membershipError = error as MembershipError;
         setStatus({
@@ -133,9 +134,17 @@ export function useMembershipVerification() {
       }
     };
 
-    checkMembership();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.address, user?.type, accountKit?.client?.account?.address, verifyMembership]);
+    void checkMembership();
+  }, [
+    user?.address,
+    user?.type,
+    client?.account?.address,
+    clientAddress,
+    modularAddress,
+    isLoadingClient,
+    isModularLoading,
+    verifyMembership,
+  ]);
 
   return status;
 }
@@ -164,9 +173,6 @@ export function useUnlockNFT({
       .finally(() => setIsLoading(false));
   }, [lockAddress, userAddress, network]);
 
-  const DEBUG = process.env.NODE_ENV === "development";
-  if (DEBUG) logger.debug("message", data);
-
   return { data, isLoading, error };
 }
 
@@ -174,7 +180,7 @@ interface UseUnlockNFTApiParams {
   lockAddress: string;
   userAddress: string;
   network: number;
-  enabled?: boolean; // Optional: only fetch if true
+  enabled?: boolean;
 }
 
 interface UnlockNFTApiResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The mobile/account menu membership block was stuck on skeleton loaders because `useMembershipVerification` only read `client.account.address` and returned early when it was missing, even though Account Kit exposes `address` on the hook directly.

This PR fixes address resolution (matching `MembershipHome`) and ensures users without a valid Unlock pass see a **Buy Membership** button that routes to `/memberships` for Base pricing and USDC purchase.

## Changes

- **`useMembershipVerification`**: Resolve SCA address via `client?.account?.address ?? clientAddress ?? modularAddress`; stop infinite loading when the client finishes initializing.
- **`MembershipSection`**: Shared `BuyMembershipCta` linking to `/memberships` with short Base/USDC copy; show for connected users without membership or on verification errors.
- **`MembershipGuard`**: Add `/memberships` to public paths so non-members can open the purchase page.
- **`Navbar`**: Close mobile menu when navigating to memberships.

## Test plan

- [ ] Connect wallet on Base, open mobile menu → membership section shows "No active membership" + **Buy Membership** (not skeleton).
- [ ] Tap **Buy Membership** → `/memberships` loads with Creator / Investor / Brand tiers.
- [ ] User with active pass still sees verified member state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d2dde14-f33b-4d49-94fc-deeff218bedc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d2dde14-f33b-4d49-94fc-deeff218bedc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

