### PR TITLE
Align Halliday onramp config with Payments SDK asset IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,8 +134,8 @@ NEXT_PUBLIC_SONGCHAIN_GROUP_ID=
 # Halliday Payments SDK — https://docs.halliday.xyz/pages/payments-sdk-docs
 NEXT_PUBLIC_HALLIDAY_API_KEY=
 # HALLIDAY_API_KEY=
-# Optional: fiat inputs for onramp (default USD,EUR). Comma-separated list.
-# NEXT_PUBLIC_HALLIDAY_INPUT_ASSET=USD,EUR
+# Optional: fiat inputs for onramp (default usd). Comma-separated, lowercase symbols.
+# NEXT_PUBLIC_HALLIDAY_INPUT_ASSET=usd,eur
 # Optional: full output asset id (chain:address), e.g. lens:0x000000000000000000000000000000000000800a
 # NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET=
 # Optional chain slug if Halliday uses a different id (defaults: lens / lens-testnet)

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -69,6 +69,8 @@ export function HallidayOnramp({
       outputs: [hallidayOutputAsset],
       sandbox: hallidaySandbox,
       windowType: "MODAL" as const,
+      /** Fiat onramp tab; matches Halliday widget `sessionType` for card/bank pay-in. */
+      sessionType: "cash" as const,
       destinationAddress: destinationAddress ?? undefined,
       headerTitle: HALLIDAY_HEADER_TITLE,
       customStyles: {

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -16,7 +16,7 @@ describe('getSongchainConfig', () => {
       '0xabc0000000000000000000000000000000000001',
     );
     expect(config.hallidayOutputAsset).toContain(':');
-    expect(config.hallidayInputAssets).toEqual(['USD', 'EUR']);
+    expect(config.hallidayInputAssets).toEqual(['usd']);
   });
 
   it('normalizes addresses to lowercase', () => {

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -14,7 +14,7 @@ export type SongchainConfig = {
   hallidayApiKey: string | null;
   /** Halliday Payments SDK `outputs` entry, e.g. `lens:0x…800a`. */
   hallidayOutputAsset: string;
-  /** Halliday Payments SDK `inputs` entries, e.g. `USD` for fiat onramp. */
+  /** Halliday Payments SDK `inputs` entries, e.g. `usd` for fiat onramp. */
   hallidayInputAssets: string[];
   hallidaySandbox: boolean;
 };

--- a/lib/songchain/halliday.test.ts
+++ b/lib/songchain/halliday.test.ts
@@ -5,7 +5,25 @@ import {
   HALLIDAY_DEFAULT_INPUT_ASSETS,
   isHallidaySandboxEnabled,
   LENS_GHO_TOKEN_ADDRESS,
+  normalizeHallidayAssetId,
 } from './halliday';
+
+describe('normalizeHallidayAssetId', () => {
+  it('lowercases fiat symbols', () => {
+    expect(normalizeHallidayAssetId('USD')).toBe('usd');
+    expect(normalizeHallidayAssetId(' EUR ')).toBe('eur');
+  });
+
+  it('lowercases chain slug and token address', () => {
+    expect(
+      normalizeHallidayAssetId('Lens:0xABCDEF0000000000000000000000000000000001'),
+    ).toBe('lens:0xabcdef0000000000000000000000000000000001');
+  });
+
+  it('lowercases chain slug and token symbol', () => {
+    expect(normalizeHallidayAssetId('Ethereum:USDC')).toBe('ethereum:usdc');
+  });
+});
 
 describe('buildHallidayOutputAsset', () => {
   const env = process.env;
@@ -24,8 +42,8 @@ describe('buildHallidayOutputAsset', () => {
     );
   });
 
-  it('respects full output asset override', () => {
-    process.env.NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET = 'lens:0xabc';
+  it('respects full output asset override and normalizes casing', () => {
+    process.env.NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET = 'Lens:0xAbC';
     expect(buildHallidayOutputAsset('mainnet')).toBe('lens:0xabc');
   });
 });
@@ -37,14 +55,14 @@ describe('buildHallidayInputAssets', () => {
     process.env = { ...env };
   });
 
-  it('defaults to USD and EUR for fiat onramp', () => {
+  it('defaults to usd for fiat onramp', () => {
     delete process.env.NEXT_PUBLIC_HALLIDAY_INPUT_ASSET;
     expect(buildHallidayInputAssets()).toEqual([...HALLIDAY_DEFAULT_INPUT_ASSETS]);
   });
 
-  it('supports comma-separated input overrides', () => {
+  it('supports comma-separated input overrides with normalization', () => {
     process.env.NEXT_PUBLIC_HALLIDAY_INPUT_ASSET = 'USD, EUR';
-    expect(buildHallidayInputAssets()).toEqual(['USD', 'EUR']);
+    expect(buildHallidayInputAssets()).toEqual(['usd', 'eur']);
   });
 
   it('falls back to defaults when override is only whitespace or commas', () => {

--- a/lib/songchain/halliday.ts
+++ b/lib/songchain/halliday.ts
@@ -18,6 +18,30 @@ function readEnv(...keys: string[]): string | null {
 }
 
 /**
+ * Normalizes a Halliday Payments SDK asset id.
+ * Fiat symbols → lowercase (`usd`). Tokens → `chain:0x…` with lowercase chain slug and hex.
+ * @see https://docs.halliday.xyz/pages/payments-sdk-docs
+ */
+export function normalizeHallidayAssetId(asset: string): string {
+  const trimmed = asset.trim();
+  if (!trimmed) return trimmed;
+
+  if (!trimmed.includes(':')) {
+    return trimmed.toLowerCase();
+  }
+
+  const colon = trimmed.indexOf(':');
+  const chain = trimmed.slice(0, colon).trim().toLowerCase();
+  const token = trimmed.slice(colon + 1).trim();
+  const normalizedToken =
+    token.startsWith('0x') || token.startsWith('0X')
+      ? token.toLowerCase()
+      : token.toLowerCase();
+
+  return `${chain}:${normalizedToken}`;
+}
+
+/**
  * Halliday Payments SDK output asset id (`chain:tokenAddress`).
  * @see https://docs.halliday.xyz/pages/payments-sdk-docs
  */
@@ -29,14 +53,14 @@ export function buildHallidayOutputAsset(
     'NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET',
     'HALLIDAY_OUTPUT_ASSET',
   );
-  if (assetOverride) return assetOverride;
+  if (assetOverride) return normalizeHallidayAssetId(assetOverride);
 
   const chainSlug =
     readEnv('NEXT_PUBLIC_HALLIDAY_CHAIN_SLUG', 'HALLIDAY_CHAIN_SLUG') ??
     DEFAULT_CHAIN_SLUG[network];
 
   const token = (tokenAddress ?? LENS_GHO_TOKEN_ADDRESS).toLowerCase();
-  return `${chainSlug}:${token}`;
+  return normalizeHallidayAssetId(`${chainSlug}:${token}`);
 }
 
 export function isHallidaySandboxEnabled(): boolean {
@@ -44,12 +68,14 @@ export function isHallidaySandboxEnabled(): boolean {
   return value === '1' || value?.toLowerCase() === 'true';
 }
 
-/** Default fiat inputs for Halliday onramp (debit/credit → crypto). */
-export const HALLIDAY_DEFAULT_INPUT_ASSETS = ['USD', 'EUR'] as const;
+/**
+ * Default fiat input for Halliday onramp (debit/credit → crypto).
+ * Single `usd` pre-selects pay currency in the widget; add `eur` via env if needed.
+ */
+export const HALLIDAY_DEFAULT_INPUT_ASSETS = ['usd'] as const;
 
 /**
  * Halliday Payments SDK input asset id (fiat symbol or `chain:tokenAddress`).
- * Multiple values let users choose pay currency in the widget (e.g. USD or EUR).
  * @see https://docs.halliday.xyz/pages/payments-sdk-docs
  */
 export function buildHallidayInputAssets(): string[] {
@@ -60,7 +86,7 @@ export function buildHallidayInputAssets(): string[] {
   if (override) {
     const assets = override
       .split(',')
-      .map((value) => value.trim())
+      .map((value) => normalizeHallidayAssetId(value))
       .filter(Boolean);
     if (assets.length > 0) {
       return assets;
@@ -68,4 +94,3 @@ export function buildHallidayInputAssets(): string[] {
   }
   return [...HALLIDAY_DEFAULT_INPUT_ASSETS];
 }
-

--- a/lib/songchain/halliday.ts
+++ b/lib/songchain/halliday.ts
@@ -32,13 +32,9 @@ export function normalizeHallidayAssetId(asset: string): string {
 
   const colon = trimmed.indexOf(':');
   const chain = trimmed.slice(0, colon).trim().toLowerCase();
-  const token = trimmed.slice(colon + 1).trim();
-  const normalizedToken =
-    token.startsWith('0x') || token.startsWith('0X')
-      ? token.toLowerCase()
-      : token.toLowerCase();
+  const token = trimmed.slice(colon + 1).trim().toLowerCase();
 
-  return `${chain}:${normalizedToken}`;
+  return `${chain}:${token}`;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns Songchain Halliday onramp configuration with `@halliday-sdk/payments` conventions so the widget pre-selects pay currency and recognizes asset IDs.

## Changes

- **`normalizeHallidayAssetId()`** — lowercases fiat symbols (`usd`) and normalizes `chain:token` outputs (lowercase chain slug + hex/symbol).
- **Default fiat input** — `usd` only (was `USD`, `EUR`); avoids empty “select currency” state when multiple uppercase codes were passed.
- **Env overrides** — `USD,EUR` in env is normalized to `usd`, `eur`.
- **Widget** — sets `sessionType: 'cash'` so card/bank onramp opens on the cash tab.
- **Docs** — `.env.example` updated for lowercase fiat ids.

## Testing

- `yarn vitest run lib/songchain/halliday.test.ts lib/songchain/config.test.ts`

## Notes

To offer EUR again, set `NEXT_PUBLIC_HALLIDAY_INPUT_ASSET=usd,eur`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db96c7dd-6ff8-489f-80a6-c083ef4d3391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db96c7dd-6ff8-489f-80a6-c083ef4d3391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

