### PR TITLE
Improve Songchain feed diagnostics

### DIFF
--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -9,12 +9,14 @@ type SongchainFeedSectionProps = {
   title: string;
   description: string;
   feedId: string | null;
+  emptyDescription: string;
 };
 
 export function SongchainFeedSection({
   title,
   description,
   feedId,
+  emptyDescription,
 }: SongchainFeedSectionProps) {
   const { posts, loading, error, hasMore, reload, loadMore } = useSongchainFeed({
     feedId,
@@ -50,7 +52,10 @@ export function SongchainFeedSection({
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       ) : posts.length === 0 ? (
-        <p className="text-center text-muted-foreground py-12">No posts in this feed yet.</p>
+        <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-border/60 p-8 text-center">
+          <p className="font-medium text-foreground">No posts found in this feed yet.</p>
+          <p className="mt-2 text-sm text-muted-foreground">{emptyDescription}</p>
+        </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {posts.map((post) => (

--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -8,7 +8,7 @@ import {
   joinGroup,
 } from "@lens-protocol/client/actions";
 import { evmAddress } from "@lens-protocol/types";
-import { publicClient } from "@/lib/sdk/lens/client";
+import { createLensClient } from "@/lib/sdk/lens/create-client";
 import { Button } from "@/components/ui/button";
 import { Loader2, Users } from "lucide-react";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
@@ -32,7 +32,7 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
     if (!groupId) return;
     setLoading(true);
     try {
-      let client: AnyClient = publicClient;
+      let client: AnyClient = createLensClient();
       if (canWrite) {
         try {
           client = await getSessionClient();

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -62,6 +62,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Songchain feed"
             description="Posts from the main Songchain Lens feed (Orb)."
             feedId={config.publicFeedId}
+            emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled, so publish a new post directly to this feed if it should appear here."
           />
         </TabsContent>
 
@@ -70,6 +71,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Exclusive feed"
             description="Members-only drops and announcements on Lens."
             feedId={config.exclusiveFeedId}
+            emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
           />
         </TabsContent>
 

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -5,7 +5,7 @@ import type { AnyClient } from '@lens-protocol/client';
 import { fetchPosts } from '@lens-protocol/client/actions';
 import { evmAddress } from '@lens-protocol/types';
 import type { AnyPost } from '@lens-protocol/graphql';
-import { publicClient } from '@/lib/sdk/lens/client';
+import { createLensClient } from '@/lib/sdk/lens/create-client';
 import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
 import { clearStaleOrbSessionIfNeeded } from '@/lib/sdk/orb/session-errors';
 import {
@@ -42,7 +42,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
       setLoading(true);
       setError(null);
       try {
-        let client: AnyClient = publicClient;
+        let client: AnyClient = createLensClient();
         if (canWrite) {
           try {
             client = await getSessionClient();

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -8,6 +8,10 @@ import type { AnyPost } from '@lens-protocol/graphql';
 import { publicClient } from '@/lib/sdk/lens/client';
 import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
 import { clearStaleOrbSessionIfNeeded } from '@/lib/sdk/orb/session-errors';
+import {
+  extractLensContractAddress,
+  getLensContractAddressError,
+} from '@/lib/sdk/lens/primitive-id';
 
 type UseSongchainFeedOptions = {
   feedId: string | null;
@@ -26,6 +30,15 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
     async (mode: 'replace' | 'append') => {
       if (!feedId || !enabled) return;
 
+      const feedAddress = extractLensContractAddress(feedId);
+      if (!feedAddress) {
+        setPosts([]);
+        cursorRef.current = null;
+        setHasMore(false);
+        setError(getLensContractAddressError(feedId, 'Feed contract ID'));
+        return;
+      }
+
       setLoading(true);
       setError(null);
       try {
@@ -41,7 +54,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
 
         const result = await fetchPosts(client, {
           filter: {
-            feeds: [{ feed: evmAddress(feedId) }],
+            feeds: [{ feed: evmAddress(feedAddress) }],
           },
           cursor: mode === 'append' ? (cursorRef.current ?? undefined) : undefined,
         });
@@ -77,6 +90,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
       setPosts([]);
       cursorRef.current = null;
       setHasMore(false);
+      setError(null);
       return;
     }
     cursorRef.current = null;

--- a/lib/sdk/lens/client.ts
+++ b/lib/sdk/lens/client.ts
@@ -1,20 +1,5 @@
-import { PublicClient, testnet, mainnet } from "@lens-protocol/client";
-
-const lensEnv = process.env.NEXT_PUBLIC_LENS_ENV === "production" ? mainnet : testnet;
-
-/**
- * Creates a Lens Public Client.
- * 
- * @param apiKey - Optional Server API Key for server-side context.
- *                 NEVER pass this in client-side code.
- * @returns PublicClient
- */
-export const createLensClient = (apiKey?: string) => {
-    return PublicClient.create({
-        environment: lensEnv,
-        ...(apiKey && { apiKey }),
-    });
-};
+export { createLensClient } from "./create-client";
+import { createLensClient } from "./create-client";
 
 /**
  * Default client for general usage (no privileged access)

--- a/lib/sdk/lens/create-client.ts
+++ b/lib/sdk/lens/create-client.ts
@@ -1,0 +1,17 @@
+import { PublicClient, testnet, mainnet } from "@lens-protocol/client";
+
+const lensEnv = process.env.NEXT_PUBLIC_LENS_ENV === "production" ? mainnet : testnet;
+
+/**
+ * Creates a Lens Public Client.
+ *
+ * @param apiKey - Optional Server API Key for server-side context.
+ *                 NEVER pass this in client-side code.
+ * @returns PublicClient
+ */
+export const createLensClient = (apiKey?: string) => {
+    return PublicClient.create({
+        environment: lensEnv,
+        ...(apiKey && { apiKey }),
+    });
+};

--- a/lib/sdk/lens/primitive-id.test.ts
+++ b/lib/sdk/lens/primitive-id.test.ts
@@ -24,5 +24,10 @@ describe('Lens primitive IDs', () => {
     expect(getLensContractAddressError('creative-feed', 'Feed contract ID')).toContain(
       '0x contract address',
     );
+    expect(
+      extractLensContractAddress(
+        'lens:0xAbC00000000000000000000000000000000000012345',
+      ),
+    ).toBeNull();
   });
 });

--- a/lib/sdk/lens/primitive-id.test.ts
+++ b/lib/sdk/lens/primitive-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractLensContractAddress,
+  getLensContractAddressError,
+  normalizeLensPrimitiveId,
+} from './primitive-id';
+
+describe('Lens primitive IDs', () => {
+  it('extracts lowercase contract addresses from Lens-style IDs', () => {
+    expect(
+      extractLensContractAddress(
+        'lens:0xAbC0000000000000000000000000000000000001',
+      ),
+    ).toBe('0xabc0000000000000000000000000000000000001');
+    expect(
+      normalizeLensPrimitiveId(
+        'https://developer.lens.xyz/contracts/0xDeF0000000000000000000000000000000000002',
+      ),
+    ).toBe('0xdef0000000000000000000000000000000000002');
+  });
+
+  it('reports IDs that do not include a contract address', () => {
+    expect(extractLensContractAddress('creative-feed')).toBeNull();
+    expect(getLensContractAddressError('creative-feed', 'Feed contract ID')).toContain(
+      '0x contract address',
+    );
+  });
+});

--- a/lib/sdk/lens/primitive-id.ts
+++ b/lib/sdk/lens/primitive-id.ts
@@ -1,0 +1,27 @@
+const EVM_ADDRESS_PATTERN = /0x[a-fA-F0-9]{40}/;
+
+export function extractLensContractAddress(
+  value: string | null | undefined,
+): `0x${string}` | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(EVM_ADDRESS_PATTERN);
+  return match ? (match[0].toLowerCase() as `0x${string}`) : null;
+}
+
+export function normalizeLensPrimitiveId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  return extractLensContractAddress(trimmed) ?? trimmed.toLowerCase();
+}
+
+export function getLensContractAddressError(
+  value: string | null | undefined,
+  label = 'Lens contract ID',
+): string | null {
+  if (!value || extractLensContractAddress(value)) return null;
+
+  return `${label} must include a 0x contract address. Paste the Lens Feed contract address or a Lens contract ID that contains it.`;
+}

--- a/lib/sdk/lens/primitive-id.ts
+++ b/lib/sdk/lens/primitive-id.ts
@@ -1,4 +1,4 @@
-const EVM_ADDRESS_PATTERN = /0x[a-fA-F0-9]{40}/;
+const EVM_ADDRESS_PATTERN = /\b0x[a-fA-F0-9]{40}\b/;
 
 export function extractLensContractAddress(
   value: string | null | undefined,

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -28,6 +28,22 @@ describe('getSongchainConfig', () => {
     );
   });
 
+  it('accepts Lens contract IDs that include an address', () => {
+    process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID =
+      'lens:0xAbC0000000000000000000000000000000000001';
+    process.env.NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID =
+      'https://developer.lens.xyz/contracts/0xDeF0000000000000000000000000000000000002';
+
+    const config = getSongchainConfig();
+
+    expect(config.publicFeedId).toBe(
+      '0xabc0000000000000000000000000000000000001',
+    );
+    expect(config.exclusiveFeedId).toBe(
+      '0xdef0000000000000000000000000000000000002',
+    );
+  });
+
   it('falls back to server-only env keys when NEXT_PUBLIC vars are unset', () => {
     delete process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID;
     process.env.SONGCHAIN_FEED_ID =

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -5,6 +5,7 @@ import {
   LENS_GHO_TOKEN_ADDRESS,
 } from '@/lib/songchain/halliday';
 import { getLensNetwork } from '@/lib/sdk/lens/chains';
+import { normalizeLensPrimitiveId } from '@/lib/sdk/lens/primitive-id';
 
 export type SongchainConfig = {
   enabled: boolean;
@@ -27,10 +28,9 @@ function readEnv(...keys: string[]): string | null {
   return null;
 }
 
-function readAddressEnv(...keys: string[]): string | null {
+function readLensPrimitiveEnv(...keys: string[]): string | null {
   const value = readEnv(...keys);
-  if (!value) return null;
-  return value.toLowerCase();
+  return normalizeLensPrimitiveId(value);
 }
 
 /**
@@ -41,15 +41,15 @@ function readAddressEnv(...keys: string[]): string | null {
  * components should receive the result via props instead of calling this directly.
  */
 export function getSongchainConfig(): SongchainConfig {
-  const publicFeedId = readAddressEnv(
+  const publicFeedId = readLensPrimitiveEnv(
     'NEXT_PUBLIC_SONGCHAIN_FEED_ID',
     'SONGCHAIN_FEED_ID',
   );
-  const exclusiveFeedId = readAddressEnv(
+  const exclusiveFeedId = readLensPrimitiveEnv(
     'NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID',
     'SONGCHAIN_EXCLUSIVE_FEED_ID',
   );
-  const groupId = readAddressEnv(
+  const groupId = readLensPrimitiveEnv(
     'NEXT_PUBLIC_SONGCHAIN_GROUP_ID',
     'SONGCHAIN_GROUP_ID',
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Normalize Lens developer-console contract IDs that contain embedded `0x` feed/group addresses before passing them to the Songchain page.
- Validate Songchain feed IDs before calling the Lens SDK so invalid IDs show a clear error instead of looking blank.
- Reject malformed overlong hex addresses instead of silently truncating them.
- Update public/exclusive empty feed messaging to explain that custom Lens feeds only show posts published to that feed contract.
- Lazy-create Songchain Lens clients so a missing/invalid app-shell Alchemy setup does not mask feed diagnostics with a page-level crash.

### Testing
- `pnpm vitest run lib/sdk/lens/primitive-id.test.ts` passed.
- `pnpm vitest run lib/sdk/lens/primitive-id.test.ts lib/songchain/config.test.ts` passed previously for the broader Songchain config path.
- `pnpm eslint lib/sdk/lens/primitive-id.ts lib/sdk/lens/primitive-id.test.ts` passed.
- `pnpm eslint hooks/useSongchainFeed.ts components/songchain/SongchainFeedSection.tsx components/songchain/SongchainPageClient.tsx components/songchain/SongchainGroupPanel.tsx lib/songchain/config.ts lib/sdk/lens/client.ts lib/sdk/lens/primitive-id.ts lib/sdk/lens/primitive-id.test.ts lib/songchain/config.test.ts` passed previously for all changed files.
- Manual browser verification was attempted with placeholder Songchain/Alchemy/Supabase env values, but the local dev app shell hung while compiling shared Account Kit/Viem dependencies and did not render the page reliably in this VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-477b7247-3d23-4e49-8c12-ea94fdf32d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-477b7247-3d23-4e49-8c12-ea94fdf32d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

