### PR TITLE
Fix Orb link banner mismatch and Halliday cash currency guidance

### DIFF
--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1387,8 +1387,15 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               <p className="text-xs text-muted-foreground">Orb / Lens</p>
               {isOrbAuthenticated ? (
                 <div className="space-y-2">
-                  <p className="text-xs text-green-600 dark:text-green-400">
-                    Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
+                  <p
+                    className={
+                      orbLinkStatus === "linked"
+                        ? "text-xs text-green-600 dark:text-green-400"
+                        : "text-xs text-amber-600 dark:text-amber-400"
+                    }
+                  >
+                    {orbLinkStatus === "linked" ? "Linked" : "Signed in"}
+                    {lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
                   </p>
                   <div className="flex gap-2">
                     <Button

--- a/components/account-dropdown/MobileOrbSection.tsx
+++ b/components/account-dropdown/MobileOrbSection.tsx
@@ -16,6 +16,7 @@ export function MobileOrbSection() {
     linkProfile,
     isLinking: isOrbLinking,
     logout: logoutOrb,
+    linkStatus,
   } = useOrbSession();
 
   const walletAddress = modularAccount?.address || user?.address;
@@ -25,8 +26,15 @@ export function MobileOrbSection() {
       <p className="text-xs text-muted-foreground font-semibold">Orb / Lens</p>
       {isOrbAuthenticated ? (
         <div className="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-700">
-          <p className="text-xs text-green-600 dark:text-green-400">
-            Linked{lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
+          <p
+            className={
+              linkStatus === "linked"
+                ? "text-xs text-green-600 dark:text-green-400"
+                : "text-xs text-amber-600 dark:text-amber-400"
+            }
+          >
+            {linkStatus === "linked" ? "Linked" : "Signed in"}
+            {lensAccount ? `: ${shortenAddress(lensAccount)}` : ""}
           </p>
           <div className="flex gap-2">
             <Button

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -193,11 +193,18 @@ export function HallidayOnramp({
       )}
 
       {embedOpen && (
-        <div
-          ref={containerRef}
-          id={containerId}
-          className="relative min-h-[420px] w-full overflow-hidden rounded-md border border-border/40 bg-muted/20"
-        />
+        <>
+          <p className="mb-2 text-xs text-muted-foreground">
+            On the Use cash tab, pick your fiat currency in the Halliday widget
+            header (top of the panel). If you do not see it, scroll up inside the
+            panel or use Open modal for the full view.
+          </p>
+          <div
+            ref={containerRef}
+            id={containerId}
+            className="relative min-h-[520px] w-full overflow-auto rounded-md border border-border/40 bg-muted/20"
+          />
+        </>
       )}
     </div>
   );

--- a/components/songchain/SongchainOrbConnect.tsx
+++ b/components/songchain/SongchainOrbConnect.tsx
@@ -8,6 +8,7 @@ import { CheckCircle2, Link2, LogIn } from "lucide-react";
 export function SongchainOrbConnect() {
   const orb = useOrbSession();
   const lensWrite = useLensOrbWrite();
+  const { linkProfile, isLinking } = orb;
 
   if (lensWrite.canWrite) {
     return (
@@ -34,9 +35,20 @@ export function SongchainOrbConnect() {
             : 'Browse feeds in read-only mode. Sign in with Orb and link your account to interact.'}
         </span>
       </div>
-      <Button size="sm" variant="secondary" onClick={() => orb.openLoginModal()}>
+      <Button
+        size="sm"
+        variant="secondary"
+        disabled={isLinking}
+        onClick={() =>
+          lensWrite.needsLink ? void linkProfile() : orb.openLoginModal()
+        }
+      >
         <LogIn className="h-4 w-4 mr-2" />
-        {orb.isAuthenticated ? 'Link Orb' : 'Sign in with Orb'}
+        {isLinking
+          ? 'Linking…'
+          : lensWrite.needsLink
+            ? 'Sync profile'
+            : 'Sign in with Orb'}
       </Button>
     </div>
   );

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -174,6 +174,33 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
     void linkProfile(walletAddress);
   }, [session?.accessToken, walletAddress, linkStatus, linkProfile]);
 
+  /** Restore link status after refresh when profile was already linked server-side. */
+  useEffect(() => {
+    if (!session?.accessToken || !walletAddress || !lensAccount) return;
+    if (linkStatus === 'linked' || linkStatus === 'needs_wallet') return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/creator-profiles?owner=${encodeURIComponent(walletAddress)}`,
+        );
+        const json = await res.json();
+        if (cancelled || !json?.success || !json.data?.lens_account_id) return;
+        const storedLens = String(json.data.lens_account_id).toLowerCase();
+        if (storedLens === lensAccount.toLowerCase()) {
+          setLinkStatus('linked');
+        }
+      } catch {
+        // Non-fatal: user can still use Sync profile / Link Orb
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session?.accessToken, walletAddress, lensAccount, linkStatus]);
+
   const connectWithQr = useCallback(
     async (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => {
       setLoginError(null);

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -179,25 +179,27 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
     if (!session?.accessToken || !walletAddress || !lensAccount) return;
     if (linkStatus === 'linked' || linkStatus === 'needs_wallet') return;
 
-    let cancelled = false;
+    const controller = new AbortController();
     (async () => {
       try {
         const res = await fetch(
           `/api/creator-profiles?owner=${encodeURIComponent(walletAddress)}`,
+          { signal: controller.signal },
         );
         const json = await res.json();
-        if (cancelled || !json?.success || !json.data?.lens_account_id) return;
+        if (!json?.success || !json.data?.lens_account_id) return;
         const storedLens = String(json.data.lens_account_id).toLowerCase();
         if (storedLens === lensAccount.toLowerCase()) {
           setLinkStatus('linked');
         }
-      } catch {
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
         // Non-fatal: user can still use Sync profile / Link Orb
       }
     })();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [session?.accessToken, walletAddress, lensAccount, linkStatus]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users reported two confusing Songchain experiences:

1. **Halliday "Use cash"** shows "Select a currency in the header" — that refers to the **Halliday widget's own header**, not the Creative TV site navbar. In the embedded widget, the currency control can sit above the cash tab and be easy to miss.

2. **Orb banner says "Link Orb"** while the account menu shows Orb as linked — these used different criteria:
   - Account menu treated any Orb session as "Linked"
   - Songchain required `linkStatus === 'linked'` (server profile sync via `/api/creator-profiles/link-orb`), which was **not restored after refresh**
   - The banner button called `openLoginModal()`, which **closes immediately** when already signed in with Orb

Alchemy wallet sign-in is separate from Orb profile linking to the creator profile.

## Changes

- Hydrate `linkStatus` from `creator_profiles` when Orb session + wallet match stored `lens_account_id`
- Songchain banner: **Sync profile** → `linkProfile()` when signed in but not linked; only open Orb QR for fresh sign-in
- Account dropdown / mobile: show **Signed in** vs **Linked** based on `linkStatus`
- Halliday embed: helper copy, taller scrollable panel so widget header currency picker is reachable; modal still available

## Testing

Manual: sign in with Alchemy + Orb, link profile, refresh Songchain — banner should show linked state. Open Halliday embed → Use cash → select currency in widget header or use Open modal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5525ebcc-78b6-4c5e-b63b-2c225480baf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5525ebcc-78b6-4c5e-b63b-2c225480baf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

