### PR TITLE
Fix undefined publicClient fallback in Songchain Lens clients

### DIFF
--- a/components/songchain/SongchainGroupPanel.tsx
+++ b/components/songchain/SongchainGroupPanel.tsx
@@ -38,7 +38,7 @@ export function SongchainGroupPanel({ groupId }: SongchainGroupPanelProps) {
           client = await getSessionClient();
         } catch (err) {
           clearStaleOrbSessionIfNeeded(err);
-          client = publicClient;
+          client = createLensClient();
         }
       }
 

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -49,7 +49,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
           } catch (err) {
             clearStaleOrbSessionIfNeeded(err);
             // Always fall back to read-only public client for feed browsing.
-            client = publicClient;
+            client = createLensClient();
           }
         }
 


### PR DESCRIPTION
## Summary
- Fixes Vercel build failure on `main` after PR #150 merge: `SongchainGroupPanel` and `useSongchainFeed` referenced `publicClient` without importing it.
- Uses `createLensClient()` consistently for read-only fallbacks when Orb session errors occur.

## Test plan
- [ ] `yarn build` passes TypeScript check
- [ ] `/songchain` Feed tab loads (with or without linked Orb)
- [ ] `/songchain` Group tab loads when group ID is configured


Made with [Cursor](https://cursor.com)