### PR TITLE
Fix Vercel build: Lens AnyClient and AnyPost types in Songchain

### DIFF
--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import type { AnyClient } from "@lens-protocol/client";
 import {
   fetchGroup,
   fetchGroupMembers,
@@ -30,7 +31,7 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
     if (!groupId) return;
     setLoading(true);
     try {
-      let client = publicClient;
+      let client: AnyClient = publicClient;
       if (canWrite) {
         client = await getSessionClient();
       }

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -62,7 +62,7 @@ export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardP
 
   useEffect(() => {
     setUpvoted(hasReacted);
-  }, [hasReacted, post.id]);
+  }, [hasReacted, content.id]);
   const imageUrl = postImage(post);
   const reactions = content.stats?.upvotes ?? 0;
 
@@ -76,7 +76,7 @@ export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardP
     setPending(true);
     try {
       const client = await getSessionClient();
-      const id = postId(post.id);
+      const id = postId(content.id);
       const result = upvoted
         ? await undoReaction(client, { post: id, reaction: 'UPVOTE' })
         : await addReaction(client, { post: id, reaction: 'UPVOTE' });

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -15,17 +15,22 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
 
+/** Lens feed items may be reposts; read metadata from the underlying post. */
+function resolvePost(post: AnyPost) {
+  return post.__typename === "Repost" ? post.repostOf : post;
+}
+
 function postText(post: AnyPost): string {
-  const meta = post.metadata;
-  if (!meta || meta.__typename === '%other') return '';
+  const meta = resolvePost(post).metadata;
+  if (!meta) return '';
   if ('content' in meta && typeof meta.content === 'string') return meta.content;
   if ('title' in meta && typeof meta.title === 'string') return meta.title;
   return '';
 }
 
 function postImage(post: AnyPost): string | null {
-  const meta = post.metadata;
-  if (!meta || meta.__typename === '%other') return null;
+  const meta = resolvePost(post).metadata;
+  if (!meta) return null;
   if ('image' in meta && meta.image?.item) {
     return resolveOrbMediaUrl(String(meta.image.item));
   }
@@ -49,7 +54,8 @@ type SongchainPostCardProps = {
 export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardProps) {
   const { canWrite, getSessionClient, promptWriteAccess } = useLensOrbWrite();
   const [pending, setPending] = useState(false);
-  const ops = 'operations' in post ? post.operations : null;
+  const content = resolvePost(post);
+  const ops = "operations" in content ? content.operations : null;
   const hasReacted =
     ops != null && 'hasReacted' in ops && ops.hasReacted === true;
   const [upvoted, setUpvoted] = useState(hasReacted);
@@ -58,7 +64,7 @@ export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardP
     setUpvoted(hasReacted);
   }, [hasReacted, post.id]);
   const imageUrl = postImage(post);
-  const reactions = post.stats?.reactions ?? 0;
+  const reactions = content.stats?.upvotes ?? 0;
 
   const toggleUpvote = async () => {
     if (!canWrite) {
@@ -107,7 +113,7 @@ export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardP
         )}
         <div className="mt-auto flex items-center justify-between gap-2 pt-2 border-t border-border/40">
           <span className="text-xs text-muted-foreground">
-            {reactions} reaction{reactions === 1 ? '' : 's'}
+            {reactions} upvote{reactions === 1 ? '' : 's'}
           </span>
           <Button
             type="button"

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AnyClient } from '@lens-protocol/client';
 import { fetchPosts } from '@lens-protocol/client/actions';
 import { evmAddress } from '@lens-protocol/types';
 import type { AnyPost } from '@lens-protocol/graphql';
@@ -27,7 +28,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
       setLoading(true);
       setError(null);
       try {
-        let client = publicClient;
+        let client: AnyClient = publicClient;
         if (canWrite) {
           client = await getSessionClient();
         }
@@ -47,7 +48,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
         cursorRef.current = page.pageInfo.next ?? null;
         setHasMore(Boolean(page.pageInfo.next));
         setPosts((prev) =>
-          mode === 'append' ? [...prev, ...page.items] : page.items,
+          mode === 'append' ? [...prev, ...page.items] : [...page.items],
         );
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load feed');

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -47,9 +47,16 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
         const page = result.value;
         cursorRef.current = page.pageInfo.next ?? null;
         setHasMore(Boolean(page.pageInfo.next));
-        setPosts((prev) =>
-          mode === 'append' ? [...prev, ...page.items] : [...page.items],
-        );
+        setPosts((prev) => {
+          const combined =
+            mode === 'append' ? [...prev, ...page.items] : [...page.items];
+          const seen = new Set<string>();
+          return combined.filter((item) => {
+            if (seen.has(item.id)) return false;
+            seen.add(item.id);
+            return true;
+          });
+        });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load feed');
       } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Vercel production build failed during TypeScript checking:

```
Type 'SessionClient<Context>' is missing the following properties from type 'PublicClient<Context>'
```

in `SongchainGroupPanel.tsx` when assigning `getSessionClient()` to a variable inferred as `PublicClient`.

## Solution

- Type Lens read clients as `AnyClient` (`PublicClient | SessionClient`) in `SongchainGroupPanel` and `useSongchainFeed`, matching what `fetchGroup` / `fetchPosts` expect.
- Fix related Songchain typing issues:
  - Copy paginated feed items into a mutable array for React state.
  - Resolve `Repost` items to their `repostOf` post for metadata/stats display.
  - Use `stats.upvotes` instead of the non-existent `stats.reactions` field.

## Files changed

- `components/songchain/SongchainGroupPanel.tsx`
- `components/songchain/SongchainPostCard.tsx`
- `hooks/useSongchainFeed.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc76b07-9483-496f-bd46-6eff091064b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc76b07-9483-496f-bd46-6eff091064b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

