### PR TITLE
fix(songchain): runtime env, Halliday Payments SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,11 +124,16 @@ NEXT_PUBLIC_IPFS_GATEWAY=
 NEXT_PUBLIC_GROVE_API_URL=
 
 # --- Songchain (Lens feeds + group on /songchain) ---
+# Use NEXT_PUBLIC_* for client bundles; server-only aliases also work at runtime on /songchain.
 NEXT_PUBLIC_SONGCHAIN_FEED_ID=
 NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID=
 NEXT_PUBLIC_SONGCHAIN_GROUP_ID=
+# SONGCHAIN_FEED_ID=
+# SONGCHAIN_EXCLUSIVE_FEED_ID=
+# SONGCHAIN_GROUP_ID=
 # Halliday onramp for GHO on Lens Chain — https://lens.xyz/docs/chain/tools/on-ramp/halliday
 NEXT_PUBLIC_HALLIDAY_API_KEY=
+# HALLIDAY_API_KEY=
 # Optional override (default: Lens wrapped gas token / GHO)
 # NEXT_PUBLIC_HALLIDAY_DESTINATION_TOKEN=
 

--- a/.env.example
+++ b/.env.example
@@ -131,10 +131,15 @@ NEXT_PUBLIC_SONGCHAIN_GROUP_ID=
 # SONGCHAIN_FEED_ID=
 # SONGCHAIN_EXCLUSIVE_FEED_ID=
 # SONGCHAIN_GROUP_ID=
-# Halliday onramp for GHO on Lens Chain — https://lens.xyz/docs/chain/tools/on-ramp/halliday
+# Halliday Payments SDK — https://docs.halliday.xyz/pages/payments-sdk-docs
 NEXT_PUBLIC_HALLIDAY_API_KEY=
 # HALLIDAY_API_KEY=
-# Optional override (default: Lens wrapped gas token / GHO)
+# Optional: full output asset id (chain:address), e.g. lens:0x000000000000000000000000000000000000800a
+# NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET=
+# Optional chain slug if Halliday uses a different id (defaults: lens / lens-testnet)
+# NEXT_PUBLIC_HALLIDAY_CHAIN_SLUG=
+# NEXT_PUBLIC_HALLIDAY_SANDBOX=true
+# Optional token override when building output asset
 # NEXT_PUBLIC_HALLIDAY_DESTINATION_TOKEN=
 
 # --- Optional / feature flags ---

--- a/app/api/songchain/status/route.ts
+++ b/app/api/songchain/status/route.ts
@@ -1,0 +1,9 @@
+import { getSongchainConfig } from '@/lib/songchain/config';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { enabled } = getSongchainConfig();
+  return NextResponse.json({ enabled });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
-"use client";
-
 import NonLoggedInView from '@/components/home-page/NonLoggedInView';
+import { getSongchainConfig } from '@/lib/songchain/config';
+
+export const dynamic = 'force-dynamic';
 
 export default function Home() {
+  const { enabled: songchainEnabled } = getSongchainConfig();
+
   return (
     <main className="flex min-h-screen flex-col">
-      <NonLoggedInView />
+      <NonLoggedInView songchainEnabled={songchainEnabled} />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,9 @@
 import NonLoggedInView from '@/components/home-page/NonLoggedInView';
-import { getSongchainConfig } from '@/lib/songchain/config';
-
-export const dynamic = 'force-dynamic';
 
 export default function Home() {
-  const { enabled: songchainEnabled } = getSongchainConfig();
-
   return (
     <main className="flex min-h-screen flex-col">
-      <NonLoggedInView songchainEnabled={songchainEnabled} />
+      <NonLoggedInView />
     </main>
   );
 }

--- a/app/songchain/page.tsx
+++ b/app/songchain/page.tsx
@@ -1,85 +1,16 @@
-"use client";
-
-import Link from "next/link";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect";
-import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
-import { SongchainGroupPanel } from "@/components/songchain/SongchainGroupPanel";
-import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+import { SongchainPageClient } from "@/components/songchain/SongchainPageClient";
 import { getSongchainConfig } from "@/lib/songchain/config";
-import { Music2 } from "lucide-react";
+import type { Metadata } from "next";
+
+/** Read Songchain env on each request (Vercel runtime vars, not build-time snapshot). */
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Songchain | Creative TV",
+  description: "Music on Lens Chain — feeds, community group, and GHO onramp.",
+};
 
 export default function SongchainPage() {
   const config = getSongchainConfig();
-
-  return (
-    <div className="mx-auto w-full max-w-7xl py-10 px-4 sm:px-6">
-      <nav className="mb-6 text-sm text-muted-foreground">
-        <Link href="/" className="hover:text-foreground">
-          Home
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-foreground">Songchain</span>
-      </nav>
-
-      <header className="relative mb-10 overflow-hidden rounded-xl border border-violet-500/20 bg-gradient-to-br from-violet-950/90 via-fuchsia-950/70 to-slate-950 p-8 sm:p-10">
-        <div className="relative z-10 max-w-2xl">
-          <p className="mb-2 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-violet-300">
-            <Music2 className="h-4 w-4" aria-hidden />
-            Lens · Orb
-          </p>
-          <h1 className="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">
-            Songchain
-          </h1>
-          <p className="mt-3 text-violet-100/80">
-            Music on Lens Chain — public and exclusive feeds, community group, and
-            onramp via Halliday. Interactions require a linked Orb account.
-          </p>
-        </div>
-      </header>
-
-      <div className="mb-8 space-y-6">
-        <SongchainOrbConnect />
-        <HallidayOnramp />
-      </div>
-
-      <Tabs defaultValue="feed" className="space-y-8">
-        <TabsList>
-          <TabsTrigger value="feed">Feed</TabsTrigger>
-          <TabsTrigger value="exclusive">Exclusive</TabsTrigger>
-          <TabsTrigger value="group">Group</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="feed">
-          <SongchainFeedSection
-            title="Songchain feed"
-            description="Posts from the main Songchain Lens feed (Orb)."
-            feedId={config.publicFeedId}
-          />
-        </TabsContent>
-
-        <TabsContent value="exclusive">
-          <SongchainFeedSection
-            title="Exclusive feed"
-            description="Members-only drops and announcements on Lens."
-            feedId={config.exclusiveFeedId}
-          />
-        </TabsContent>
-
-        <TabsContent value="group">
-          <SongchainGroupPanel groupId={config.groupId} />
-        </TabsContent>
-      </Tabs>
-
-      {!config.enabled && (
-        <p className="mt-10 text-center text-sm text-muted-foreground">
-          Configure{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code>,{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID</code>, and{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GROUP_ID</code> with your Lens
-          primitives.
-        </p>
-      )}
-    </div>
-  );
+  return <SongchainPageClient config={config} />;
 }

--- a/components/home-page/NonLoggedInView.tsx
+++ b/components/home-page/NonLoggedInView.tsx
@@ -3,24 +3,20 @@
 import React from "react";
 import HeroSection from "./HeroSection";
 import { SongchainPromoBanner } from "@/components/songchain/SongchainPromoBanner";
-
-type NonLoggedInViewProps = {
-  songchainEnabled?: boolean;
-};
 // import { TopChart } from "./TopChart";
 // import FeaturedVideo from './Featured';
 import { TopVideos } from "./TopVideos";
 import { useAuthStateMonitor } from '@/lib/hooks/accountkit/useAuthStateMonitor';
 import DearCreativePublications from "./DearCreativePublications";
 
-const NonLoggedInView: React.FC<NonLoggedInViewProps> = ({ songchainEnabled = false }) => {
+const NonLoggedInView: React.FC = () => {
   // Monitor auth state for logout/timeout scenarios
   useAuthStateMonitor();
 
   return (
     <div>
       <HeroSection />
-      <SongchainPromoBanner enabled={songchainEnabled} />
+      <SongchainPromoBanner />
       {/* <TopChart /> */}
       {/* <FeaturedVideo /> */}
       <TopVideos />

--- a/components/home-page/NonLoggedInView.tsx
+++ b/components/home-page/NonLoggedInView.tsx
@@ -3,20 +3,24 @@
 import React from "react";
 import HeroSection from "./HeroSection";
 import { SongchainPromoBanner } from "@/components/songchain/SongchainPromoBanner";
+
+type NonLoggedInViewProps = {
+  songchainEnabled?: boolean;
+};
 // import { TopChart } from "./TopChart";
 // import FeaturedVideo from './Featured';
 import { TopVideos } from "./TopVideos";
 import { useAuthStateMonitor } from '@/lib/hooks/accountkit/useAuthStateMonitor';
 import DearCreativePublications from "./DearCreativePublications";
 
-const NonLoggedInView: React.FC = () => {
+const NonLoggedInView: React.FC<NonLoggedInViewProps> = ({ songchainEnabled = false }) => {
   // Monitor auth state for logout/timeout scenarios
   useAuthStateMonitor();
 
   return (
     <div>
       <HeroSection />
-      <SongchainPromoBanner />
+      <SongchainPromoBanner enabled={songchainEnabled} />
       {/* <TopChart /> */}
       {/* <FeaturedVideo /> */}
       <TopVideos />

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -1,45 +1,106 @@
 "use client";
 
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useId, useLayoutEffect, useRef, useState } from "react";
 import { openHalliday } from "@halliday-sdk/commerce";
 import { Button } from "@/components/ui/button";
-import { getSongchainConfig } from "@/lib/songchain/config";
 import { Wallet } from "lucide-react";
 
-export function HallidayOnramp() {
-  const containerId = useId().replace(/:/g, "");
+export type HallidayOnrampProps = {
+  hallidayApiKey: string | null;
+  destinationChainId: number;
+  destinationTokenAddress: string;
+};
+
+export function HallidayOnramp({
+  hallidayApiKey,
+  destinationChainId,
+  destinationTokenAddress,
+}: HallidayOnrampProps) {
+  const reactId = useId().replace(/:/g, "");
+  const containerId = `halliday-onramp-${reactId}`;
+  const containerRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
-  const config = useMemo(() => getSongchainConfig(), []);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleOpen = useCallback(() => {
-    if (!config.hallidayApiKey) return;
+    if (!hallidayApiKey) return;
+    setError(null);
     setOpen(true);
-  }, [config.hallidayApiKey]);
+  }, [hallidayApiKey]);
 
-  useEffect(() => {
-    if (!open || !config.hallidayApiKey) return;
+  useLayoutEffect(() => {
+    if (!open || !hallidayApiKey) return;
 
-    openHalliday({
-      apiKey: config.hallidayApiKey,
-      destinationChainId: config.hallidayDestinationChainId,
-      destinationTokenAddress: config.hallidayDestinationTokenAddress,
-      services: ["ONRAMP"],
-      windowType: "EMBED",
-      targetElementId: containerId,
-    });
+    const target = containerRef.current;
+    if (!target) return;
+
+    let cancelled = false;
+
+    const mountEmbed = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        await openHalliday({
+          apiKey: hallidayApiKey,
+          destinationChainId,
+          destinationTokenAddress,
+          services: ["ONRAMP"],
+          windowType: "EMBED",
+          targetElementId: containerId,
+        });
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Could not load Halliday onramp. Try again or use popup mode.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void mountEmbed();
+
+    return () => {
+      cancelled = true;
+      target.innerHTML = "";
+    };
   }, [
     open,
     containerId,
-    config.hallidayApiKey,
-    config.hallidayDestinationChainId,
-    config.hallidayDestinationTokenAddress,
+    hallidayApiKey,
+    destinationChainId,
+    destinationTokenAddress,
   ]);
 
-  if (!config.hallidayApiKey) {
+  const handlePopup = useCallback(async () => {
+    if (!hallidayApiKey) return;
+    setError(null);
+    try {
+      await openHalliday({
+        apiKey: hallidayApiKey,
+        destinationChainId,
+        destinationTokenAddress,
+        services: ["ONRAMP"],
+        windowType: "POPUP",
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not open Halliday popup.");
+    }
+  }, [hallidayApiKey, destinationChainId, destinationTokenAddress]);
+
+  if (!hallidayApiKey) {
     return (
       <p className="text-sm text-muted-foreground">
         Fund your Lens wallet with GHO via Halliday — set{" "}
-        <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> to enable.
+        <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> (or{" "}
+        <code className="text-xs">HALLIDAY_API_KEY</code> on the server) to enable.
       </p>
     );
   }
@@ -57,16 +118,43 @@ export function HallidayOnramp() {
           </p>
         </div>
         {!open && (
-          <Button type="button" variant="secondary" size="sm" onClick={handleOpen}>
-            Get GHO
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="secondary" size="sm" onClick={handleOpen}>
+              Get GHO
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void handlePopup()}>
+              Open in popup
+            </Button>
+          </div>
         )}
       </div>
+
+      {error && (
+        <p className="mb-3 text-sm text-destructive" role="alert">
+          {error}{" "}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => void handlePopup()}
+          >
+            Try popup
+          </button>
+        </p>
+      )}
+
       {open && (
         <div
+          ref={containerRef}
           id={containerId}
-          className="min-h-[420px] w-full overflow-hidden rounded-md border border-border/40 bg-muted/20"
-        />
+          className="relative min-h-[420px] w-full overflow-hidden rounded-md border border-border/40 bg-muted/20"
+          aria-busy={loading}
+        >
+          {loading && (
+            <p className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+              Loading Halliday…
+            </p>
+          )}
+        </div>
       )}
     </div>
   );

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -1,99 +1,144 @@
 "use client";
 
-import { useCallback, useId, useLayoutEffect, useRef, useState } from "react";
-import { openHalliday } from "@halliday-sdk/commerce";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  destroyClient,
+  initializeClient,
+  openHallidayPayments,
+} from "@halliday-sdk/payments";
+import { connectWalletClient } from "@halliday-sdk/payments/viem";
+import { useAuthModal, useSmartAccountClient, useUser } from "@account-kit/react";
+import type { WalletClient } from "viem";
 import { Button } from "@/components/ui/button";
+import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { Wallet } from "lucide-react";
 
 export type HallidayOnrampProps = {
   hallidayApiKey: string | null;
-  destinationChainId: number;
-  destinationTokenAddress: string;
+  hallidayOutputAsset: string;
+  hallidaySandbox: boolean;
 };
+
+const CONTAINER_ID_PREFIX = "halliday-onramp";
 
 export function HallidayOnramp({
   hallidayApiKey,
-  destinationChainId,
-  destinationTokenAddress,
+  hallidayOutputAsset,
+  hallidaySandbox,
 }: HallidayOnrampProps) {
   const reactId = useId().replace(/:/g, "");
-  const containerId = `halliday-onramp-${reactId}`;
+  const containerId = `${CONTAINER_ID_PREFIX}-${reactId}`;
   const containerRef = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(false);
+
+  const { openAuthModal } = useAuthModal();
+  const user = useUser();
+  const { client: smartAccountClient, address: smartAccountAddress } =
+    useSmartAccountClient({});
+  const { lensAccount } = useLensOrbWrite();
+
+  const [embedOpen, setEmbedOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  const handleOpen = useCallback(() => {
-    if (!hallidayApiKey) return;
-    setError(null);
-    setOpen(true);
-  }, [hallidayApiKey]);
-
-  useLayoutEffect(() => {
-    if (!open || !hallidayApiKey) return;
-
-    const target = containerRef.current;
-    if (!target) return;
-
-    let cancelled = false;
-
-    const mountEmbed = async () => {
-      setLoading(true);
-      setError(null);
-
-      try {
-        await openHalliday({
-          apiKey: hallidayApiKey,
-          destinationChainId,
-          destinationTokenAddress,
-          services: ["ONRAMP"],
-          windowType: "EMBED",
-          targetElementId: containerId,
-        });
-      } catch (err) {
-        if (!cancelled) {
-          setError(
-            err instanceof Error
-              ? err.message
-              : "Could not load Halliday onramp. Try again or use popup mode.",
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void mountEmbed();
-
-    return () => {
-      cancelled = true;
-      target.innerHTML = "";
-    };
+  const destinationAddress = useMemo(() => {
+    return (
+      lensAccount ??
+      smartAccountClient?.account?.address ??
+      smartAccountAddress ??
+      user?.address ??
+      null
+    );
   }, [
-    open,
-    containerId,
-    hallidayApiKey,
-    destinationChainId,
-    destinationTokenAddress,
+    lensAccount,
+    smartAccountClient?.account?.address,
+    smartAccountAddress,
+    user?.address,
   ]);
 
-  const handlePopup = useCallback(async () => {
+  const userWallet = useMemo(() => {
+    if (!smartAccountClient || !destinationAddress) return undefined;
+    return connectWalletClient(
+      () => smartAccountClient as unknown as WalletClient,
+      "HIDE",
+    );
+  }, [smartAccountClient, destinationAddress]);
+
+  const baseParams = useMemo(
+    () => ({
+      apiKey: hallidayApiKey ?? "",
+      outputs: [hallidayOutputAsset],
+      sandbox: hallidaySandbox,
+      destinationAddress: destinationAddress ?? undefined,
+      userWallet,
+      onError: (err: Error) => {
+        setError(err.message || "Halliday widget failed to load.");
+      },
+      onConnectUserWallet: () => openAuthModal(),
+    }),
+    [
+      hallidayApiKey,
+      hallidayOutputAsset,
+      hallidaySandbox,
+      destinationAddress,
+      userWallet,
+      openAuthModal,
+    ],
+  );
+
+  useEffect(() => {
     if (!hallidayApiKey) return;
+
+    initializeClient({
+      ...baseParams,
+      onError: (err) => {
+        setError(err.message || "Halliday failed to preload.");
+      },
+    });
+
+    return () => {
+      destroyClient();
+    };
+  }, [hallidayApiKey, baseParams]);
+
+  const requireWallet = useCallback((): boolean => {
+    if (destinationAddress) return true;
+    setError("Connect your wallet (or link Orb) so Halliday knows where to send GHO.");
+    openAuthModal();
+    return false;
+  }, [destinationAddress, openAuthModal]);
+
+  const openEmbedded = useCallback(() => {
+    if (!hallidayApiKey || !requireWallet()) return;
     setError(null);
+    setEmbedOpen(true);
+  }, [hallidayApiKey, requireWallet]);
+
+  useEffect(() => {
+    if (!embedOpen || !hallidayApiKey || !destinationAddress) return;
+    if (!containerRef.current) return;
+
+    setError(null);
+
     try {
-      await openHalliday({
-        apiKey: hallidayApiKey,
-        destinationChainId,
-        destinationTokenAddress,
-        services: ["ONRAMP"],
-        windowType: "POPUP",
+      openHallidayPayments({
+        ...baseParams,
+        targetElementId: containerId,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not open Halliday popup.");
+      setError(
+        err instanceof Error ? err.message : "Could not open Halliday embed.",
+      );
     }
-  }, [hallidayApiKey, destinationChainId, destinationTokenAddress]);
+  }, [embedOpen, hallidayApiKey, destinationAddress, containerId, baseParams]);
+
+  const openModal = useCallback(() => {
+    if (!hallidayApiKey || !requireWallet()) return;
+    setError(null);
+    try {
+      openHallidayPayments(baseParams);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not open Halliday.");
+    }
+  }, [hallidayApiKey, requireWallet, baseParams]);
 
   if (!hallidayApiKey) {
     return (
@@ -114,16 +159,19 @@ export function HallidayOnramp({
             Fund on Lens Chain
           </h3>
           <p className="text-sm text-muted-foreground">
-            Halliday onramp for GHO on Lens — powered by Alchemy RPC in this app.
+            Halliday onramp for GHO on Lens — destination{" "}
+            {destinationAddress
+              ? `${destinationAddress.slice(0, 6)}…${destinationAddress.slice(-4)}`
+              : "connect wallet"}
           </p>
         </div>
-        {!open && (
+        {!embedOpen && (
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="secondary" size="sm" onClick={handleOpen}>
+            <Button type="button" variant="secondary" size="sm" onClick={openEmbedded}>
               Get GHO
             </Button>
-            <Button type="button" variant="outline" size="sm" onClick={() => void handlePopup()}>
-              Open in popup
+            <Button type="button" variant="outline" size="sm" onClick={openModal}>
+              Open modal
             </Button>
           </div>
         )}
@@ -132,29 +180,24 @@ export function HallidayOnramp({
       {error && (
         <p className="mb-3 text-sm text-destructive" role="alert">
           {error}{" "}
-          <button
-            type="button"
-            className="underline"
-            onClick={() => void handlePopup()}
-          >
-            Try popup
+          <button type="button" className="underline" onClick={openModal}>
+            Try modal
           </button>
         </p>
       )}
 
-      {open && (
+      {!destinationAddress && (
+        <p className="mb-3 text-sm text-amber-200/90">
+          Sign in and connect a wallet so funds arrive at your Lens destination address.
+        </p>
+      )}
+
+      {embedOpen && (
         <div
           ref={containerRef}
           id={containerId}
           className="relative min-h-[420px] w-full overflow-hidden rounded-md border border-border/40 bg-muted/20"
-          aria-busy={loading}
-        >
-          {loading && (
-            <p className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
-              Loading Halliday…
-            </p>
-          )}
-        </div>
+        />
       )}
     </div>
   );

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -44,8 +44,8 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
         <SongchainOrbConnect />
         <HallidayOnramp
           hallidayApiKey={config.hallidayApiKey}
-          destinationChainId={config.hallidayDestinationChainId}
-          destinationTokenAddress={config.hallidayDestinationTokenAddress}
+          hallidayOutputAsset={config.hallidayOutputAsset}
+          hallidaySandbox={config.hallidaySandbox}
         />
       </div>
 

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect";
+import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
+import { SongchainGroupPanel } from "@/components/songchain/SongchainGroupPanel";
+import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+import type { SongchainConfig } from "@/lib/songchain/config";
+import { Music2 } from "lucide-react";
+
+type SongchainPageClientProps = {
+  config: SongchainConfig;
+};
+
+export function SongchainPageClient({ config }: SongchainPageClientProps) {
+  return (
+    <div className="mx-auto w-full max-w-7xl py-10 px-4 sm:px-6">
+      <nav className="mb-6 text-sm text-muted-foreground">
+        <Link href="/" className="hover:text-foreground">
+          Home
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">Songchain</span>
+      </nav>
+
+      <header className="relative mb-10 overflow-hidden rounded-xl border border-violet-500/20 bg-gradient-to-br from-violet-950/90 via-fuchsia-950/70 to-slate-950 p-8 sm:p-10">
+        <div className="relative z-10 max-w-2xl">
+          <p className="mb-2 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-violet-300">
+            <Music2 className="h-4 w-4" aria-hidden />
+            Lens · Orb
+          </p>
+          <h1 className="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">
+            Songchain
+          </h1>
+          <p className="mt-3 text-violet-100/80">
+            Music on Lens Chain — public and exclusive feeds, community group, and
+            onramp via Halliday. Interactions require a linked Orb account.
+          </p>
+        </div>
+      </header>
+
+      <div className="mb-8 space-y-6">
+        <SongchainOrbConnect />
+        <HallidayOnramp
+          hallidayApiKey={config.hallidayApiKey}
+          destinationChainId={config.hallidayDestinationChainId}
+          destinationTokenAddress={config.hallidayDestinationTokenAddress}
+        />
+      </div>
+
+      <Tabs defaultValue="feed" className="space-y-8">
+        <TabsList>
+          <TabsTrigger value="feed">Feed</TabsTrigger>
+          <TabsTrigger value="exclusive">Exclusive</TabsTrigger>
+          <TabsTrigger value="group">Group</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="feed">
+          <SongchainFeedSection
+            title="Songchain feed"
+            description="Posts from the main Songchain Lens feed (Orb)."
+            feedId={config.publicFeedId}
+          />
+        </TabsContent>
+
+        <TabsContent value="exclusive">
+          <SongchainFeedSection
+            title="Exclusive feed"
+            description="Members-only drops and announcements on Lens."
+            feedId={config.exclusiveFeedId}
+          />
+        </TabsContent>
+
+        <TabsContent value="group">
+          <SongchainGroupPanel groupId={config.groupId} />
+        </TabsContent>
+      </Tabs>
+
+      {!config.enabled && (
+        <p className="mt-10 text-center text-sm text-muted-foreground">
+          Configure{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code>,{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID</code>, and{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GROUP_ID</code> with your Lens
+          primitives, then redeploy if you added them after the last build.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/songchain/SongchainPromoBanner.tsx
+++ b/components/songchain/SongchainPromoBanner.tsx
@@ -2,13 +2,15 @@
 
 import Link from "next/link";
 import { Music2 } from "lucide-react";
-import { getSongchainConfig } from "@/lib/songchain/config";
+
+type SongchainPromoBannerProps = {
+  enabled: boolean;
+};
 
 /**
  * Home promo banner — links to the Songchain Lens hub on Creative TV.
  */
-export function SongchainPromoBanner() {
-  const { enabled } = getSongchainConfig();
+export function SongchainPromoBanner({ enabled }: SongchainPromoBannerProps) {
 
   return (
     <div className="w-full max-w-7xl mx-auto py-3 px-4 sm:px-6">

--- a/components/songchain/SongchainPromoBanner.tsx
+++ b/components/songchain/SongchainPromoBanner.tsx
@@ -1,16 +1,32 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Music2 } from "lucide-react";
 
-type SongchainPromoBannerProps = {
-  enabled: boolean;
-};
-
 /**
  * Home promo banner — links to the Songchain Lens hub on Creative TV.
+ * Fetches runtime config so the home page can stay statically optimized.
  */
-export function SongchainPromoBanner({ enabled }: SongchainPromoBannerProps) {
+export function SongchainPromoBanner() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/songchain/status")
+      .then((res) => res.json())
+      .then((data: { enabled?: boolean }) => {
+        if (!cancelled) setEnabled(Boolean(data.enabled));
+      })
+      .catch(() => {
+        if (!cancelled) setEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const configured = enabled === true;
 
   return (
     <div className="w-full max-w-7xl mx-auto py-3 px-4 sm:px-6">
@@ -30,9 +46,11 @@ export function SongchainPromoBanner({ enabled }: SongchainPromoBannerProps) {
             Onchain music feeds, exclusive drops &amp; community
           </span>
           <span className="mt-0.5 block text-sm text-violet-200/70 group-hover:text-violet-100/90">
-            {enabled
-              ? "Browse Lens posts — link Orb to like & join"
-              : "Lens hub — configure feeds in env to go live"}
+            {enabled === null
+              ? "Loading Songchain status…"
+              : configured
+                ? "Browse Lens posts — link Orb to like & join"
+                : "Lens hub — configure feeds in env to go live"}
           </span>
         </span>
         <span className="hidden shrink-0 rounded-md bg-violet-500/90 px-3 py-1.5 text-sm font-medium text-white sm:inline-block">

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -25,4 +25,15 @@ describe('getSongchainConfig', () => {
       '0xabc0000000000000000000000000000000000001',
     );
   });
+
+  it('falls back to server-only env keys when NEXT_PUBLIC vars are unset', () => {
+    delete process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID;
+    process.env.SONGCHAIN_FEED_ID =
+      '0xdef0000000000000000000000000000000000002';
+    const config = getSongchainConfig();
+    expect(config.publicFeedId).toBe(
+      '0xdef0000000000000000000000000000000000002',
+    );
+    expect(config.enabled).toBe(true);
+  });
 });

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -15,6 +15,7 @@ describe('getSongchainConfig', () => {
     expect(config.publicFeedId).toBe(
       '0xabc0000000000000000000000000000000000001',
     );
+    expect(config.hallidayOutputAsset).toContain(':');
   });
 
   it('normalizes addresses to lowercase', () => {

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -1,7 +1,9 @@
-import { getLensChainId, getLensNetwork } from '@/lib/sdk/lens/chains';
-
-/** Lens GHO on mainnet (wrapped gas token). Same address pattern on Lens Chain. */
-const LENS_GHO_ADDRESS = '0x000000000000000000000000000000000000800A' as const;
+import {
+  buildHallidayOutputAsset,
+  isHallidaySandboxEnabled,
+  LENS_GHO_TOKEN_ADDRESS,
+} from '@/lib/songchain/halliday';
+import { getLensNetwork } from '@/lib/sdk/lens/chains';
 
 export type SongchainConfig = {
   enabled: boolean;
@@ -9,8 +11,9 @@ export type SongchainConfig = {
   exclusiveFeedId: string | null;
   groupId: string | null;
   hallidayApiKey: string | null;
-  hallidayDestinationChainId: number;
-  hallidayDestinationTokenAddress: string;
+  /** Halliday Payments SDK `outputs` entry, e.g. `lens:0x…800a`. */
+  hallidayOutputAsset: string;
+  hallidaySandbox: boolean;
 };
 
 function readEnv(...keys: string[]): string | null {
@@ -58,13 +61,18 @@ export function getSongchainConfig(): SongchainConfig {
     'HALLIDAY_API_KEY',
   );
 
+  const network = getLensNetwork();
+
   return {
     enabled: Boolean(publicFeedId || exclusiveFeedId || groupId),
     publicFeedId,
     exclusiveFeedId,
     groupId,
     hallidayApiKey,
-    hallidayDestinationChainId: getLensChainId(getLensNetwork()),
-    hallidayDestinationTokenAddress: tokenOverride || LENS_GHO_ADDRESS,
+    hallidayOutputAsset: buildHallidayOutputAsset(
+      network,
+      tokenOverride ?? LENS_GHO_TOKEN_ADDRESS,
+    ),
+    hallidaySandbox: isHallidaySandboxEnabled(),
   };
 }

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -13,25 +13,57 @@ export type SongchainConfig = {
   hallidayDestinationTokenAddress: string;
 };
 
-function readAddressEnv(key: string): string | null {
-  const value = process.env[key]?.trim();
+function readEnv(...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+function readAddressEnv(...keys: string[]): string | null {
+  const value = readEnv(...keys);
   if (!value) return null;
   return value.toLowerCase();
 }
 
+/**
+ * Reads Songchain configuration from environment variables.
+ *
+ * Prefer calling this from Server Components or Route Handlers so values reflect
+ * runtime env (e.g. Vercel) without requiring a client rebuild. Client
+ * components should receive the result via props instead of calling this directly.
+ */
 export function getSongchainConfig(): SongchainConfig {
-  const publicFeedId = readAddressEnv('NEXT_PUBLIC_SONGCHAIN_FEED_ID');
-  const exclusiveFeedId = readAddressEnv('NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID');
-  const groupId = readAddressEnv('NEXT_PUBLIC_SONGCHAIN_GROUP_ID');
+  const publicFeedId = readAddressEnv(
+    'NEXT_PUBLIC_SONGCHAIN_FEED_ID',
+    'SONGCHAIN_FEED_ID',
+  );
+  const exclusiveFeedId = readAddressEnv(
+    'NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID',
+    'SONGCHAIN_EXCLUSIVE_FEED_ID',
+  );
+  const groupId = readAddressEnv(
+    'NEXT_PUBLIC_SONGCHAIN_GROUP_ID',
+    'SONGCHAIN_GROUP_ID',
+  );
 
-  const tokenOverride = process.env.NEXT_PUBLIC_HALLIDAY_DESTINATION_TOKEN?.trim();
+  const tokenOverride = readEnv(
+    'NEXT_PUBLIC_HALLIDAY_DESTINATION_TOKEN',
+    'HALLIDAY_DESTINATION_TOKEN',
+  );
+
+  const hallidayApiKey = readEnv(
+    'NEXT_PUBLIC_HALLIDAY_API_KEY',
+    'HALLIDAY_API_KEY',
+  );
 
   return {
     enabled: Boolean(publicFeedId || exclusiveFeedId || groupId),
     publicFeedId,
     exclusiveFeedId,
     groupId,
-    hallidayApiKey: process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() || null,
+    hallidayApiKey,
     hallidayDestinationChainId: getLensChainId(getLensNetwork()),
     hallidayDestinationTokenAddress: tokenOverride || LENS_GHO_ADDRESS,
   };

--- a/lib/songchain/halliday.test.ts
+++ b/lib/songchain/halliday.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildHallidayOutputAsset,
+  isHallidaySandboxEnabled,
+  LENS_GHO_TOKEN_ADDRESS,
+} from './halliday';
+
+describe('buildHallidayOutputAsset', () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it('builds lens mainnet GHO output by default', () => {
+    delete process.env.NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET;
+    delete process.env.NEXT_PUBLIC_HALLIDAY_CHAIN_SLUG;
+    process.env.NEXT_PUBLIC_LENS_ENV = 'production';
+
+    expect(buildHallidayOutputAsset('mainnet')).toBe(
+      `lens:${LENS_GHO_TOKEN_ADDRESS}`,
+    );
+  });
+
+  it('respects full output asset override', () => {
+    process.env.NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET = 'lens:0xabc';
+    expect(buildHallidayOutputAsset('mainnet')).toBe('lens:0xabc');
+  });
+});
+
+describe('isHallidaySandboxEnabled', () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it('returns true when sandbox flag is set', () => {
+    process.env.NEXT_PUBLIC_HALLIDAY_SANDBOX = 'true';
+    expect(isHallidaySandboxEnabled()).toBe(true);
+  });
+});

--- a/lib/songchain/halliday.ts
+++ b/lib/songchain/halliday.ts
@@ -1,0 +1,45 @@
+import { getLensNetwork, type LensNetwork } from '@/lib/sdk/lens/chains';
+
+/** Lens GHO (wrapped gas token) — matches Lens + Halliday onramp docs. */
+export const LENS_GHO_TOKEN_ADDRESS =
+  '0x000000000000000000000000000000000000800a' as const;
+
+const DEFAULT_CHAIN_SLUG: Record<LensNetwork, string> = {
+  mainnet: 'lens',
+  testnet: 'lens-testnet',
+};
+
+function readEnv(...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Halliday Payments SDK output asset id (`chain:tokenAddress`).
+ * @see https://docs.halliday.xyz/pages/payments-sdk-docs
+ */
+export function buildHallidayOutputAsset(
+  network: LensNetwork = getLensNetwork(),
+  tokenAddress?: string | null,
+): string {
+  const assetOverride = readEnv(
+    'NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET',
+    'HALLIDAY_OUTPUT_ASSET',
+  );
+  if (assetOverride) return assetOverride;
+
+  const chainSlug =
+    readEnv('NEXT_PUBLIC_HALLIDAY_CHAIN_SLUG', 'HALLIDAY_CHAIN_SLUG') ??
+    DEFAULT_CHAIN_SLUG[network];
+
+  const token = (tokenAddress ?? LENS_GHO_TOKEN_ADDRESS).toLowerCase();
+  return `${chainSlug}:${token}`;
+}
+
+export function isHallidaySandboxEnabled(): boolean {
+  const value = readEnv('NEXT_PUBLIC_HALLIDAY_SANDBOX', 'HALLIDAY_SANDBOX');
+  return value === '1' || value?.toLowerCase() === 'true';
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@ffmpeg/core": "^0.12.10",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
-    "@halliday-sdk/commerce": "^3.2.2",
+    "@halliday-sdk/payments": "^3.2.0",
     "@helia/strings": "^5.0.3",
     "@helia/unixfs": "^6.0.4",
     "@hookform/resolvers": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,12 +2282,14 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@halliday-sdk/commerce@^3.2.2":
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/@halliday-sdk/commerce/-/commerce-3.2.2.tgz"
-  integrity sha512-rStsuFrlShwUEzcbCgHHPccQOLWbAg1LppcOPHHhKWbBu3YDsRjTV/eeqhV5gqZzadu/rGe8M8nGywORWzv89w==
+"@halliday-sdk/payments@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@halliday-sdk/payments/-/payments-3.2.0.tgz"
+  integrity sha512-Ek47Wenv92KzfmIlyyk6aGpNDdUAM/24RJGwrZgfHm5JevViHBAtTpZL3SGw5A2wl6KzdfWVOCCmwHSRDClqGw==
   dependencies:
-    ethers "^6.12.1"
+    axios "^1.12.2"
+    reflect-metadata "^0.2.2"
+    zod "4.3.6"
 
 "@headlessui/react@^1.7.17":
   version "1.7.19"
@@ -12691,7 +12693,7 @@ ethers@^5.8.0:
     "@ethersproject/web" "5.8.0"
     "@ethersproject/wordlists" "5.8.0"
 
-ethers@^6.0.8, ethers@^6.12.1:
+ethers@^6.0.8:
   version "6.14.1"
   resolved "https://registry.npmjs.org/ethers/-/ethers-6.14.1.tgz"
   integrity sha512-JnFiPFi3sK2Z6y7jZ3qrafDMwiXmU+6cNZ0M+kPq+mTy9skqEzwqAdFW3nb/em2xjlIVXX6Lz8ID6i3LmS4+fQ==
@@ -21860,6 +21862,11 @@ zod@3.22.4:
   version "3.22.4"
   resolved "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+
+zod@4.3.6:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
 zod@^3.22.4, zod@^3.23.8, zod@^3.24.1, zod@^3.24.2, zod@^3.24.4, zod@^3.25.0, "zod@^3.25.0 || ^4.0.0", zod@^3.25.1:
   version "3.25.76"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Songchain showed feeds as unconfigured when env vars were set on Vercel, and Halliday onramp stuck on a white spinner.

## Root causes

1. **Client-only `/songchain`** baked `NEXT_PUBLIC_*` at build time.
2. **Deprecated Commerce SDK** (`@halliday-sdk/commerce` / `openHalliday`) instead of the current [Halliday Payments SDK](https://docs.halliday.xyz/pages/payments-sdk-docs).
3. Missing **`destinationAddress`** and **`outputs`** required by `openHallidayPayments`.
4. Embed mounted before DOM was ready.

## Solution

- Server Component `/songchain` with `force-dynamic` passes runtime config to `SongchainPageClient`.
- Migrated to **`@halliday-sdk/payments`**: `initializeClient` preload, `openHallidayPayments` with `outputs`, `destinationAddress`, `userWallet` via `connectWalletClient` (Account Kit).
- Lens GHO output built as `lens:0x…800a` (overridable via `NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET`).
- **PR review**: home page stays static; promo banner reads `/api/songchain/status`; embed uses `useEffect`.

## After merge

Redeploy and confirm:

- `NEXT_PUBLIC_SONGCHAIN_*` feed/group IDs
- `NEXT_PUBLIC_HALLIDAY_API_KEY`
- `NEXT_PUBLIC_LENS_ENV=production` for mainnet GHO
- Optional: `NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET` if Halliday chain slug differs

User must **connect wallet** (or link Orb) so Halliday has a destination address.

## Testing

- `npm run test -- lib/songchain/` (6 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c999667-ee36-4429-bc33-3db6fd7becf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c999667-ee36-4429-bc33-3db6fd7becf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

