### PR TITLE
Fix Songchain revoked Orb session error

### DIFF
--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -12,6 +12,7 @@ import { publicClient } from "@/lib/sdk/lens/client";
 import { Button } from "@/components/ui/button";
 import { Loader2, Users } from "lucide-react";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { isRevokedOrbSessionError } from "@/lib/sdk/orb/session-errors";
 import { toast } from "sonner";
 
 type SongchainGroupPanelProps = {
@@ -33,7 +34,11 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
     try {
       let client: AnyClient = publicClient;
       if (canWrite) {
-        client = await getSessionClient();
+        try {
+          client = await getSessionClient();
+        } catch (err) {
+          if (!isRevokedOrbSessionError(err)) throw err;
+        }
       }
 
       const groupResult = await fetchGroup(client, {

--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -12,7 +12,7 @@ import { publicClient } from "@/lib/sdk/lens/client";
 import { Button } from "@/components/ui/button";
 import { Loader2, Users } from "lucide-react";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
-import { isRevokedOrbSessionError } from "@/lib/sdk/orb/session-errors";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { toast } from "sonner";
 
 type SongchainGroupPanelProps = {
@@ -37,7 +37,7 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
         try {
           client = await getSessionClient();
         } catch (err) {
-          if (!isRevokedOrbSessionError(err)) throw err;
+          if (!clearStaleOrbSessionIfNeeded(err)) throw err;
         }
       }
 

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/lib/sdk/orb/login';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { formatOrbAuthError } from '@/lib/sdk/orb/format-auth-error';
-import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
+import { isStaleOrbSessionError } from '@/lib/sdk/orb/session-errors';
 import { toast } from 'sonner';
 
 export type OrbLinkStatus = 'idle' | 'linked' | 'needs_wallet' | 'failed';
@@ -116,13 +116,20 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       persistSession(stored);
       return stored;
     } catch (err) {
-      if (isRevokedOrbSessionError(err)) {
+      if (isStaleOrbSessionError(err)) {
         invalidateOrbSession();
         return null;
       }
       return session;
     }
   }, [session, orb, persistSession, invalidateOrbSession]);
+
+  /** Reset link UI when tokens were cleared outside this provider (e.g. Songchain feed). */
+  useEffect(() => {
+    if (!session?.accessToken && linkStatus === 'linked') {
+      setLinkStatus('idle');
+    }
+  }, [session?.accessToken, linkStatus]);
 
   /** Clear revoked/expired Orb tokens so Songchain and feeds stay read-only instead of erroring. */
   useEffect(() => {

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -15,13 +15,14 @@ import {
   getOrbLogin,
   loadStoredOrbSession,
   saveStoredOrbSession,
+  clearStoredOrbSession,
   subscribeOrbSession,
   getOrbSessionServerSnapshot,
   type StoredOrbSession,
 } from '@/lib/sdk/orb/login';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { formatOrbAuthError } from '@/lib/sdk/orb/format-auth-error';
-import { clearLensSessionCache } from '@/lib/sdk/lens/orb-session-client';
+import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
 import { toast } from 'sonner';
 
 export type OrbLinkStatus = 'idle' | 'linked' | 'needs_wallet' | 'failed';
@@ -76,6 +77,20 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
     saveStoredOrbSession(next);
   }, []);
 
+  const invalidateOrbSession = useCallback(
+    (options?: { notify?: boolean }) => {
+      clearStoredOrbSession();
+      setLoginError(null);
+      setLinkStatus('idle');
+      if (options?.notify !== false) {
+        toast.info(
+          'Your Orb session ended. Sign in again to like posts and join groups.',
+        );
+      }
+    },
+    [],
+  );
+
   const bumpAccountMenuRefresh = useCallback(() => {
     setAccountMenuRefreshSignal((n) => n + 1);
   }, []);
@@ -88,7 +103,10 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         refreshToken: session.refreshToken,
         authenticationId: session.authenticationId,
       });
-      if (!synced?.accessToken) return null;
+      if (!synced?.accessToken) {
+        invalidateOrbSession();
+        return null;
+      }
       const stored: StoredOrbSession = {
         accessToken: synced.accessToken,
         refreshToken: synced.refreshToken ?? session.refreshToken,
@@ -97,10 +115,20 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
       };
       persistSession(stored);
       return stored;
-    } catch {
+    } catch (err) {
+      if (isRevokedOrbSessionError(err)) {
+        invalidateOrbSession();
+        return null;
+      }
       return session;
     }
-  }, [session, orb, persistSession]);
+  }, [session, orb, persistSession, invalidateOrbSession]);
+
+  /** Clear revoked/expired Orb tokens so Songchain and feeds stay read-only instead of erroring. */
+  useEffect(() => {
+    if (!session?.accessToken) return;
+    void syncSession();
+  }, [session?.accessToken, syncSession]);
 
   const linkProfile = useCallback(
     async (ownerAddress?: string) => {
@@ -253,12 +281,11 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         // still clear local session
       }
     }
-    persistSession(null);
-    clearLensSessionCache();
+    clearStoredOrbSession();
     setLoginError(null);
     setLinkStatus('idle');
     toast.success('Signed out of Orb');
-  }, [session, orb, persistSession]);
+  }, [session, orb]);
 
   const openLoginModal = useCallback(() => {
     if (!hasWallet) {

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -7,6 +7,7 @@ import { evmAddress } from '@lens-protocol/types';
 import type { AnyPost } from '@lens-protocol/graphql';
 import { publicClient } from '@/lib/sdk/lens/client';
 import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
+import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
 
 type UseSongchainFeedOptions = {
   feedId: string | null;
@@ -30,7 +31,12 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
       try {
         let client: AnyClient = publicClient;
         if (canWrite) {
-          client = await getSessionClient();
+          try {
+            client = await getSessionClient();
+          } catch (err) {
+            if (!isRevokedOrbSessionError(err)) throw err;
+            // Stale Orb session was cleared; keep browsing the feed read-only.
+          }
         }
 
         const result = await fetchPosts(client, {

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -7,7 +7,7 @@ import { evmAddress } from '@lens-protocol/types';
 import type { AnyPost } from '@lens-protocol/graphql';
 import { publicClient } from '@/lib/sdk/lens/client';
 import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
-import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
+import { clearStaleOrbSessionIfNeeded } from '@/lib/sdk/orb/session-errors';
 
 type UseSongchainFeedOptions = {
   feedId: string | null;
@@ -34,8 +34,8 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
           try {
             client = await getSessionClient();
           } catch (err) {
-            if (!isRevokedOrbSessionError(err)) throw err;
-            // Stale Orb session was cleared; keep browsing the feed read-only.
+            if (!clearStaleOrbSessionIfNeeded(err)) throw err;
+            // Stale Orb session cleared; keep browsing the feed read-only.
           }
         }
 

--- a/lib/sdk/lens/orb-session-client.ts
+++ b/lib/sdk/lens/orb-session-client.ts
@@ -5,7 +5,7 @@ import {
 } from '@lens-protocol/storage';
 import type { AccessToken, IdToken, RefreshToken } from '@lens-protocol/types';
 import type { StoredOrbSession } from '@/lib/sdk/orb/login';
-import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
+import { isStaleOrbSessionError } from '@/lib/sdk/orb/session-errors';
 
 function getLensEnvironment() {
   return process.env.NEXT_PUBLIC_LENS_ENV === 'production' ? mainnet : testnet;
@@ -64,7 +64,7 @@ export async function resumeLensSessionFromOrb(
     const resumeResult = await publicClient.resumeSession();
     if (resumeResult.isErr()) {
       const message = resumeResult.error.message;
-      if (isRevokedOrbSessionError(message)) {
+      if (isStaleOrbSessionError(message)) {
         sessionCache.delete(cacheKey);
       }
       throw new Error(message);

--- a/lib/sdk/lens/orb-session-client.ts
+++ b/lib/sdk/lens/orb-session-client.ts
@@ -5,6 +5,7 @@ import {
 } from '@lens-protocol/storage';
 import type { AccessToken, IdToken, RefreshToken } from '@lens-protocol/types';
 import type { StoredOrbSession } from '@/lib/sdk/orb/login';
+import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
 
 function getLensEnvironment() {
   return process.env.NEXT_PUBLIC_LENS_ENV === 'production' ? mainnet : testnet;
@@ -62,7 +63,11 @@ export async function resumeLensSessionFromOrb(
 
     const resumeResult = await publicClient.resumeSession();
     if (resumeResult.isErr()) {
-      throw new Error(resumeResult.error.message);
+      const message = resumeResult.error.message;
+      if (isRevokedOrbSessionError(message)) {
+        sessionCache.delete(cacheKey);
+      }
+      throw new Error(message);
     }
 
     return resumeResult.value;

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -19,6 +19,14 @@ describe('formatOrbAuthError', () => {
     );
   });
 
+  it('maps revoked Orb/Lens session copy', () => {
+    expect(
+      formatOrbAuthError(
+        new Error('You are trying to renew a revoked authentication'),
+      ),
+    ).toMatch(/signed out/i);
+  });
+
   it('maps missing lens_account_id schema cache errors', () => {
     expect(
       formatOrbAuthError(

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -1,3 +1,5 @@
+import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
+
 /** User-facing copy for Orb QR / link failures (init proxy, poll, SDK). */
 export function formatOrbAuthError(error: unknown): string {
   const raw =
@@ -26,6 +28,9 @@ export function formatOrbAuthError(error: unknown): string {
   }
   if (lower.includes('invalid orb access token') || lower.includes('401')) {
     return 'Your Orb session expired. Sign in again with the Orb app.';
+  }
+  if (isRevokedOrbSessionError(error)) {
+    return 'Your Orb session was signed out. Sign in again with Orb to interact on Lens.';
   }
   if (lower.includes('wallet not connected') || lower.includes('sign in with your wallet')) {
     return 'Connect your wallet with Get Started before linking your Lens identity.';

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -1,5 +1,6 @@
 import { createOrbLogin, type OrbLogin } from '@orbclub/modules/auth';
 import { getOrbLoginConfig } from '@/lib/sdk/orb/config';
+import { clearLensSessionCache } from '@/lib/sdk/lens/orb-session-client';
 
 let orbLoginSingleton: OrbLogin | null = null;
 
@@ -80,4 +81,10 @@ export function saveStoredOrbSession(session: StoredOrbSession | null): void {
   }
   invalidateOrbSessionCache();
   notifyOrbSessionChange();
+}
+
+/** Drops Orb tokens and cached Lens session clients (e.g. revoked refresh). */
+export function clearStoredOrbSession(): void {
+  clearLensSessionCache();
+  saveStoredOrbSession(null);
 }

--- a/lib/sdk/orb/session-errors.test.ts
+++ b/lib/sdk/orb/session-errors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isRevokedOrbSessionError } from './session-errors';
+
+describe('isRevokedOrbSessionError', () => {
+  it('detects Lens revoked refresh copy', () => {
+    expect(
+      isRevokedOrbSessionError(
+        new Error('You are trying to renew a revoked authentication'),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isRevokedOrbSessionError(new Error('Network request failed'))).toBe(
+      false,
+    );
+  });
+});

--- a/lib/sdk/orb/session-errors.test.ts
+++ b/lib/sdk/orb/session-errors.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from 'vitest';
-import { isRevokedOrbSessionError } from './session-errors';
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearStaleOrbSessionIfNeeded,
+  getOrbErrorMessage,
+  isRevokedOrbSessionError,
+  isStaleOrbSessionError,
+} from './session-errors';
+import { ORB_SESSION_STORAGE_KEY } from './login';
+
+describe('getOrbErrorMessage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+  it('reads message from plain objects', () => {
+    expect(getOrbErrorMessage({ message: 'GraphQL failure' })).toBe(
+      'GraphQL failure',
+    );
+  });
+});
 
 describe('isRevokedOrbSessionError', () => {
   it('detects Lens revoked refresh copy', () => {
@@ -14,5 +32,47 @@ describe('isRevokedOrbSessionError', () => {
     expect(isRevokedOrbSessionError(new Error('Network request failed'))).toBe(
       false,
     );
+  });
+});
+
+describe('isStaleOrbSessionError', () => {
+  it('detects 401 and unauthorized', () => {
+    expect(isStaleOrbSessionError(new Error('401 Unauthorized'))).toBe(true);
+    expect(isStaleOrbSessionError(new Error('invalid orb access token'))).toBe(
+      true,
+    );
+  });
+});
+
+describe('clearStaleOrbSessionIfNeeded', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('clears storage for stale sessions', () => {
+    localStorage.setItem(
+      ORB_SESSION_STORAGE_KEY,
+      JSON.stringify({ accessToken: 'stale' }),
+    );
+
+    expect(
+      clearStaleOrbSessionIfNeeded(
+        new Error('You are trying to renew a revoked authentication'),
+      ),
+    ).toBe(true);
+    expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not clear for unrelated errors', () => {
+    localStorage.setItem(
+      ORB_SESSION_STORAGE_KEY,
+      JSON.stringify({ accessToken: 'keep' }),
+    );
+
+    expect(clearStaleOrbSessionIfNeeded(new Error('Network failed'))).toBe(
+      false,
+    );
+    expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).not.toBeNull();
+    localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
   });
 });

--- a/lib/sdk/orb/session-errors.ts
+++ b/lib/sdk/orb/session-errors.ts
@@ -1,0 +1,16 @@
+/** Lens / Orb errors when refresh tokens were revoked (sign-out elsewhere, expired auth). */
+export function isRevokedOrbSessionError(error: unknown): boolean {
+  const msg =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('renew a revoked authentication') ||
+    lower.includes('revoked authentication') ||
+    (lower.includes('revoked') && lower.includes('authentication'))
+  );
+}

--- a/lib/sdk/orb/session-errors.ts
+++ b/lib/sdk/orb/session-errors.ts
@@ -1,16 +1,47 @@
+import { clearStoredOrbSession } from '@/lib/sdk/orb/login';
+
+/** Extract a message from Error, string, or SDK objects with a `message` field. */
+export function getOrbErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+  return '';
+}
+
 /** Lens / Orb errors when refresh tokens were revoked (sign-out elsewhere, expired auth). */
 export function isRevokedOrbSessionError(error: unknown): boolean {
-  const msg =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : '';
-
-  const lower = msg.toLowerCase();
+  const lower = getOrbErrorMessage(error).toLowerCase();
   return (
     lower.includes('renew a revoked authentication') ||
     lower.includes('revoked authentication') ||
     (lower.includes('revoked') && lower.includes('authentication'))
   );
+}
+
+/** Auth failures that mean the cached Orb session should be dropped. */
+export function isStaleOrbSessionError(error: unknown): boolean {
+  if (isRevokedOrbSessionError(error)) return true;
+
+  const lower = getOrbErrorMessage(error).toLowerCase();
+  return (
+    lower.includes('401') ||
+    lower.includes('unauthorized') ||
+    lower.includes('invalid orb access token') ||
+    lower.includes('session expired') ||
+    lower.includes('token expired')
+  );
+}
+
+/** Clears local Orb tokens when `error` indicates the session is no longer valid. */
+export function clearStaleOrbSessionIfNeeded(error: unknown): boolean {
+  if (!isStaleOrbSessionError(error)) return false;
+  clearStoredOrbSession();
+  return true;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting `/songchain` with stale Orb tokens in `localStorage` showed:

> You are trying to renew a revoked authentication

## Solution

- Detect revoked and other stale auth errors (`401`, `unauthorized`, expired tokens)
- Clear stored Orb session on sync failure and when Songchain loaders catch auth errors
- Fall back to read-only Lens client for feeds and groups
- Reset link UI when tokens are cleared outside `OrbSessionContext`

## Review feedback addressed

- Expanded `syncSession` invalidation beyond revoked-only errors
- `clearStaleOrbSessionIfNeeded()` in `useSongchainFeed` and `SongchainGroupPanel`
- `getOrbErrorMessage()` handles non-`Error` objects with a `message` property

## Testing

`vitest run lib/sdk/orb/session-errors.test.ts lib/sdk/orb/format-auth-error.test.ts lib/sdk/orb/login.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82bfc97e-41cf-46f6-a767-73b3e741a237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82bfc97e-41cf-46f6-a767-73b3e741a237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

