### PR TITLE
Add Lens Songchain feeds, social actions, and auth recovery UX

### DIFF
--- a/app/api/songchain/config-check/route.ts
+++ b/app/api/songchain/config-check/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { getSongchainConfig } from '@/lib/songchain/config';
+import { getLensNetwork } from '@/lib/sdk/lens/chains';
+import {
+  getLensNetworkLabel,
+  truncateFeedId,
+} from '@/lib/songchain/feed-diagnostics';
+
+export const dynamic = 'force-dynamic';
+
+/** Public health check for Songchain / Lens env (no secrets). */
+export async function GET() {
+  const config = getSongchainConfig();
+  const network = getLensNetwork();
+
+  return NextResponse.json({
+    ok: config.enabled,
+    lensNetwork: network,
+    lensNetworkLabel: getLensNetworkLabel(network),
+    feeds: {
+      publicConfigured: Boolean(config.publicFeedId),
+      publicFeedId: truncateFeedId(config.publicFeedId),
+      exclusiveConfigured: Boolean(config.exclusiveFeedId),
+      exclusiveFeedId: truncateFeedId(config.exclusiveFeedId),
+      groupConfigured: Boolean(config.groupId),
+      groupId: truncateFeedId(config.groupId),
+    },
+    hints: config.enabled
+      ? []
+      : [
+          'Set NEXT_PUBLIC_SONGCHAIN_FEED_ID (and related vars) in your deployment environment.',
+          'Ensure NEXT_PUBLIC_LENS_ENV matches the network where feeds were created.',
+        ],
+  });
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -20,6 +20,7 @@ import { MembershipGuard } from "@/components/auth/MembershipGuard";
 import { AccountKitStoreGuard } from "@/components/auth/AccountKitStoreGuard";
 import { OrbSessionProvider } from "@/context/OrbSessionContext";
 import { OrbLoginModal } from "@/components/auth/OrbLoginModal";
+import { OrbLinkingOverlay } from "@/components/auth/OrbLinkingOverlay";
 import NoSSR from "@/components/NoSSR";
 
 function ErrorFallback({ error }: { error: Error }) {
@@ -84,6 +85,7 @@ export const Providers = (
                               </MembershipGuard>
                             </AccountKitStoreGuard>
                             <OrbLoginModal />
+                            <OrbLinkingOverlay />
                             <Toaster position="top-right" richColors />
                           </OrbSessionProvider>
                         </VideoProvider>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -35,6 +35,7 @@ import {
   RadioTower,
   Bot,
   ShieldUser,
+  Music2,
   TrendingUp,
 } from "lucide-react";
 import type { User as AccountUser } from "@account-kit/signer";
@@ -49,6 +50,8 @@ import {
 } from "@/components/account-dropdown/AccountDropdown";
 import { MobileOrbSection } from "@/components/account-dropdown/MobileOrbSection";
 import { useOrbSession } from "@/context/OrbSessionContext";
+import { useUnifiedLogout } from "@/hooks/useUnifiedLogout";
+import { resetAppSession } from "@/lib/auth/session-recovery";
 import { shortenAddress } from "@/lib/utils/utils";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
@@ -161,7 +164,9 @@ function NetworkStatus({ isConnected }: { isConnected: boolean }) {
 export default function Navbar() {
   const { openAuthModal } = useAuthModal();
   const user = useUser();
-  const { logout } = useLogout();
+  const { logout: walletLogout } = useLogout();
+  const unifiedLogout = useUnifiedLogout();
+  const { logout: orbLogout } = useOrbSession();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
   const { account: modularAccount } = useModularAccount();
   const [displayAddress, setDisplayAddress] = useState<string>("");
@@ -188,8 +193,6 @@ export default function Navbar() {
   }, [modularAccount?.address, user?.address]);
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { isAuthenticated: isOrbAuthenticated, accountMenuRefreshSignal } =
-    useOrbSession();
   const accountDropdownRef = useRef<AccountDropdownHandle>(null);
   const [copySuccess, setCopySuccess] = useState(false);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
@@ -201,12 +204,6 @@ export default function Navbar() {
     logger.debug("Current Chain ID:", currentChain.id);
     setCurrentChainName(currentChain?.name || "Unknown Chain");
   }, [currentChain]);
-
-  // Surface Orb / Lens linked state in the mobile account menu after sign-in.
-  useEffect(() => {
-    if (!accountMenuRefreshSignal || !isOrbAuthenticated) return;
-    setIsMenuOpen(true);
-  }, [accountMenuRefreshSignal, isOrbAuthenticated]);
 
   // Add scroll effect for sticky navbar
   useEffect(() => {
@@ -454,6 +451,22 @@ export default function Navbar() {
               {/* Navigation Links */}
               <nav className="grid grid-flow-row gap-2 auto-rows-max text-sm pb-4 border-b border-gray-200 dark:border-gray-700">
                 <Link
+                  href="/"
+                  className={mobileNavLinkClass}
+                  onClick={handleLinkClick}
+                  id="mobile-nav-home-link"
+                >
+                  Home
+                </Link>
+                <Link
+                  href="/songchain"
+                  className={mobileNavLinkClass}
+                  onClick={handleLinkClick}
+                  id="mobile-nav-songchain-link"
+                >
+                  <Music2 className="mr-2 h-4 w-4" /> Songchain
+                </Link>
+                <Link
                   href="/discover"
                   className={mobileNavLinkClass}
                   onClick={handleLinkClick}
@@ -637,10 +650,10 @@ export default function Navbar() {
                     )}
 
                     {/* Logout Button */}
-                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 space-y-2">
                       <button
                         onClick={() => {
-                          logout();
+                          void unifiedLogout();
                           setIsMenuOpen(false);
                         }}
                         className="flex w-full items-center rounded-md p-2 text-sm font-medium
@@ -648,6 +661,21 @@ export default function Navbar() {
                       >
                         <LogOut className="mr-2 h-4 w-4" />
                         Logout
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void resetAppSession({
+                            walletLogout: async () => {
+                              await walletLogout();
+                            },
+                            orbLogout,
+                          });
+                        }}
+                        className="flex w-full items-center rounded-md p-2 text-xs font-medium
+                            text-muted-foreground hover:bg-muted transition-colors"
+                      >
+                        Reset session (fix login loops)
                       </button>
                     </div>
                   </>

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -31,12 +31,12 @@ import {
 } from "react";
 import {
   useAuthModal,
-  useLogout,
   useUser,
   useChain,
   useSmartAccountClient,
   useSendUserOperation,
 } from "@account-kit/react";
+import { useUnifiedLogout } from "@/hooks/useUnifiedLogout";
 import { base } from "@account-kit/infra";
 import { Button } from "@/components/ui/button";
 import {
@@ -274,7 +274,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
     accountMenuRefreshSignal,
   } = useOrbSession();
   const user = useUser();
-  const { logout } = useLogout();
+  const unifiedLogout = useUnifiedLogout();
   const { chain, setChain, isSettingChain } = useChain();
   const [displayAddress, setDisplayAddress] = useState<string>("");
   const [isNetworkConnected, setIsNetworkConnected] = useState(true);
@@ -1674,7 +1674,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               <DropdownMenuItem
                 onClick={async () => {
                   try {
-                    await logout();
+                    await unifiedLogout();
                     logger.debug('Logged out successfully');
                     // Small delay to ensure logout completes
                     setTimeout(() => {

--- a/components/auth/AccountKitStoreGuard.tsx
+++ b/components/auth/AccountKitStoreGuard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { config } from "@/config";
-import { Loader2 } from "lucide-react";
+import { GuardLoadingFallback } from "@/components/auth/GuardLoadingFallback";
 
 function isStoreReady(): boolean {
   try {
@@ -30,8 +30,6 @@ function isStoreReady(): boolean {
 /**
  * Renders children only after the Account Kit store has the current chain in connections.
  * Prevents ChainNotFoundError when useSmartAccountClient runs before the store is ready.
- * Uses useEffect + deferred setState so we never update this component during a child's render
- * (avoids "Cannot update a component while rendering a different component").
  */
 export function AccountKitStoreGuard({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
@@ -49,10 +47,8 @@ export function AccountKitStoreGuard({ children }: { children: React.ReactNode }
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const unsub = store.subscribe(() => {
       if (!isStoreReady()) return;
-      // Defer setState to next tick so we don't update during another component's render
       timeoutId = setTimeout(() => setReady(true), 0);
     });
-    // In case store became ready before we subscribed
     if (isStoreReady()) setReady(true);
     return () => {
       unsub();
@@ -60,13 +56,13 @@ export function AccountKitStoreGuard({ children }: { children: React.ReactNode }
     };
   }, []);
 
-  if (!ready) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  return <>{children}</>;
+  return (
+    <GuardLoadingFallback
+      isLoading={!ready}
+      allowBypass
+      message="Connecting wallet services…"
+    >
+      {children}
+    </GuardLoadingFallback>
+  );
 }

--- a/components/auth/GuardLoadingFallback.tsx
+++ b/components/auth/GuardLoadingFallback.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useLogout } from '@account-kit/react';
+import { useOrbSession } from '@/context/OrbSessionContext';
+import { resetAppSession } from '@/lib/auth/session-recovery';
+
+const GUARD_TIMEOUT_MS = 8000;
+
+type GuardLoadingFallbackProps = {
+  isLoading: boolean;
+  /** When true, show children after timeout instead of blocking forever. */
+  allowBypass?: boolean;
+  message?: string;
+  children: React.ReactNode;
+};
+
+export function GuardLoadingFallback({
+  isLoading,
+  allowBypass = false,
+  message = 'Loading your session…',
+  children,
+}: GuardLoadingFallbackProps) {
+  const [timedOut, setTimedOut] = useState(false);
+  const { logout: walletLogoutMutate } = useLogout();
+  const { logout: orbLogout } = useOrbSession();
+
+  const walletLogout = useCallback(async () => {
+    await walletLogoutMutate();
+  }, [walletLogoutMutate]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      setTimedOut(false);
+      return;
+    }
+    const timer = setTimeout(() => setTimedOut(true), GUARD_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isLoading]);
+
+  if (!isLoading) {
+    return <>{children}</>;
+  }
+
+  if (allowBypass && timedOut) {
+    return (
+      <>
+        {children}
+        <div
+          className="fixed inset-x-0 bottom-0 z-[100] border-t border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur-sm"
+          role="status"
+        >
+          <p className="text-sm text-muted-foreground mb-3">{message}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => window.location.reload()}
+            >
+              Retry
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() =>
+                void resetAppSession({ walletLogout, orbLogout })
+              }
+            >
+              Reset session
+            </Button>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Reset session clears wallet and Orb sign-in without wiping all browser data.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+        {timedOut && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() =>
+              void resetAppSession({ walletLogout, orbLogout })
+            }
+          >
+            Reset session
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/auth/MembershipGuard.tsx
+++ b/components/auth/MembershipGuard.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
-import { Loader2 } from "lucide-react";
 import { createContext, useContext } from "react";
 import type { MembershipStatus } from "@/lib/hooks/unlock/useMembershipVerification";
 import { logger } from '@/lib/utils/logger';
+import { GuardLoadingFallback } from "@/components/auth/GuardLoadingFallback";
 
 
 interface MembershipGuardProps {
@@ -15,57 +15,73 @@ interface MembershipGuardProps {
 
 export const MembershipContext = createContext<MembershipStatus | null>(null);
 
+const PUBLIC_PATHS = [
+  '/discover',
+  '/market',
+  '/predict',
+  '/vote',
+  '/news',
+  '/live',
+  '/watch',
+  '/profile',
+  '/upload',
+  '/creator',
+  '/memberships',
+  '/songchain',
+];
+
 export function MembershipGuard({ children }: MembershipGuardProps) {
   const router = useRouter();
   const pathname = usePathname();
   const membership = useMembershipVerification();
   const { isVerified, hasMembership, isLoading } = membership;
   const isHomePage = pathname === "/";
-
-  const PUBLIC_PATHS = [
-    '/discover',
-    '/market',
-    '/predict',
-    '/vote',
-    '/news',
-    '/live',
-    '/watch',
-    '/profile',
-    '/upload',
-    '/creator',
-    '/memberships',
-    '/songchain',
-  ];
-
   const isPublicPath = PUBLIC_PATHS.some(path => pathname?.startsWith(path));
+  const canBypassLoading = isHomePage || isPublicPath;
 
   useEffect(() => {
     logger.debug("MembershipGuard:", membership);
-    // Don't redirect if we are on the home page or a public page
     if (!isLoading && (!isVerified || !hasMembership) && !isHomePage && !isPublicPath) {
       router.push("/");
     }
   }, [isLoading, isVerified, hasMembership, router, membership, isHomePage, isPublicPath]);
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
+  if ((!isVerified || !hasMembership) && !isHomePage && !isPublicPath) {
+    if (isLoading) {
+      return (
+        <GuardLoadingFallback isLoading allowBypass={false}>
+          {null}
+        </GuardLoadingFallback>
+      );
+    }
+    return null;
   }
 
-  // Allow rendering children if:
-  // 1. User has verified membership
-  // 2. OR User is on the home page (which has its own non-logged-in view)
-  // 3. OR User is on a public page
-  if ((!isVerified || !hasMembership) && !isHomePage && !isPublicPath) {
-    return null;
+  if (isLoading && !canBypassLoading) {
+    return (
+      <GuardLoadingFallback
+        isLoading
+        allowBypass={false}
+        message="Verifying membership…"
+      >
+        {null}
+      </GuardLoadingFallback>
+    );
   }
 
   return (
     <MembershipContext.Provider value={membership}>
-      {children}
+      <GuardLoadingFallback
+        isLoading={isLoading && canBypassLoading}
+        allowBypass={canBypassLoading}
+        message="Still loading your wallet session…"
+      >
+        {children}
+      </GuardLoadingFallback>
     </MembershipContext.Provider>
   );
+}
+
+export function useMembershipContext() {
+  return useContext(MembershipContext);
 }

--- a/components/auth/OrbLinkingOverlay.tsx
+++ b/components/auth/OrbLinkingOverlay.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useOrbSession } from '@/context/OrbSessionContext';
+
+/** Full-screen overlay while Orb profile is linking after QR sign-in. */
+export function OrbLinkingOverlay() {
+  const { isLinking } = useOrbSession();
+
+  if (!isLinking) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      role="status"
+      aria-live="polite"
+      aria-label="Linking Orb profile"
+    >
+      <div className="flex flex-col items-center gap-3 rounded-lg border border-border/60 bg-card px-8 py-6 shadow-lg">
+        <Loader2 className="h-8 w-8 animate-spin text-violet-400" />
+        <p className="text-sm font-medium">Linking your Orb / Lens profile…</p>
+        <p className="text-xs text-muted-foreground max-w-xs text-center">
+          Confirm any wallet signature if prompted. This usually takes a few seconds.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/OrbLoginModal.tsx
+++ b/components/auth/OrbLoginModal.tsx
@@ -13,6 +13,8 @@ import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import { useOrbSession } from '@/context/OrbSessionContext';
 
+const QR_TIMEOUT_MS = 120_000;
+
 export function OrbLoginModal() {
   const {
     isLoginModalOpen,
@@ -27,29 +29,53 @@ export function OrbLoginModal() {
   const [deepLink, setDeepLink] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
   const startedRef = useRef(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const displayError = localError ?? loginError;
+  const displayError =
+    localError ??
+    loginError ??
+    (timedOut ? 'QR sign-in timed out. Try again or cancel.' : null);
 
   const resetFlow = useCallback(() => {
     setQrCode(null);
     setDeepLink(null);
     setLocalError(null);
+    setTimedOut(false);
     clearLoginError();
     startedRef.current = false;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
   }, [clearLoginError]);
 
   const startConnect = useCallback(async () => {
     setIsConnecting(true);
     setLocalError(null);
+    setTimedOut(false);
     clearLoginError();
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setTimedOut(true);
+      setIsConnecting(false);
+    }, QR_TIMEOUT_MS);
     try {
       await connectWithQr(({ qrCode: qr, deepLink: link }) => {
         setQrCode(qr);
         setDeepLink(link ?? null);
       });
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
     } catch (err) {
       setLocalError(err instanceof Error ? err.message : 'Orb sign-in failed');
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
     } finally {
       setIsConnecting(false);
     }
@@ -67,7 +93,7 @@ export function OrbLoginModal() {
       return;
     }
 
-    if (displayError || startedRef.current) return;
+    if ((displayError && !timedOut) || startedRef.current) return;
 
     startedRef.current = true;
     void startConnect();
@@ -78,17 +104,26 @@ export function OrbLoginModal() {
     closeLoginModal,
     resetFlow,
     displayError,
+    timedOut,
     startConnect,
   ]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCancel = () => {
+    resetFlow();
+    closeLoginModal();
+  };
 
   return (
     <Dialog
       open={isLoginModalOpen}
       onOpenChange={(open) => {
-        if (!open) {
-          resetFlow();
-          closeLoginModal();
-        }
+        if (!open) handleCancel();
       }}
     >
       <DialogContent className="sm:max-w-md">
@@ -101,10 +136,10 @@ export function OrbLoginModal() {
         </DialogHeader>
 
         <div className="flex flex-col items-center gap-4 py-2">
-          {isConnecting && !qrCode && (
+          {isConnecting && !qrCode && !displayError && (
             <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
           )}
-          {qrCode && (
+          {qrCode && !displayError && (
             <div className="relative h-56 w-56 overflow-hidden rounded-lg border bg-white p-2">
               <Image
                 src={qrCode}
@@ -125,8 +160,8 @@ export function OrbLoginModal() {
           {displayError && (
             <p className="text-center text-sm text-destructive">{displayError}</p>
           )}
-          {displayError && (
-            <div className="flex w-full flex-col gap-2 sm:flex-row">
+          <div className="flex w-full flex-col gap-2 sm:flex-row">
+            {(displayError || qrCode) && (
               <Button
                 className="flex-1"
                 onClick={() => {
@@ -137,18 +172,15 @@ export function OrbLoginModal() {
               >
                 Try again
               </Button>
-              <Button
-                variant="secondary"
-                className="flex-1"
-                onClick={() => {
-                  resetFlow();
-                  closeLoginModal();
-                }}
-              >
-                Close
-              </Button>
-            </div>
-          )}
+            )}
+            <Button
+              variant={displayError || qrCode ? 'secondary' : 'outline'}
+              className="flex-1"
+              onClick={handleCancel}
+            >
+              Cancel
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/songchain/SongchainAuthorTimeline.tsx
+++ b/components/songchain/SongchainAuthorTimeline.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchPosts } from "@lens-protocol/client/actions";
+import { evmAddress } from "@lens-protocol/types";
+import type { AnyPost } from "@lens-protocol/graphql";
+import { publicClient } from "@/lib/sdk/lens/client";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
+
+type SongchainAuthorTimelineProps = {
+  authorAddress: string;
+  authorLabel: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function SongchainAuthorTimeline({
+  authorAddress,
+  authorLabel,
+  open,
+  onOpenChange,
+}: SongchainAuthorTimelineProps) {
+  const [posts, setPosts] = useState<AnyPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!authorAddress) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchPosts(publicClient, {
+        filter: {
+          authors: [evmAddress(authorAddress)],
+        },
+      });
+      if (result.isErr()) throw new Error(result.error.message);
+      setPosts([...result.value.items]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load timeline");
+      setPosts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [authorAddress]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Timeline — {authorLabel}</DialogTitle>
+        </DialogHeader>
+        {loading && (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!loading && !error && posts.length === 0 && (
+          <p className="text-sm text-muted-foreground py-4">No posts found.</p>
+        )}
+        <div className="space-y-4">
+          {posts.map((post) => (
+            <SongchainPostCard key={post.id} post={post} compact />
+          ))}
+        </div>
+        {posts.length > 0 && (
+          <Button variant="outline" size="sm" onClick={() => void load()}>
+            Refresh
+          </Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/songchain/SongchainBookmarksSection.tsx
+++ b/components/songchain/SongchainBookmarksSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useSongchainBookmarks } from "@/hooks/useSongchainBookmarks";
+import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
+
+export function SongchainBookmarksSection() {
+  const { posts, loading, error, reload, canWrite, promptWriteAccess } =
+    useSongchainBookmarks();
+
+  if (!canWrite) {
+    return (
+      <section className="rounded-lg border border-dashed border-border/60 p-8 text-center">
+        <p className="text-muted-foreground mb-4">
+          Sign in with Orb and link your profile to view saved bookmarks.
+        </p>
+        <Button variant="outline" onClick={promptWriteAccess}>
+          Link Orb account
+        </Button>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold">Bookmarks</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Posts you saved on Lens.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" disabled={loading} onClick={() => reload()}>
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <p className="mb-4 text-sm text-destructive">{error}</p>
+      )}
+
+      {loading && posts.length === 0 ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : posts.length === 0 ? (
+        <p className="text-center text-muted-foreground py-12">No bookmarks yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {posts.map((post) => (
+            <SongchainPostCard key={post.id} post={post} onReactionChange={reload} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/songchain/SongchainComposePost.tsx
+++ b/components/songchain/SongchainComposePost.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useSongchainPost } from "@/hooks/useSongchainPost";
+
+type SongchainComposePostProps = {
+  feedId: string | null;
+  onPosted?: () => void;
+};
+
+export function SongchainComposePost({ feedId, onPosted }: SongchainComposePostProps) {
+  const [content, setContent] = useState("");
+  const { createPost, isPosting, canWrite, promptWriteAccess } = useSongchainPost();
+
+  if (!feedId) return null;
+
+  const handleSubmit = async () => {
+    const ok = await createPost({ content, feedId });
+    if (ok) {
+      setContent("");
+      onPosted?.();
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-border/60 bg-card p-4 space-y-3">
+      <h3 className="text-sm font-semibold">Create a post</h3>
+      {!canWrite && (
+        <p className="text-xs text-muted-foreground">
+          Connect wallet, sign in with Orb, and link your profile to post to this feed.
+        </p>
+      )}
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Share something with Songchain…"
+        rows={3}
+        disabled={isPosting}
+        maxLength={5000}
+      />
+      <div className="flex justify-end gap-2">
+        {!canWrite ? (
+          <Button type="button" variant="outline" size="sm" onClick={promptWriteAccess}>
+            Link Orb to post
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            disabled={isPosting || !content.trim()}
+            onClick={() => void handleSubmit()}
+          >
+            {isPosting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            Post
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -4,12 +4,55 @@ import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSongchainFeed } from "@/hooks/useSongchainFeed";
 import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
+import { getFeedDiagnosticInfo } from "@/lib/songchain/feed-diagnostics";
 
 type SongchainFeedSectionProps = {
   title: string;
   description: string;
   feedId: string | null;
 };
+
+function FeedDiagnostics({
+  feedId,
+  error,
+  isEmpty,
+}: {
+  feedId: string | null;
+  error: string | null;
+  isEmpty: boolean;
+}) {
+  const info = getFeedDiagnosticInfo(feedId);
+
+  return (
+    <div className="mb-4 rounded-md border border-border/50 bg-muted/30 px-4 py-3 text-xs text-muted-foreground space-y-1">
+      <p>
+        <span className="font-medium text-foreground">Lens network:</span>{" "}
+        {info.lensNetworkLabel}
+        {info.lensNetwork === "testnet" && (
+          <span className="ml-1">
+            — set <code className="text-[10px]">NEXT_PUBLIC_LENS_ENV=production</code> for
+            mainnet feeds
+          </span>
+        )}
+      </p>
+      <p>
+        <span className="font-medium text-foreground">Feed:</span>{" "}
+        <code className="text-[10px]">{info.feedIdDisplay}</code>
+      </p>
+      {error && (
+        <p className="text-destructive">
+          <span className="font-medium">API error:</span> {error}
+        </p>
+      )}
+      {isEmpty && !error && feedId && (
+        <p>
+          Feed is reachable but has no posts yet. Posts must be created on this custom feed
+          address (not the global Lens feed).
+        </p>
+      )}
+    </div>
+  );
+}
 
 export function SongchainFeedSection({
   title,
@@ -21,10 +64,15 @@ export function SongchainFeedSection({
   });
 
   if (!feedId) {
+    const info = getFeedDiagnosticInfo(null);
     return (
       <section className="rounded-lg border border-dashed border-border/60 p-8 text-center text-muted-foreground">
         <h2 className="text-lg font-semibold text-foreground mb-2">{title}</h2>
         <p className="text-sm">Feed address not configured yet.</p>
+        <p className="mt-3 text-xs">
+          Set <code>NEXT_PUBLIC_SONGCHAIN_FEED_ID</code> ({info.lensNetworkLabel}) in your
+          environment, then redeploy if needed.
+        </p>
       </section>
     );
   }
@@ -36,9 +84,11 @@ export function SongchainFeedSection({
         <p className="text-muted-foreground mt-1">{description}</p>
       </div>
 
+      <FeedDiagnostics feedId={feedId} error={error} isEmpty={!loading && posts.length === 0} />
+
       {error && (
         <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
+          Could not load posts.
           <Button variant="link" className="ml-2 h-auto p-0" onClick={() => reload()}>
             Retry
           </Button>
@@ -54,7 +104,12 @@ export function SongchainFeedSection({
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {posts.map((post) => (
-            <SongchainPostCard key={post.id} post={post} onReactionChange={reload} />
+            <SongchainPostCard
+              key={post.id}
+              post={post}
+              feedId={feedId}
+              onReactionChange={reload}
+            />
           ))}
         </div>
       )}

--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -37,7 +37,8 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
         try {
           client = await getSessionClient();
         } catch (err) {
-          if (!clearStaleOrbSessionIfNeeded(err)) throw err;
+          clearStaleOrbSessionIfNeeded(err);
+          client = publicClient;
         }
       }
 

--- a/components/songchain/SongchainLensAdvancedPanel.tsx
+++ b/components/songchain/SongchainLensAdvancedPanel.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+
+type SongchainLensAdvancedPanelProps = {
+  className?: string;
+};
+
+/**
+ * Documents Lens primitives not yet exposed in-app (boost, custom feed rules, post rules).
+ * Manage feeds and rules in the Lens / Orb dashboard until admin UI is built.
+ */
+export function SongchainLensAdvancedPanel({ className }: SongchainLensAdvancedPanelProps) {
+  return (
+    <section
+      className={`rounded-lg border border-border/40 bg-muted/20 p-6 text-sm text-muted-foreground ${className ?? ""}`}
+    >
+      <h2 className="text-base font-semibold text-foreground mb-2">
+        Advanced Lens features
+      </h2>
+      <p className="mb-3">
+        Boost engagement, custom feed creation, feed rules, and post rules are configured
+        on-chain via Lens — not yet in Creative TV UI. Use the Lens dashboard for:
+      </p>
+      <ul className="list-disc pl-5 space-y-1 mb-4">
+        <li>Custom feeds and feed rule contracts</li>
+        <li>Post rules and moderation policies</li>
+        <li>Sponsored / boost flows where supported</li>
+      </ul>
+      <Link
+        href="https://lens.xyz/docs"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 text-violet-400 hover:text-violet-300"
+      >
+        Lens documentation
+        <ExternalLink className="h-3.5 w-3.5" />
+      </Link>
+    </section>
+  );
+}

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -5,15 +5,24 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect";
 import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
 import { SongchainGroupPanel } from "@/components/songchain/SongchainGroupPanel";
+import { SongchainComposePost } from "@/components/songchain/SongchainComposePost";
+import { SongchainBookmarksSection } from "@/components/songchain/SongchainBookmarksSection";
+import { SongchainLensAdvancedPanel } from "@/components/songchain/SongchainLensAdvancedPanel";
 import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
 import type { SongchainConfig } from "@/lib/songchain/config";
 import { Music2 } from "lucide-react";
+import { useCallback, useState } from "react";
 
 type SongchainPageClientProps = {
   config: SongchainConfig;
 };
 
 export function SongchainPageClient({ config }: SongchainPageClientProps) {
+  const [feedRefreshKey, setFeedRefreshKey] = useState(0);
+  const bumpFeedRefresh = useCallback(() => {
+    setFeedRefreshKey((k) => k + 1);
+  }, []);
+
   return (
     <div className="mx-auto w-full max-w-7xl py-10 px-4 sm:px-6">
       <nav className="mb-6 text-sm text-muted-foreground">
@@ -51,22 +60,33 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
       </div>
 
       <Tabs defaultValue="feed" className="space-y-8">
-        <TabsList>
+        <TabsList className="flex flex-wrap h-auto gap-1">
           <TabsTrigger value="feed">Feed</TabsTrigger>
           <TabsTrigger value="exclusive">Exclusive</TabsTrigger>
           <TabsTrigger value="group">Group</TabsTrigger>
+          <TabsTrigger value="bookmarks">Bookmarks</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="feed">
+        <TabsContent value="feed" className="space-y-6">
+          <SongchainComposePost
+            feedId={config.publicFeedId}
+            onPosted={bumpFeedRefresh}
+          />
           <SongchainFeedSection
+            key={`public-${feedRefreshKey}`}
             title="Songchain feed"
             description="Posts from the main Songchain Lens feed (Orb)."
             feedId={config.publicFeedId}
           />
         </TabsContent>
 
-        <TabsContent value="exclusive">
+        <TabsContent value="exclusive" className="space-y-6">
+          <SongchainComposePost
+            feedId={config.exclusiveFeedId}
+            onPosted={bumpFeedRefresh}
+          />
           <SongchainFeedSection
+            key={`exclusive-${feedRefreshKey}`}
             title="Exclusive feed"
             description="Members-only drops and announcements on Lens."
             feedId={config.exclusiveFeedId}
@@ -76,7 +96,13 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
         <TabsContent value="group">
           <SongchainGroupPanel groupId={config.groupId} />
         </TabsContent>
+
+        <TabsContent value="bookmarks">
+          <SongchainBookmarksSection />
+        </TabsContent>
       </Tabs>
+
+      <SongchainLensAdvancedPanel className="mt-10" />
 
       {!config.enabled && (
         <p className="mt-10 text-center text-sm text-muted-foreground">
@@ -84,7 +110,8 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
           <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code>,{" "}
           <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID</code>, and{" "}
           <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GROUP_ID</code> with your Lens
-          primitives, then redeploy if you added them after the last build.
+          primitives, then redeploy if you added them after the last build. See{" "}
+          <code className="text-xs">env.example</code> in the repo.
         </p>
       )}
     </div>

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -38,25 +38,31 @@ import { resolveOrbMediaUrl } from "@/lib/sdk/orb/media";
 import { publicClient } from "@/lib/sdk/lens/client";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { groveService } from "@/lib/sdk/grove/service";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { SongchainAuthorTimeline } from "@/components/songchain/SongchainAuthorTimeline";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
 
-function resolvePost(post: AnyPost) {
-  return post.__typename === "Repost" ? post.repostOf : post;
+function resolvePost(post: AnyPost): AnyPost | null {
+  if (post.__typename === "Repost") {
+    return post.repostOf ?? null;
+  }
+  return post;
 }
 
 function postText(post: AnyPost): string {
-  const meta = resolvePost(post).metadata;
-  if (!meta) return "";
+  const resolved = resolvePost(post);
+  if (!resolved || !("metadata" in resolved) || !resolved.metadata) return "";
+  const meta = resolved.metadata;
   if ("content" in meta && typeof meta.content === "string") return meta.content;
   if ("title" in meta && typeof meta.title === "string") return meta.title;
   return "";
 }
 
 function postImage(post: AnyPost): string | null {
-  const meta = resolvePost(post).metadata;
-  if (!meta) return null;
+  const resolved = resolvePost(post);
+  if (!resolved || !("metadata" in resolved) || !resolved.metadata) return null;
+  const meta = resolved.metadata;
   if ("image" in meta && meta.image?.item) {
     return resolveOrbMediaUrl(String(meta.image.item));
   }
@@ -97,25 +103,47 @@ export function SongchainPostCard({
   const [bookmarked, setBookmarked] = useState(false);
 
   const content = resolvePost(post);
-  const ops = "operations" in content ? content.operations : null;
+  const ops =
+    content != null && "operations" in content ? content.operations : null;
   const hasReacted =
     ops != null && "hasReacted" in ops && ops.hasReacted === true;
   const [upvoted, setUpvoted] = useState(hasReacted);
   const imageUrl = postImage(post);
-  const reactions = content.stats?.upvotes ?? 0;
+  const reactions =
+    content != null && "stats" in content ? (content.stats?.upvotes ?? 0) : 0;
   const isOwner =
     !!lensAccount &&
+    !!content &&
     content.author.address.toLowerCase() === lensAccount.toLowerCase();
 
   useEffect(() => {
     setUpvoted(hasReacted);
-  }, [hasReacted, content.id]);
+  }, [hasReacted, content?.id]);
 
   useEffect(() => {
     if (ops && "hasBookmarked" in ops) {
       setBookmarked(Boolean(ops.hasBookmarked));
     }
-  }, [ops, content.id]);
+  }, [ops, content?.id]);
+
+  const loadComments = useCallback(async () => {
+    if (!content) return;
+    try {
+      const result = await fetchPostReferences(publicClient, {
+        referencedPost: postId(content.id),
+        referenceTypes: [PostReferenceType.CommentOn],
+      });
+      if (result.isOk()) setComments([...result.value.items]);
+    } catch {
+      // Non-fatal
+    }
+  }, [content]);
+
+  useEffect(() => {
+    if (showComments) void loadComments();
+  }, [showComments, loadComments]);
+
+  if (!content) return null;
 
   const withWrite = async (
     action: string,
@@ -130,6 +158,7 @@ export function SongchainPostCard({
       await fn();
       onReactionChange?.();
     } catch (err) {
+      clearStaleOrbSessionIfNeeded(err);
       toast.error(err instanceof Error ? err.message : "Action failed");
     } finally {
       setPending(null);
@@ -169,22 +198,6 @@ export function SongchainPostCard({
       if (result.isErr()) throw new Error(result.error.message);
       toast.success("Reposted");
     });
-
-  const loadComments = useCallback(async () => {
-    try {
-      const result = await fetchPostReferences(publicClient, {
-        referencedPost: postId(content.id),
-        referenceTypes: [PostReferenceType.CommentOn],
-      });
-      if (result.isOk()) setComments([...result.value.items]);
-    } catch {
-      // Non-fatal
-    }
-  }, [content.id]);
-
-  useEffect(() => {
-    if (showComments) void loadComments();
-  }, [showComments, loadComments]);
 
   const submitComment = () =>
     void withWrite("comment", async () => {

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -1,40 +1,66 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import {
   addReaction,
   undoReaction,
+  editPost,
+  deletePost,
+  bookmarkPost,
+  undoBookmarkPost,
+  repost,
+  post as createLensPost,
+  fetchPostReferences,
 } from "@lens-protocol/client/actions";
-import { postId } from "@lens-protocol/types";
+import { evmAddress, postId, uri, PostReferenceType } from "@lens-protocol/client";
+import { textOnly } from "@lens-protocol/metadata";
 import type { AnyPost } from "@lens-protocol/graphql";
-import { Heart, Loader2 } from "lucide-react";
+import {
+  Heart,
+  Loader2,
+  MessageCircle,
+  Repeat2,
+  Bookmark,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { resolveOrbMediaUrl } from "@/lib/sdk/orb/media";
+import { publicClient } from "@/lib/sdk/lens/client";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { groveService } from "@/lib/sdk/grove/service";
+import { SongchainAuthorTimeline } from "@/components/songchain/SongchainAuthorTimeline";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
 
-/** Lens feed items may be reposts; read metadata from the underlying post. */
 function resolvePost(post: AnyPost) {
   return post.__typename === "Repost" ? post.repostOf : post;
 }
 
 function postText(post: AnyPost): string {
   const meta = resolvePost(post).metadata;
-  if (!meta) return '';
-  if ('content' in meta && typeof meta.content === 'string') return meta.content;
-  if ('title' in meta && typeof meta.title === 'string') return meta.title;
-  return '';
+  if (!meta) return "";
+  if ("content" in meta && typeof meta.content === "string") return meta.content;
+  if ("title" in meta && typeof meta.title === "string") return meta.title;
+  return "";
 }
 
 function postImage(post: AnyPost): string | null {
   const meta = resolvePost(post).metadata;
   if (!meta) return null;
-  if ('image' in meta && meta.image?.item) {
+  if ("image" in meta && meta.image?.item) {
     return resolveOrbMediaUrl(String(meta.image.item));
   }
-  if ('video' in meta && meta.video?.cover) {
+  if ("video" in meta && meta.video?.cover) {
     return resolveOrbMediaUrl(String(meta.video.cover));
   }
   return null;
@@ -48,91 +74,362 @@ function authorLabel(post: AnyPost): string {
 
 type SongchainPostCardProps = {
   post: AnyPost;
+  feedId?: string | null;
+  compact?: boolean;
   onReactionChange?: () => void;
 };
 
-export function SongchainPostCard({ post, onReactionChange }: SongchainPostCardProps) {
-  const { canWrite, getSessionClient, promptWriteAccess } = useLensOrbWrite();
-  const [pending, setPending] = useState(false);
+export function SongchainPostCard({
+  post,
+  feedId,
+  compact = false,
+  onReactionChange,
+}: SongchainPostCardProps) {
+  const { canWrite, getSessionClient, promptWriteAccess, lensAccount } =
+    useLensOrbWrite();
+  const [pending, setPending] = useState<string | null>(null);
+  const [showComments, setShowComments] = useState(false);
+  const [comments, setComments] = useState<AnyPost[]>([]);
+  const [commentText, setCommentText] = useState("");
+  const [editOpen, setEditOpen] = useState(false);
+  const [editText, setEditText] = useState("");
+  const [timelineOpen, setTimelineOpen] = useState(false);
+  const [bookmarked, setBookmarked] = useState(false);
+
   const content = resolvePost(post);
   const ops = "operations" in content ? content.operations : null;
   const hasReacted =
-    ops != null && 'hasReacted' in ops && ops.hasReacted === true;
+    ops != null && "hasReacted" in ops && ops.hasReacted === true;
   const [upvoted, setUpvoted] = useState(hasReacted);
+  const imageUrl = postImage(post);
+  const reactions = content.stats?.upvotes ?? 0;
+  const isOwner =
+    !!lensAccount &&
+    content.author.address.toLowerCase() === lensAccount.toLowerCase();
 
   useEffect(() => {
     setUpvoted(hasReacted);
   }, [hasReacted, content.id]);
-  const imageUrl = postImage(post);
-  const reactions = content.stats?.upvotes ?? 0;
 
-  const toggleUpvote = async () => {
+  useEffect(() => {
+    if (ops && "hasBookmarked" in ops) {
+      setBookmarked(Boolean(ops.hasBookmarked));
+    }
+  }, [ops, content.id]);
+
+  const withWrite = async (
+    action: string,
+    fn: () => Promise<void>,
+  ) => {
     if (!canWrite) {
       promptWriteAccess();
-      toast.info('Link your Orb account to like posts on Lens');
       return;
     }
-
-    setPending(true);
+    setPending(action);
     try {
-      const client = await getSessionClient();
-      const id = postId(content.id);
-      const result = upvoted
-        ? await undoReaction(client, { post: id, reaction: 'UPVOTE' })
-        : await addReaction(client, { post: id, reaction: 'UPVOTE' });
-
-      if (result.isErr()) {
-        throw new Error(result.error.message);
-      }
-      setUpvoted(!upvoted);
+      await fn();
       onReactionChange?.();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Reaction failed');
+      toast.error(err instanceof Error ? err.message : "Action failed");
     } finally {
-      setPending(false);
+      setPending(null);
     }
   };
 
+  const toggleUpvote = () =>
+    void withWrite("upvote", async () => {
+      const client = await getSessionClient();
+      const id = postId(content.id);
+      const result = upvoted
+        ? await undoReaction(client, { post: id, reaction: "UPVOTE" })
+        : await addReaction(client, { post: id, reaction: "UPVOTE" });
+      if (result.isErr()) throw new Error(result.error.message);
+      setUpvoted(!upvoted);
+    });
+
+  const toggleBookmark = () =>
+    void withWrite("bookmark", async () => {
+      const client = await getSessionClient();
+      const id = postId(content.id);
+      const result = bookmarked
+        ? await undoBookmarkPost(client, { post: id })
+        : await bookmarkPost(client, { post: id });
+      if (result.isErr()) throw new Error(result.error.message);
+      setBookmarked(!bookmarked);
+      toast.success(bookmarked ? "Removed bookmark" : "Saved to bookmarks");
+    });
+
+  const handleRepost = () =>
+    void withWrite("repost", async () => {
+      const client = await getSessionClient();
+      const result = await repost(client, {
+        post: postId(content.id),
+        ...(feedId ? { feed: evmAddress(feedId) } : {}),
+      });
+      if (result.isErr()) throw new Error(result.error.message);
+      toast.success("Reposted");
+    });
+
+  const loadComments = useCallback(async () => {
+    try {
+      const result = await fetchPostReferences(publicClient, {
+        referencedPost: postId(content.id),
+        referenceTypes: [PostReferenceType.CommentOn],
+      });
+      if (result.isOk()) setComments([...result.value.items]);
+    } catch {
+      // Non-fatal
+    }
+  }, [content.id]);
+
+  useEffect(() => {
+    if (showComments) void loadComments();
+  }, [showComments, loadComments]);
+
+  const submitComment = () =>
+    void withWrite("comment", async () => {
+      const trimmed = commentText.trim();
+      if (!trimmed) return;
+      const client = await getSessionClient();
+      const metadata = textOnly({ content: trimmed, locale: "en" });
+      const upload = await groveService.uploadJson(metadata);
+      if (!upload.success || !upload.url) {
+        throw new Error("Failed to upload comment metadata");
+      }
+      const result = await createLensPost(client, {
+        contentUri: uri(upload.url),
+        commentOn: { post: postId(content.id) },
+        ...(feedId ? { feed: evmAddress(feedId) } : {}),
+      });
+      if (result.isErr()) throw new Error(result.error.message);
+      setCommentText("");
+      toast.success("Comment posted");
+      void loadComments();
+    });
+
+  const submitEdit = () =>
+    void withWrite("edit", async () => {
+      const trimmed = editText.trim();
+      if (!trimmed) return;
+      const client = await getSessionClient();
+      const metadata = textOnly({ content: trimmed, locale: "en" });
+      const upload = await groveService.uploadJson(metadata);
+      if (!upload.success || !upload.url) {
+        throw new Error("Failed to upload edit metadata");
+      }
+      const result = await editPost(client, {
+        post: postId(content.id),
+        contentUri: uri(upload.url),
+      });
+      if (result.isErr()) throw new Error(result.error.message);
+      setEditOpen(false);
+      toast.success("Post updated");
+    });
+
+  const handleDelete = () => {
+    if (!window.confirm("Delete this post? This cannot be undone.")) return;
+    void withWrite("delete", async () => {
+      const client = await getSessionClient();
+      const result = await deletePost(client, { post: postId(content.id) });
+      if (result.isErr()) throw new Error(result.error.message);
+      toast.success("Post deleted");
+    });
+  };
+
   return (
-    <article className="flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card shadow-sm">
-      {imageUrl && (
-        <div className="relative aspect-video w-full bg-muted">
-          <Image
-            src={imageUrl}
-            alt=""
-            fill
-            className="object-cover"
-            unoptimized
-          />
-        </div>
-      )}
-      <div className="flex flex-1 flex-col gap-3 p-4">
-        <p className="text-xs text-muted-foreground">{authorLabel(post)}</p>
-        {postText(post) && (
-          <p className="text-sm leading-relaxed whitespace-pre-wrap">{postText(post)}</p>
+    <>
+      <article
+        className={cn(
+          "flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card shadow-sm",
+          compact && "text-sm",
         )}
-        <div className="mt-auto flex items-center justify-between gap-2 pt-2 border-t border-border/40">
-          <span className="text-xs text-muted-foreground">
-            {reactions} upvote{reactions === 1 ? '' : 's'}
-          </span>
-          <Button
+      >
+        {imageUrl && !compact && (
+          <div className="relative aspect-video w-full bg-muted">
+            <Image
+              src={imageUrl}
+              alt=""
+              fill
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+        )}
+        <div className="flex flex-1 flex-col gap-3 p-4">
+          <button
             type="button"
-            variant="ghost"
-            size="sm"
-            disabled={pending}
-            onClick={() => void toggleUpvote()}
-            className={cn(upvoted && 'text-rose-500 hover:text-rose-600')}
-            aria-pressed={upvoted}
-            aria-label={upvoted ? 'Remove upvote' : 'Upvote post'}
+            className="text-xs text-muted-foreground text-left hover:text-violet-400 w-fit"
+            onClick={() => setTimelineOpen(true)}
           >
-            {pending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Heart className={cn('h-4 w-4', upvoted && 'fill-current')} />
+            {authorLabel(post)}
+          </button>
+          {postText(post) && (
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">
+              {postText(post)}
+            </p>
+          )}
+          <div className="mt-auto flex flex-wrap items-center gap-1 pt-2 border-t border-border/40">
+            <span className="text-xs text-muted-foreground mr-auto">
+              {reactions} upvote{reactions === 1 ? "" : "s"}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending === "upvote"}
+              onClick={toggleUpvote}
+              className={cn(upvoted && "text-rose-500")}
+              aria-label="Upvote"
+            >
+              {pending === "upvote" ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Heart className={cn("h-4 w-4", upvoted && "fill-current")} />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowComments((v) => !v)}
+              aria-label="Comments"
+            >
+              <MessageCircle className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending === "repost"}
+              onClick={handleRepost}
+              aria-label="Repost"
+            >
+              {pending === "repost" ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Repeat2 className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending === "bookmark"}
+              onClick={toggleBookmark}
+              className={cn(bookmarked && "text-amber-500")}
+              aria-label="Bookmark"
+            >
+              {pending === "bookmark" ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Bookmark className={cn("h-4 w-4", bookmarked && "fill-current")} />
+              )}
+            </Button>
+            {isOwner && (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setEditText(postText(post));
+                    setEditOpen(true);
+                  }}
+                  aria-label="Edit post"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={pending === "delete"}
+                  onClick={handleDelete}
+                  className="text-destructive"
+                  aria-label="Delete post"
+                >
+                  {pending === "delete" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </>
             )}
-          </Button>
+          </div>
+
+          {showComments && (
+            <div className="space-y-2 border-t border-border/30 pt-3">
+              {comments.length > 0 && (
+                <ul className="space-y-2 text-xs text-muted-foreground">
+                  {comments.map((c) => (
+                    <li key={c.id} className="rounded bg-muted/40 p-2">
+                      <span className="font-medium">{authorLabel(c)}: </span>
+                      {postText(c)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {canWrite ? (
+                <div className="flex gap-2">
+                  <Textarea
+                    value={commentText}
+                    onChange={(e) => setCommentText(e.target.value)}
+                    placeholder="Write a comment…"
+                    rows={2}
+                    className="text-xs"
+                  />
+                  <Button
+                    size="sm"
+                    disabled={pending === "comment" || !commentText.trim()}
+                    onClick={submitComment}
+                  >
+                    Post
+                  </Button>
+                </div>
+              ) : (
+                <Button size="sm" variant="outline" onClick={promptWriteAccess}>
+                  Link Orb to comment
+                </Button>
+              )}
+            </div>
+          )}
         </div>
-      </div>
-    </article>
+      </article>
+
+      <SongchainAuthorTimeline
+        authorAddress={content.author.address}
+        authorLabel={authorLabel(post)}
+        open={timelineOpen}
+        onOpenChange={setTimelineOpen}
+      />
+
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit post</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            rows={4}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={pending === "edit" || !editText.trim()}
+              onClick={submitEdit}
+            >
+              {pending === "edit" ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : null}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/env.example
+++ b/env.example
@@ -1,0 +1,27 @@
+# Creative TV — environment variables (copy to .env.local)
+
+# --- Account Kit / Alchemy ---
+NEXT_PUBLIC_ALCHEMY_API_KEY=
+NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID=
+
+# --- Lens / Songchain ---
+# Network: omit or set anything except "production" for Lens testnet (Sepolia).
+# Set to "production" for Lens mainnet feeds and API.
+NEXT_PUBLIC_LENS_ENV=testnet
+
+# Custom feed contract addresses (lowercase 0x…). Required for /songchain feeds.
+NEXT_PUBLIC_SONGCHAIN_FEED_ID=
+NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID=
+NEXT_PUBLIC_SONGCHAIN_GROUP_ID=
+
+# Optional server-only fallbacks (no NEXT_PUBLIC_ prefix)
+# SONGCHAIN_FEED_ID=
+# SONGCHAIN_EXCLUSIVE_FEED_ID=
+# SONGCHAIN_GROUP_ID=
+
+# Optional Lens RPC override
+# NEXT_PUBLIC_LENS_RPC_URL=
+
+# --- Halliday onramp (Songchain) ---
+# NEXT_PUBLIC_HALLIDAY_API_KEY=
+# NEXT_PUBLIC_HALLIDAY_DESTINATION_TOKEN=

--- a/hooks/useLens.ts
+++ b/hooks/useLens.ts
@@ -8,7 +8,7 @@ import { useOrbSession } from "@/context/OrbSessionContext";
 import { video, MediaVideoMimeType, MetadataLicenseType } from "@lens-protocol/metadata";
 import { groveService } from "@/lib/sdk/grove/service";
 import { post } from "@lens-protocol/client/actions";
-import { uri, SessionClient } from "@lens-protocol/client";
+import { uri, SessionClient, evmAddress } from "@lens-protocol/client";
 import { WalletClient } from "viem";
 import { toast } from "sonner";
 
@@ -18,6 +18,8 @@ export interface CreatePostParams {
   title?: string;
   coverUrl?: string;
   mimeType?: MediaVideoMimeType;
+  /** Custom Lens feed address; posts appear in fetchPosts for that feed. */
+  feedId?: string;
 }
 
 export interface UseLensReturn {
@@ -98,6 +100,7 @@ export function useLens(): UseLensReturn {
       title = "Creative TV Video",
       coverUrl,
       mimeType = MediaVideoMimeType.MP4,
+      feedId,
     }: CreatePostParams) => {
       let activeClient = sessionClient;
       if (!activeClient) {
@@ -134,6 +137,7 @@ export function useLens(): UseLensReturn {
 
         const result = await post(activeClient, {
           contentUri: uri(uploadResult.url),
+          ...(feedId ? { feed: evmAddress(feedId) } : {}),
         });
 
         if (result.isErr()) {

--- a/hooks/useLensOrbWrite.ts
+++ b/hooks/useLensOrbWrite.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
+import { useAuthModal } from '@account-kit/react';
 import { useOrbSession } from '@/context/OrbSessionContext';
 import { resumeLensSessionFromOrb } from '@/lib/sdk/lens/orb-session-client';
 import type { SessionClient } from '@lens-protocol/client';
@@ -27,6 +28,7 @@ export function useLensOrbWrite(): LensOrbWriteAccess {
     hasWallet,
     openLoginModal,
   } = useOrbSession();
+  const { openAuthModal } = useAuthModal();
 
   const canWrite = isAuthenticated && linkStatus === 'linked';
   const needsLink = isAuthenticated && linkStatus !== 'linked';
@@ -44,14 +46,14 @@ export function useLensOrbWrite(): LensOrbWriteAccess {
   }, [canWrite, session, syncSession]);
 
   const promptWriteAccess = useCallback(() => {
+    if (!hasWallet) {
+      openAuthModal();
+      return;
+    }
     if (needsOrbLogin || needsLink) {
-      if (!hasWallet && needsOrbLogin) {
-        openLoginModal();
-        return;
-      }
       openLoginModal();
     }
-  }, [needsOrbLogin, needsLink, hasWallet, openLoginModal]);
+  }, [needsOrbLogin, needsLink, hasWallet, openLoginModal, openAuthModal]);
 
   return useMemo(
     () => ({

--- a/hooks/useSongchainBookmarks.ts
+++ b/hooks/useSongchainBookmarks.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { fetchPostBookmarks } from '@lens-protocol/client/actions';
+import type { AnyPost } from '@lens-protocol/graphql';
+import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
+import { clearStaleOrbSessionIfNeeded } from '@/lib/sdk/orb/session-errors';
+
+export function useSongchainBookmarks() {
+  const [posts, setPosts] = useState<AnyPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { canWrite, getSessionClient, promptWriteAccess } = useLensOrbWrite();
+
+  const load = useCallback(async () => {
+    if (!canWrite) {
+      setPosts([]);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const client = await getSessionClient();
+      const result = await fetchPostBookmarks(client);
+      if (result.isErr()) throw new Error(result.error.message);
+      setPosts([...result.value.items]);
+    } catch (err) {
+      if (clearStaleOrbSessionIfNeeded(err)) {
+        setError('Session expired — link Orb again.');
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load bookmarks');
+      }
+      setPosts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [canWrite, getSessionClient]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { posts, loading, error, reload: load, canWrite, promptWriteAccess };
+}

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -34,8 +34,9 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
           try {
             client = await getSessionClient();
           } catch (err) {
-            if (!clearStaleOrbSessionIfNeeded(err)) throw err;
-            // Stale Orb session cleared; keep browsing the feed read-only.
+            clearStaleOrbSessionIfNeeded(err);
+            // Always fall back to read-only public client for feed browsing.
+            client = publicClient;
           }
         }
 

--- a/hooks/useSongchainPost.ts
+++ b/hooks/useSongchainPost.ts
@@ -5,6 +5,7 @@ import { textOnly } from "@lens-protocol/metadata";
 import { post } from "@lens-protocol/client/actions";
 import { evmAddress, uri } from "@lens-protocol/client";
 import { groveService } from "@/lib/sdk/grove/service";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { toast } from "sonner";
 
@@ -60,6 +61,7 @@ export function useSongchainPost() {
         toast.success("Posted to Songchain feed!");
         return true;
       } catch (err) {
+        clearStaleOrbSessionIfNeeded(err);
         toast.error(err instanceof Error ? err.message : "Posting failed");
         return false;
       } finally {

--- a/hooks/useSongchainPost.ts
+++ b/hooks/useSongchainPost.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { textOnly } from "@lens-protocol/metadata";
+import { post } from "@lens-protocol/client/actions";
+import { evmAddress, uri } from "@lens-protocol/client";
+import { groveService } from "@/lib/sdk/grove/service";
+import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { toast } from "sonner";
+
+export type CreateSongchainPostParams = {
+  content: string;
+  feedId: string;
+  title?: string;
+};
+
+export function useSongchainPost() {
+  const [isPosting, setIsPosting] = useState(false);
+  const { canWrite, getSessionClient, promptWriteAccess } = useLensOrbWrite();
+
+  const createPost = useCallback(
+    async ({ content, feedId, title = "Songchain post" }: CreateSongchainPostParams) => {
+      const trimmed = content.trim();
+      if (!trimmed) {
+        toast.error("Write something before posting.");
+        return false;
+      }
+      if (!feedId) {
+        toast.error("Feed is not configured.");
+        return false;
+      }
+      if (!canWrite) {
+        promptWriteAccess();
+        toast.info("Link your Orb account to post on Lens.");
+        return false;
+      }
+
+      setIsPosting(true);
+      try {
+        const client = await getSessionClient();
+        const metadata = textOnly({
+          content: trimmed,
+          locale: "en",
+        });
+
+        const uploadResult = await groveService.uploadJson(metadata);
+        if (!uploadResult.success || !uploadResult.url) {
+          throw new Error("Failed to upload post metadata");
+        }
+
+        const result = await post(client, {
+          contentUri: uri(uploadResult.url),
+          feed: evmAddress(feedId),
+        });
+
+        if (result.isErr()) {
+          throw new Error(result.error.message);
+        }
+
+        toast.success("Posted to Songchain feed!");
+        return true;
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Posting failed");
+        return false;
+      } finally {
+        setIsPosting(false);
+      }
+    },
+    [canWrite, getSessionClient, promptWriteAccess],
+  );
+
+  return { createPost, isPosting, canWrite, promptWriteAccess };
+}

--- a/hooks/useUnifiedLogout.ts
+++ b/hooks/useUnifiedLogout.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useLogout } from '@account-kit/react';
+import { useOrbSession } from '@/context/OrbSessionContext';
+
+/** Signs out of both Account Kit wallet and Orb / Lens session. */
+export function useUnifiedLogout() {
+  const { logout: walletLogout } = useLogout();
+  const { logout: orbLogout } = useOrbSession();
+
+  return useCallback(async () => {
+    await orbLogout();
+    await walletLogout();
+  }, [orbLogout, walletLogout]);
+}

--- a/lib/auth/session-recovery.test.ts
+++ b/lib/auth/session-recovery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { resetAppSession } from '@/lib/auth/session-recovery';
+
+describe('resetAppSession', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    vi.stubGlobal('window', {
+      location: { assign: vi.fn() },
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  it('calls orb and wallet logout then redirects home', async () => {
+    const walletLogout = vi.fn().mockResolvedValue(undefined);
+    const orbLogout = vi.fn().mockResolvedValue(undefined);
+
+    await resetAppSession({ walletLogout, orbLogout });
+
+    expect(orbLogout).toHaveBeenCalledOnce();
+    expect(walletLogout).toHaveBeenCalledOnce();
+    expect(window.location.assign).toHaveBeenCalledWith('/');
+  });
+
+  it('still clears wallet when orb logout throws', async () => {
+    const walletLogout = vi.fn().mockResolvedValue(undefined);
+    const orbLogout = vi.fn().mockRejectedValue(new Error('orb fail'));
+
+    await resetAppSession({ walletLogout, orbLogout });
+
+    expect(walletLogout).toHaveBeenCalledOnce();
+    expect(window.location.assign).toHaveBeenCalledWith('/');
+  });
+});

--- a/lib/auth/session-recovery.ts
+++ b/lib/auth/session-recovery.ts
@@ -1,0 +1,23 @@
+import { clearStoredOrbSession } from '@/lib/sdk/orb/login';
+
+export type SessionResetHandlers = {
+  walletLogout: () => Promise<void>;
+  orbLogout: () => Promise<void>;
+};
+
+/** Clears Orb tokens, wallet session, and reloads to home. */
+export async function resetAppSession(handlers: SessionResetHandlers): Promise<void> {
+  try {
+    await handlers.orbLogout();
+  } catch {
+    clearStoredOrbSession();
+  }
+  try {
+    await handlers.walletLogout();
+  } catch {
+    // Wallet logout may fail if already disconnected
+  }
+  if (typeof window !== 'undefined') {
+    window.location.assign('/');
+  }
+}

--- a/lib/songchain/feed-diagnostics.test.ts
+++ b/lib/songchain/feed-diagnostics.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getFeedDiagnosticInfo,
+  getLensNetworkLabel,
+  truncateFeedId,
+} from '@/lib/songchain/feed-diagnostics';
+
+describe('feed-diagnostics', () => {
+  it('truncates long feed ids', () => {
+    const id = '0xabcdef1234567890abcdef1234567890abcdef12';
+    expect(truncateFeedId(id)).toMatch(/^0xabcdef…/);
+  });
+
+  it('returns not configured for null feed', () => {
+    expect(truncateFeedId(null)).toBe('not configured');
+  });
+
+  it('builds diagnostic info', () => {
+    const info = getFeedDiagnosticInfo('0xabc0000000000000000000000000000000000001');
+    expect(info.feedIdDisplay).toContain('0xabc000');
+    expect(getLensNetworkLabel('testnet')).toBe('Lens testnet (Sepolia)');
+  });
+});

--- a/lib/songchain/feed-diagnostics.ts
+++ b/lib/songchain/feed-diagnostics.ts
@@ -1,0 +1,28 @@
+import { getLensNetwork, type LensNetwork } from '@/lib/sdk/lens/chains';
+
+export function truncateFeedId(feedId: string | null): string {
+  if (!feedId) return 'not configured';
+  if (feedId.length <= 14) return feedId;
+  return `${feedId.slice(0, 8)}…${feedId.slice(-6)}`;
+}
+
+export function getLensNetworkLabel(network: LensNetwork = getLensNetwork()): string {
+  return network === 'mainnet' ? 'Lens mainnet' : 'Lens testnet (Sepolia)';
+}
+
+export type FeedDiagnosticInfo = {
+  lensNetwork: LensNetwork;
+  lensNetworkLabel: string;
+  feedId: string | null;
+  feedIdDisplay: string;
+};
+
+export function getFeedDiagnosticInfo(feedId: string | null): FeedDiagnosticInfo {
+  const lensNetwork = getLensNetwork();
+  return {
+    lensNetwork,
+    lensNetworkLabel: getLensNetworkLabel(lensNetwork),
+    feedId,
+    feedIdDisplay: truncateFeedId(feedId),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds full Songchain Lens integration on `/songchain`: feed diagnostics, compose posts to custom feeds, edit/delete, comments, reposts, bookmarks, and author timelines.
- Fixes mobile Orb/wallet UX traps (linking overlay, QR cancel/timeout, guard loading fallback, Home/Songchain nav) and unified session reset without clearing browser cache.
- Documents Songchain/Lens env vars in `env.example` and exposes `/api/songchain/config-check` for deployment verification.

## Test plan
- [ ] Set `NEXT_PUBLIC_LENS_ENV` and Songchain feed IDs; confirm `/api/songchain/config-check` returns configured network/feeds
- [ ] Visit `/songchain` Feed tab — posts load or show diagnostic empty/error states with network + feed ID
- [ ] Link Orb, create a post on the public feed, confirm it appears after refresh
- [ ] Test upvote, comment, bookmark, repost, edit/delete on own posts
- [ ] Mobile: wallet + Orb connect without black-screen trap; Home link works from drawer
- [ ] Use **Reset session** to recover from stale auth without clearing browser cache/history
- [ ] Logout clears both wallet and Orb session


Made with [Cursor](https://cursor.com)