### PR TITLE
Platform API access tiers, Orb auth fixes, and mobile tour

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,20 @@ STREAM_KEY=
 # --- Cron / internal API ---
 CRON_SECRET=
 
+# --- Creative TV Platform API (partner apps, admin bypass, x402 agents) ---
+# Generate keys locally: pnpm tsx scripts/generate-platform-api-key.ts --tier partner --id mixtape
+PLATFORM_API_ACCESS_ENABLED=
+CREATIVE_PLATFORM_ADMIN_API_KEYS=
+CREATIVE_PLATFORM_PARTNER_API_KEYS=
+# USDC recipient on Base for x402 agent payments
+X402_API_RECIPIENT=
+# Prices in USDC base units (6 decimals). 10000 = $0.01
+X402_PLAYBACK_RESOLVE_PRICE=10000
+X402_PUBLISHED_LIST_PRICE=25000
+X402_PLAYBACK_INFO_PRICE=50000
+X402_VIEWS_METRICS_PRICE=50000
+X402_DEFAULT_PRICE=10000
+
 # --- Scripts / Paragraph ---
 PARAGRAPH_API_KEY=
 

--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -2,10 +2,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
 import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
+import {
+  platformApiOptionsResponse,
+  requirePlatformApiAccess,
+} from '@/lib/middleware/platformApiAccess';
 
 const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
 
+export async function OPTIONS() {
+  return platformApiOptionsResponse();
+}
+
 export async function GET(request: NextRequest) {
+  const access = await requirePlatformApiAccess(request, { resource: 'playback.info' });
+  if (!access.allowed) {
+    return access.response;
+  }
+
   try {
     if (!process.env.LIVEPEER_FULL_API_KEY?.trim()) {
       return NextResponse.json(

--- a/app/api/livepeer/views/[playbackId]/route.ts
+++ b/app/api/livepeer/views/[playbackId]/route.ts
@@ -9,6 +9,11 @@ import {
 import { getStoredViewsCount } from '@/lib/livepeer/sync-view-count';
 import { serverLogger } from '@/lib/utils/logger';
 import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
+import {
+  platformApiOptionsResponse,
+  requirePlatformApiAccess,
+} from '@/lib/middleware/platformApiAccess';
+import { PLATFORM_API_CORS_HEADERS } from '@/lib/middleware/x402Gate';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -18,15 +23,25 @@ const noStoreHeaders = {
   'Cache-Control': 'no-store, no-cache, max-age=0, must-revalidate',
   Pragma: 'no-cache',
   Expires: '0',
+  ...PLATFORM_API_CORS_HEADERS,
 };
 
 /**
  * Read-only endpoint: returns max(Livepeer views, database views_count).
  */
+export async function OPTIONS() {
+  return platformApiOptionsResponse();
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> },
 ) {
+  const access = await requirePlatformApiAccess(request, { resource: 'views.metrics' });
+  if (!access.allowed) {
+    return access.response;
+  }
+
   try {
     const { playbackId } = await params;
 

--- a/app/api/video-assets/by-asset-id/[assetId]/playback/route.test.ts
+++ b/app/api/video-assets/by-asset-id/[assetId]/playback/route.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetVideoAssetByAssetId = vi.fn();
+
+vi.mock("@/services/video-assets", () => ({
+  getVideoAssetByAssetId: (...args: unknown[]) => mockGetVideoAssetByAssetId(...args),
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/middleware/platformApiAccess", () => ({
+  requirePlatformApiAccess: vi.fn(async () => ({ allowed: true, tier: "public" })),
+  platformApiOptionsResponse: vi.fn(() => new Response(null, { status: 200 })),
+}));
+
+import { GET, OPTIONS } from "./route";
+
+describe("GET /api/video-assets/by-asset-id/[assetId]/playback", () => {
+  const assetId = "550e8400-e29b-41d4-a716-446655440000";
+
+  beforeEach(() => {
+    vi.stubEnv("PLATFORM_API_ACCESS_ENABLED", "false");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://tv.creativeplatform.xyz");
+    mockGetVideoAssetByAssetId.mockResolvedValue({
+      asset_id: assetId,
+      playback_id: "playback-123",
+      title: "Test Video",
+      thumbnailUri: "https://example.com/thumb.jpg",
+      requires_metoken: false,
+      status: "published",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("returns slim playback payload with CORS headers", async () => {
+    const response = await GET(new NextRequest("http://localhost/api"), {
+      params: Promise.resolve({ assetId }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    await expect(response.json()).resolves.toEqual({
+      playbackId: "playback-123",
+      title: "Test Video",
+      thumbnailUri: "https://example.com/thumb.jpg",
+      requiresMetoken: false,
+      fallbackUrl: `https://tv.creativeplatform.xyz/discover/${assetId}`,
+    });
+  });
+
+  it("returns 404 for unpublished assets", async () => {
+    mockGetVideoAssetByAssetId.mockResolvedValue({
+      asset_id: assetId,
+      playback_id: "playback-123",
+      status: "draft",
+    });
+
+    const response = await GET(new NextRequest("http://localhost/api"), {
+      params: Promise.resolve({ assetId }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("handles OPTIONS preflight", async () => {
+    const response = await OPTIONS();
+    expect(response.status).toBe(200);
+  });
+});

--- a/app/api/video-assets/by-asset-id/[assetId]/playback/route.ts
+++ b/app/api/video-assets/by-asset-id/[assetId]/playback/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVideoAssetByAssetId } from "@/services/video-assets";
+import { serverLogger } from "@/lib/utils/logger";
+import {
+  platformApiOptionsResponse,
+  requirePlatformApiAccess,
+} from "@/lib/middleware/platformApiAccess";
+import { PLATFORM_API_CORS_HEADERS } from "@/lib/middleware/x402Gate";
+
+export const maxDuration = 30;
+export const runtime = "nodejs";
+
+function jsonWithCors(body: unknown, init?: { status?: number }) {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: PLATFORM_API_CORS_HEADERS,
+  });
+}
+
+export async function OPTIONS() {
+  return platformApiOptionsResponse();
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ assetId: string }> },
+) {
+  const access = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+  if (!access.allowed) {
+    return access.response;
+  }
+
+  try {
+    const { assetId } = await params;
+
+    if (!assetId) {
+      return jsonWithCors({ error: "Asset ID is required" }, { status: 400 });
+    }
+
+    const asset = await getVideoAssetByAssetId(assetId);
+
+    if (!asset || asset.status !== "published") {
+      return jsonWithCors({ error: "Video asset not found" }, { status: 404 });
+    }
+
+    if (!asset.playback_id) {
+      return jsonWithCors({ error: "Playback ID not available" }, { status: 404 });
+    }
+
+    const siteOrigin =
+      process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ??
+      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "https://tv.creativeplatform.xyz");
+
+    return jsonWithCors({
+      playbackId: asset.playback_id,
+      title: asset.title,
+      thumbnailUri: asset.thumbnailUri,
+      requiresMetoken: Boolean(asset.requires_metoken),
+      fallbackUrl: `${siteOrigin}/discover/${asset.asset_id}`,
+    });
+  } catch (error) {
+    serverLogger.error("Error fetching playback by asset ID:", error);
+    return jsonWithCors(
+      {
+        error: "Failed to fetch playback",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/video-assets/published/route.ts
+++ b/app/api/video-assets/published/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPublishedVideoAssets } from "@/services/video-assets";
 import { serverLogger } from "@/lib/utils/logger";
+import {
+  platformApiOptionsResponse,
+  requirePlatformApiAccess,
+} from "@/lib/middleware/platformApiAccess";
+import { PLATFORM_API_CORS_HEADERS } from "@/lib/middleware/x402Gate";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 export const fetchCache = "force-no-store";
@@ -11,6 +16,7 @@ const noStoreHeaders = {
   "Cache-Control": "no-store, no-cache, max-age=0, must-revalidate",
   Pragma: "no-cache",
   Expires: "0",
+  ...PLATFORM_API_CORS_HEADERS,
 };
 
 /**
@@ -28,7 +34,16 @@ const noStoreHeaders = {
  * - category: string (optional)
  * - search: string (optional)
  */
+export async function OPTIONS() {
+  return platformApiOptionsResponse();
+}
+
 export async function GET(request: NextRequest) {
+  const access = await requirePlatformApiAccess(request, { resource: "videos.published" });
+  if (!access.allowed) {
+    return access.response;
+  }
+
   try {
     // Parse query parameters
     const searchParams = request.nextUrl.searchParams;

--- a/app/embed/discover/[id]/page.tsx
+++ b/app/embed/discover/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { DiscoverEmbedPlayer } from "@/components/Embed/DiscoverEmbedPlayer";
+import { CREATIVE_TV_ASSET_UUID_REGEX } from "@/lib/utils/creative-tv-url";
+
+type EmbedDiscoverPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EmbedDiscoverPage({ params }: EmbedDiscoverPageProps) {
+  const { id } = await params;
+
+  if (!CREATIVE_TV_ASSET_UUID_REGEX.test(id)) {
+    return (
+      <div className="flex aspect-video w-full items-center justify-center bg-black text-sm text-white/80">
+        Invalid video id
+      </div>
+    );
+  }
+
+  return <DiscoverEmbedPlayer assetId={id} />;
+}

--- a/app/embed/layout.tsx
+++ b/app/embed/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-black">{children}</div>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,6 +63,7 @@ export default async function RootLayout({
     config,
     headersList.get("cookie") ?? undefined
   );
+  const isEmbedRoute = headersList.get("x-crtv-embed-route") === "1";
 
   return (
     <html lang="en" suppressHydrationWarning>
@@ -91,11 +92,11 @@ export default async function RootLayout({
         <LayoutClientChunks />
         <Providers initialState={initialState}>
           <ErrorBoundary>
-            <Tour />
-            <Navbar />
+            {!isEmbedRoute ? <Tour /> : null}
+            {!isEmbedRoute ? <Navbar /> : null}
             <div className="min-h-screen flex flex-col">
               <main className="flex-1">{children}</main>
-              <Footer />
+              {!isEmbedRoute ? <Footer /> : null}
             </div>
           </ErrorBoundary>
         </Providers>

--- a/components/Embed/DiscoverEmbedPlayer.tsx
+++ b/components/Embed/DiscoverEmbedPlayer.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Player, PlayerLoading } from "@/components/Player/Player";
+import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
+import { resolveCreativeTVPlayback } from "@/lib/utils/resolve-creative-tv-playback";
+import type { Src } from "@livepeer/react";
+
+type DiscoverEmbedPlayerProps = {
+  assetId: string;
+};
+
+export function DiscoverEmbedPlayer({ assetId }: DiscoverEmbedPlayerProps) {
+  const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
+  const [title, setTitle] = useState("Creative TV");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setError(null);
+      setPlaybackSources(null);
+
+      const result = await resolveCreativeTVPlayback(`/discover/${assetId}`);
+      if (cancelled) {
+        return;
+      }
+
+      if (!result.ok) {
+        setError(result.message ?? "Video unavailable");
+        return;
+      }
+
+      if (result.requiresMetoken) {
+        setError("Sign in on Creative TV to watch this video.");
+        return;
+      }
+
+      setTitle(result.title ?? "Creative TV");
+
+      try {
+        const sources = await getDetailPlaybackSource(result.playbackId);
+        if (!cancelled) {
+          if (!sources?.length) {
+            setError("Playback unavailable");
+            return;
+          }
+          setPlaybackSources(sources);
+        }
+      } catch {
+        if (!cancelled) {
+          setError("Playback unavailable");
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assetId]);
+
+  if (error) {
+    return (
+      <div className="flex aspect-video w-full items-center justify-center bg-black px-4 text-center text-sm text-white/80">
+        {error}
+      </div>
+    );
+  }
+
+  if (!playbackSources) {
+    return (
+      <div className="aspect-video w-full bg-black">
+        <PlayerLoading title="Loading video..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="aspect-video w-full bg-black">
+      <Player src={playbackSources} title={title} />
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -195,6 +195,12 @@ export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const accountDropdownRef = useRef<AccountDropdownHandle>(null);
   const [copySuccess, setCopySuccess] = useState(false);
+
+  useEffect(() => {
+    const openMobileMenu = () => setIsMenuOpen(true);
+    window.addEventListener('crtv:open-mobile-menu', openMobileMenu);
+    return () => window.removeEventListener('crtv:open-mobile-menu', openMobileMenu);
+  }, []);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
   const [isScrolled, setIsScrolled] = useState(false);
 
@@ -440,7 +446,7 @@ export default function Navbar() {
                         openAuthModal();
                         setIsMenuOpen(false);
                       }}
-                      id="connect-wallet-btn"
+                      id="connect-wallet-btn-mobile"
                     >
                       Get Started
                     </Button>

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -167,12 +167,23 @@ export const Tour = () => {
     const prepareStepTarget = useCallback(
         async (step?: TourStep) => {
             if (!step?.data?.openMobileMenu || !isMobile) {
-                return;
+                return true;
             }
             openMobileMenuForTour();
-            await waitForElement(String(step.target));
+            return waitForElement(String(step.target));
         },
         [isMobile],
+    );
+
+    const advanceToStep = useCallback(
+        async (nextIndex: number) => {
+            const nextStep = steps[nextIndex];
+            if (nextStep?.data?.openMobileMenu && isMobile) {
+                await prepareStepTarget(nextStep);
+            }
+            setStepIndex(nextIndex);
+        },
+        [isMobile, prepareStepTarget, setStepIndex, steps],
     );
 
     const handleJoyrideCallback = (data: CallBackProps) => {
@@ -188,23 +199,45 @@ export const Tour = () => {
             return;
         }
 
-        if (type === EVENTS.STEP_BEFORE) {
-            void prepareStepTarget(currentStep);
-            return;
-        }
-
         if (type === EVENTS.TARGET_NOT_FOUND) {
             logger.warn('Tour: target not found', { target: currentStep?.target, index });
             if (index < steps.length - 1) {
-                window.setTimeout(() => setStepIndex(index + 1), 400);
+                window.setTimeout(() => {
+                    void advanceToStep(index + 1);
+                }, 400);
             }
             return;
         }
 
         if (type === EVENTS.STEP_AFTER && action !== 'prev') {
-            setStepIndex(index + 1);
+            if (index < steps.length - 1) {
+                void advanceToStep(index + 1);
+            }
         }
     };
+
+    useEffect(() => {
+        if (!run || !isMobile) {
+            return;
+        }
+
+        const currentStep = steps[stepIndex];
+        if (!currentStep?.data?.openMobileMenu) {
+            return;
+        }
+
+        let cancelled = false;
+        void (async () => {
+            await prepareStepTarget(currentStep);
+            if (cancelled) {
+                return;
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [run, stepIndex, isMobile, steps, prepareStepTarget]);
 
     useEffect(() => {
         if (!isConnected || !run || !isMobile) {

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Joyride,
     EVENTS,
@@ -14,7 +14,7 @@ import { useTour } from '@/context/TourContext';
 import { logger } from '@/lib/utils/logger';
 
 type TourStep = Step & {
-    data?: { id: string };
+    data?: { id: string; openMobileMenu?: boolean };
 };
 
 const DESKTOP_STEPS: TourStep[] = [
@@ -23,40 +23,118 @@ const DESKTOP_STEPS: TourStep[] = [
         content: 'Sign in to get started! Click "Get Started" to create your account with just your email.',
         disableBeacon: true,
         spotlightClicks: true,
-        data: { id: 'connect' }
+        placement: 'bottom',
+        data: { id: 'connect' },
     },
     {
         target: '#nav-user-menu',
         content: 'Click your profile to open the menu, then select "Upload" to start adding content.',
         spotlightClicks: true,
-        data: { id: 'user-menu' }
+        placement: 'bottom',
+        data: { id: 'user-menu' },
     },
     {
         target: '#upload-video-form',
         content: 'Upload your video file here. You can drag and drop or select a file.',
         placement: 'bottom',
-        data: { id: 'upload-form' }
+        data: { id: 'upload-form' },
     },
     {
         target: '#publish-video-btn',
         content: 'Once uploaded, click Publish to share it with the world!',
-        data: { id: 'publish-btn' }
+        placement: 'top',
+        data: { id: 'publish-btn' },
     },
     {
         target: '#nav-discover-link',
         content: 'Check out what others are creating on the Discover page.',
-        data: { id: 'discover' }
+        placement: 'bottom',
+        data: { id: 'discover' },
     },
     {
         target: '#nav-trade-link',
         content: 'Buy or sell Creative Coins by creators on the platform in the Trading Market.',
-        data: { id: 'trade' }
+        placement: 'bottom',
+        data: { id: 'trade' },
     },
 ];
 
+const MOBILE_STEPS: TourStep[] = [
+    {
+        target: '#mobile-menu-btn',
+        content: 'Tap the menu icon to open navigation and sign in.',
+        disableBeacon: true,
+        spotlightClicks: true,
+        placement: 'bottom',
+        data: { id: 'connect', openMobileMenu: false },
+    },
+    {
+        target: '#connect-wallet-btn-mobile',
+        content: 'Tap "Get Started" to create your account with just your email.',
+        spotlightClicks: true,
+        placement: 'bottom',
+        data: { id: 'connect-wallet', openMobileMenu: true },
+    },
+    {
+        target: '#nav-user-menu',
+        content: 'After signing in, tap your profile avatar to open account options.',
+        spotlightClicks: true,
+        placement: 'bottom',
+        data: { id: 'user-menu' },
+    },
+    {
+        target: '#nav-upload-link',
+        content: 'Open the menu and choose Upload to add your video.',
+        placement: 'bottom',
+        data: { id: 'upload-form', openMobileMenu: true },
+    },
+    {
+        target: '#publish-video-btn',
+        content: 'After selecting a file, tap Publish to share your video.',
+        placement: 'top',
+        data: { id: 'publish-btn' },
+    },
+    {
+        target: '#mobile-nav-discover-link',
+        content: 'Use Discover in the menu to see what others are creating.',
+        placement: 'bottom',
+        data: { id: 'discover', openMobileMenu: true },
+    },
+    {
+        target: '#mobile-nav-trade-link',
+        content: 'Open Trade in the menu to buy or sell Creative Coins.',
+        placement: 'bottom',
+        data: { id: 'trade', openMobileMenu: true },
+    },
+];
 
+function openMobileMenuForTour() {
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new Event('crtv:open-mobile-menu'));
+    }
+}
 
+function waitForElement(selector: string, timeoutMs = 2500): Promise<boolean> {
+    return new Promise((resolve) => {
+        if (document.querySelector(selector)) {
+            resolve(true);
+            return;
+        }
 
+        const started = Date.now();
+        const interval = window.setInterval(() => {
+            if (document.querySelector(selector)) {
+                window.clearInterval(interval);
+                resolve(true);
+                return;
+            }
+            if (Date.now() - started >= timeoutMs) {
+                window.clearInterval(interval);
+                resolve(false);
+            }
+        }, 100);
+    });
+}
 
 export const Tour = () => {
     const { run, stepIndex, setRun, setStepIndex } = useTour();
@@ -64,7 +142,6 @@ export const Tour = () => {
     const user = useUser();
     const isConnected = !!user;
 
-    // Simple mobile detection
     const [isMobile, setIsMobile] = useState(false);
 
     useEffect(() => {
@@ -77,84 +154,83 @@ export const Tour = () => {
         return () => window.removeEventListener('resize', checkMobile);
     }, []);
 
-    const MOBILE_STEPS: TourStep[] = [
-        {
-            target: '#mobile-menu-btn',
-            content: 'Tap the menu to get started by signing in.',
-            disableBeacon: true,
-            data: { id: 'connect' }
-        },
-        {
-            target: '#nav-user-menu',
-            content:
-                'Tap your profile avatar to open the account menu, then select "Upload" to add your own content.',
-            spotlightClicks: true,
-            data: { id: 'user-menu' }
-        },
-        {
-            target: '#mobile-menu-btn',
-            content: 'Select "Upload" in the menu to access the video upload form.',
-            data: { id: 'upload-form' }
-        },
-        {
-            target: '#mobile-menu-btn',
-            content: 'After selecting a file, use the "Publish" button to share your video.',
-            data: { id: 'publish-btn' }
-        },
-        {
-            target: '#mobile-menu-btn',
-            content: 'Use the "Discover" link in the menu to see what others are creating.',
-            data: { id: 'discover' }
-        },
-        {
-            target: '#mobile-menu-btn',
-            content: 'Access the "Trading Market" via the menu to buy or sell Creative Coins.',
-            data: { id: 'trade' }
-        },
-    ];
+    const steps = useMemo(
+        () => (isMobile ? MOBILE_STEPS : DESKTOP_STEPS),
+        [isMobile],
+    );
 
-    const steps = isMobile ? MOBILE_STEPS : DESKTOP_STEPS;
+    const getStepIndex = useCallback(
+        (id: string) => steps.findIndex((step) => step.data?.id === id),
+        [steps],
+    );
 
-    // Helper to find step index by ID
-    const getStepIndex = (id: string) => {
-        return steps.findIndex(s => s.data?.id === id);
-    };
+    const prepareStepTarget = useCallback(
+        async (step?: TourStep) => {
+            if (!step?.data?.openMobileMenu || !isMobile) {
+                return;
+            }
+            openMobileMenuForTour();
+            await waitForElement(String(step.target));
+        },
+        [isMobile],
+    );
 
     const handleJoyrideCallback = (data: CallBackProps) => {
         const { index, status, type, action } = data;
         const currentStep = steps[index];
         const currentId = currentStep?.data?.id;
 
-        logger.debug("Tour: Callback", { index, status, type, action, currentId });
+        logger.debug('Tour: Callback', { index, status, type, action, currentId });
 
-        if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status as any)) {
+        if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status as typeof STATUS.FINISHED)) {
             setRun(false);
             localStorage.setItem('crtv3_tour_completed', 'true');
-        } else if (type === EVENTS.STEP_AFTER) {
-            // Logic to handle specific transitions if needed, 
-            // otherwise just let it go to next index
+            return;
+        }
+
+        if (type === EVENTS.STEP_BEFORE) {
+            void prepareStepTarget(currentStep);
+            return;
+        }
+
+        if (type === EVENTS.TARGET_NOT_FOUND) {
+            logger.warn('Tour: target not found', { target: currentStep?.target, index });
+            if (index < steps.length - 1) {
+                window.setTimeout(() => setStepIndex(index + 1), 400);
+            }
+            return;
+        }
+
+        if (type === EVENTS.STEP_AFTER && action !== 'prev') {
             setStepIndex(index + 1);
-        } else if (type === EVENTS.TARGET_NOT_FOUND) {
-            // Wait
         }
     };
 
-    // Auto-advance logic refactored to use IDs
-
-    // 1. Authenticated -> Go to next relevant step
-    // Desktop: Connect (0) -> User Menu (1)
-    // Mobile: Connect (1) -> Open Menu for Upload (2)
     useEffect(() => {
-        if (isConnected && run) {
-            // If we are on the connect step, move forward
-            const connectIndex = getStepIndex('connect');
-            if (stepIndex === connectIndex) {
-                setStepIndex(connectIndex + 1);
-            }
+        if (!isConnected || !run || !isMobile) {
+            return;
         }
-    }, [isConnected, stepIndex, run, steps]);
 
-    // 2. Navigation to /upload
+        const connectIndex = getStepIndex('connect');
+        const connectWalletIndex = getStepIndex('connect-wallet');
+        if (stepIndex === connectIndex || stepIndex === connectWalletIndex) {
+            window.setTimeout(() => {
+                setStepIndex(getStepIndex('user-menu'));
+            }, 400);
+        }
+    }, [isConnected, stepIndex, run, isMobile, getStepIndex, setStepIndex]);
+
+    useEffect(() => {
+        if (!isConnected || !run || isMobile) {
+            return;
+        }
+
+        const connectIndex = getStepIndex('connect');
+        if (stepIndex === connectIndex) {
+            window.setTimeout(() => setStepIndex(connectIndex + 1), 300);
+        }
+    }, [isConnected, stepIndex, run, isMobile, getStepIndex, setStepIndex]);
+
     useEffect(() => {
         if (pathname.startsWith('/upload') && run) {
             const uploadFormIndex = getStepIndex('upload-form');
@@ -162,9 +238,8 @@ export const Tour = () => {
                 setStepIndex(uploadFormIndex);
             }
         }
-    }, [pathname, stepIndex, run, steps]);
+    }, [pathname, stepIndex, run, getStepIndex, setStepIndex]);
 
-    // 3. Publish Button Appearance
     useEffect(() => {
         let interval: NodeJS.Timeout;
         const uploadFormIndex = getStepIndex('upload-form');
@@ -178,9 +253,8 @@ export const Tour = () => {
             }, 1000);
         }
         return () => clearInterval(interval);
-    }, [stepIndex, run, steps]);
+    }, [stepIndex, run, getStepIndex, setStepIndex]);
 
-    // 4. Navigation to /discover
     useEffect(() => {
         if (pathname.startsWith('/discover') && run) {
             const discoverIndex = getStepIndex('discover');
@@ -188,43 +262,51 @@ export const Tour = () => {
                 setStepIndex(discoverIndex);
             }
         }
-    }, [pathname, stepIndex, run, steps]);
+    }, [pathname, stepIndex, run, getStepIndex, setStepIndex]);
 
-
-    // Custom Tooltip component
     const TourTooltip = ({
         index,
         step,
-        backProps,
         primaryProps,
         skipProps,
         tooltipProps,
         isLastStep,
         size,
-    }: any) => {
+    }: {
+        index: number;
+        step: Step;
+        primaryProps: React.ComponentProps<'button'>;
+        skipProps: React.ComponentProps<'button'>;
+        tooltipProps: React.ComponentProps<'div'>;
+        isLastStep: boolean;
+        size: number;
+    }) => {
         return (
-            <div {...tooltipProps} className="bg-white dark:bg-slate-900 p-6 rounded-2xl shadow-2xl border border-indigo-100 dark:border-indigo-900 max-w-sm relative overflow-hidden">
-                {/* Decorative BG element */}
-                <div className="absolute top-0 right-0 w-16 h-16 bg-gradient-to-br from-indigo-500 to-purple-600 opacity-10 rounded-bl-full -mr-4 -mt-4"></div>
+            <div
+                {...tooltipProps}
+                className="relative z-[10001] w-[min(calc(100vw-2rem),22rem)] overflow-hidden rounded-2xl border border-indigo-100 bg-white p-5 shadow-2xl dark:border-indigo-900 dark:bg-slate-900"
+            >
+                <div className="absolute -right-4 -top-4 h-16 w-16 rounded-bl-full bg-gradient-to-br from-indigo-500 to-purple-600 opacity-10" />
 
-                <div className="relative z-10 text-slate-800 dark:text-slate-100">
+                <div className="relative z-10 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
                     {step.content}
                 </div>
 
-                <div className="mt-6 flex justify-between items-center relative z-10 w-full">
-                    <div className="flex gap-2">
-                        <button {...skipProps} className="px-3 py-1.5 text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 text-sm font-medium transition">
-                            Skip
-                        </button>
-                    </div>
-
-                    <div className="flex gap-2">
-                        <button {...primaryProps} className="px-4 py-2 bg-indigo-600 text-white text-sm font-bold rounded-full hover:bg-indigo-700 transition shadow-lg shadow-indigo-200 dark:shadow-none">
-                            {isLastStep ? 'Finish' : 'Next Step'}
-                        </button>
-                    </div>
+                <div className="relative z-10 mt-5 flex items-center justify-between gap-2">
+                    <button
+                        {...skipProps}
+                        className="px-3 py-1.5 text-sm font-medium text-slate-500 transition hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                    >
+                        Skip
+                    </button>
+                    <button
+                        {...primaryProps}
+                        className="rounded-full bg-indigo-600 px-4 py-2 text-sm font-bold text-white shadow-lg shadow-indigo-200 transition hover:bg-indigo-700 dark:shadow-none"
+                    >
+                        {isLastStep ? 'Finish' : 'Next Step'}
+                    </button>
                 </div>
-                <div className="mt-2 text-center text-xs text-slate-400 font-medium">
+                <div className="relative z-10 mt-2 text-center text-xs font-medium text-slate-400">
                     Step {index + 1} of {size}
                 </div>
             </div>
@@ -241,9 +323,27 @@ export const Tour = () => {
             showProgress
             showSkipButton
             disableOverlayClose
+            scrollToFirstStep
+            scrollOffset={96}
+            disableScrollParentFix={false}
+            spotlightPadding={10}
+            floaterProps={{
+                disableAnimation: true,
+                styles: {
+                    floater: {
+                        filter: 'none',
+                    },
+                },
+            }}
             styles={{
                 options: {
                     primaryColor: '#4f46e5',
+                    zIndex: 10000,
+                },
+                overlay: {
+                    zIndex: 9999,
+                },
+                spotlight: {
                     zIndex: 10000,
                 },
             }}

--- a/components/Videos/CreativeTVUrlEmbed.tsx
+++ b/components/Videos/CreativeTVUrlEmbed.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Player, PlayerLoading } from "@/components/Player/Player";
+import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
+import { useCreativeTVUrlResolve } from "@/hooks/useCreativeTVUrlResolve";
+import type { Src } from "@livepeer/react";
+import { logger } from "@/lib/utils/logger";
+
+export type CreativeTVUrlEmbedProps = {
+  /** Optional API origin for cross-origin playback resolution. */
+  apiBaseUrl?: string;
+  /** Optional site origin for fallback link/iframe targets. */
+  siteOrigin?: string;
+  className?: string;
+  placeholder?: string;
+};
+
+export function CreativeTVUrlEmbed({
+  apiBaseUrl,
+  siteOrigin,
+  className,
+  placeholder = "Paste a Creative TV discover or watch URL",
+}: CreativeTVUrlEmbedProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+  const { state, resolveFromInput, handlePaste, reset } = useCreativeTVUrlResolve({
+    apiBaseUrl,
+    siteOrigin,
+  });
+
+  useEffect(() => {
+    if (state.status !== "resolved") {
+      setPlaybackSources(null);
+      setPlayerError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadSources() {
+      try {
+        const sources = await getDetailPlaybackSource(state.result.playbackId);
+        if (!cancelled) {
+          setPlaybackSources(sources);
+          if (!sources?.length) {
+            setPlayerError("Unable to load playback sources.");
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          logger.error("[CreativeTVUrlEmbed] Failed to load playback sources:", error);
+          setPlayerError("Unable to load playback sources.");
+        }
+      }
+    }
+
+    void loadSources();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state]);
+
+  const fallbackUrl =
+    state.status === "resolved"
+      ? state.result.fallbackUrl
+      : state.status === "fallback"
+        ? state.result.fallbackUrl
+        : undefined;
+
+  const showIframeFallback =
+    state.status === "fallback" ||
+    (state.status === "resolved" && (Boolean(playerError) || !playbackSources?.length));
+
+  const resolvedTitle =
+    state.status === "resolved" ? state.result.title ?? "Creative TV Video" : "Creative TV Video";
+
+  return (
+    <div className={className}>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Input
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onPaste={(event) => {
+            const pasted = event.clipboardData.getData("text");
+            if (pasted.trim()) {
+              setInputValue(pasted);
+            }
+            handlePaste(event);
+          }}
+          placeholder={placeholder}
+          aria-label="Creative TV video URL"
+        />
+        <Button
+          type="button"
+          onClick={() => void resolveFromInput(inputValue)}
+          disabled={!inputValue.trim() || state.status === "loading"}
+        >
+          {state.status === "loading" ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Resolving
+            </>
+          ) : (
+            "Embed"
+          )}
+        </Button>
+        {state.status !== "idle" ? (
+          <Button type="button" variant="outline" onClick={() => {
+            reset();
+            setInputValue("");
+            setPlaybackSources(null);
+            setPlayerError(null);
+          }}>
+            Clear
+          </Button>
+        ) : null}
+      </div>
+
+      {state.status === "fallback" && state.result.message ? (
+        <Alert className="mt-3">
+          <AlertDescription>{state.result.message}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {state.status === "loading" ? (
+        <div className="mt-4">
+          <PlayerLoading title="Resolving Creative TV URL..." />
+        </div>
+      ) : null}
+
+      {state.status === "resolved" && !showIframeFallback ? (
+        <div className="mt-4 overflow-hidden rounded-lg border">
+          {playbackSources ? (
+            <Player
+              src={playbackSources}
+              title={resolvedTitle}
+              playbackId={state.result.playbackId}
+            />
+          ) : (
+            <PlayerLoading title="Loading playback..." />
+          )}
+        </div>
+      ) : null}
+
+      {showIframeFallback && fallbackUrl ? (
+        <div className="mt-4 space-y-3">
+          <div className="overflow-hidden rounded-lg border">
+            <iframe
+              src={fallbackUrl}
+              title="Creative TV video"
+              className="aspect-video w-full border-0"
+              allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+              loading="lazy"
+            />
+          </div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <ExternalLink className="h-4 w-4" />
+            <Link href={fallbackUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
+              Open on Creative TV
+            </Link>
+          </div>
+        </div>
+      ) : null}
+
+      {state.status === "fallback" && !fallbackUrl ? (
+        <Alert className="mt-3" variant="destructive">
+          <AlertDescription>
+            {state.result.message ?? "Could not resolve that URL. Paste a /discover or /watch link."}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </div>
+  );
+}

--- a/components/Videos/CreativeTVUrlEmbed.tsx
+++ b/components/Videos/CreativeTVUrlEmbed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ExternalLink, Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -9,6 +9,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Player, PlayerLoading } from "@/components/Player/Player";
 import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
 import { useCreativeTVUrlResolve } from "@/hooks/useCreativeTVUrlResolve";
+import { getCreativeTVEmbedUrlForParsed } from "@/lib/utils/creative-tv-url";
 import type { Src } from "@livepeer/react";
 import { logger } from "@/lib/utils/logger";
 
@@ -74,6 +75,21 @@ export function CreativeTVUrlEmbed({
       : state.status === "fallback"
         ? state.result.fallbackUrl
         : undefined;
+
+  const iframeSrc = useMemo(() => {
+    const parsed =
+      state.status === "resolved"
+        ? state.result.parsed
+        : state.status === "fallback"
+          ? state.result.parsed
+          : undefined;
+
+    if (parsed) {
+      return getCreativeTVEmbedUrlForParsed(parsed, { origin: siteOrigin }) ?? fallbackUrl;
+    }
+
+    return fallbackUrl;
+  }, [state, siteOrigin, fallbackUrl]);
 
   const showIframeFallback =
     state.status === "fallback" ||
@@ -150,11 +166,11 @@ export function CreativeTVUrlEmbed({
         </div>
       ) : null}
 
-      {showIframeFallback && fallbackUrl ? (
+      {showIframeFallback && iframeSrc ? (
         <div className="mt-4 space-y-3">
           <div className="overflow-hidden rounded-lg border">
             <iframe
-              src={fallbackUrl}
+              src={iframeSrc}
               title="Creative TV video"
               className="aspect-video w-full border-0"
               allow="autoplay; encrypted-media; picture-in-picture; fullscreen"

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -97,6 +97,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
 
   const syncSession = useCallback(async () => {
     if (!session?.accessToken) return null;
+    let syncTimeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       const synced = await Promise.race([
         orb.syncSession({
@@ -105,7 +106,10 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
           authenticationId: session.authenticationId,
         }),
         new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Orb session sync timed out')), 20_000);
+          syncTimeoutId = setTimeout(
+            () => reject(new Error('Orb session sync timed out')),
+            20_000,
+          );
         }),
       ]);
       if (!synced?.accessToken) {
@@ -126,6 +130,10 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         return null;
       }
       return session;
+    } finally {
+      if (syncTimeoutId !== undefined) {
+        clearTimeout(syncTimeoutId);
+      }
     }
   }, [session, orb, persistSession, invalidateOrbSession]);
 

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -62,7 +62,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
   const [accountMenuRefreshSignal, setAccountMenuRefreshSignal] = useState(0);
   const user = useUser();
   const { account: modularAccount } = useModularAccount();
-  const { getAuthHeaders } = useWalletAuth();
+  const { getAuthHeaders, isReady: isWalletAuthReady } = useWalletAuth();
   const orb = useMemo(() => getOrbLogin(), []);
 
   const walletAddress = modularAccount?.address || user?.address || null;
@@ -98,11 +98,16 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
   const syncSession = useCallback(async () => {
     if (!session?.accessToken) return null;
     try {
-      const synced = await orb.syncSession({
-        accessToken: session.accessToken,
-        refreshToken: session.refreshToken,
-        authenticationId: session.authenticationId,
-      });
+      const synced = await Promise.race([
+        orb.syncSession({
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken,
+          authenticationId: session.authenticationId,
+        }),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('Orb session sync timed out')), 20_000);
+        }),
+      ]);
       if (!synced?.accessToken) {
         invalidateOrbSession();
         return null;
@@ -133,8 +138,22 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
 
   /** Clear revoked/expired Orb tokens so Songchain and feeds stay read-only instead of erroring. */
   useEffect(() => {
-    if (!session?.accessToken) return;
-    void syncSession();
+    const token = session?.accessToken;
+    if (!token) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        await syncSession();
+      } catch {
+        /* syncSession handles stale sessions internally */
+      }
+      if (cancelled) return;
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [session?.accessToken, syncSession]);
 
   const linkProfile = useCallback(
@@ -161,6 +180,15 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
 
       setIsLinking(true);
       try {
+        if (!isWalletAuthReady) {
+          setLinkStatus('needs_wallet');
+          const message =
+            'Wallet is still initializing. Wait a moment, then tap Sync profile again.';
+          setLoginError(message);
+          toast.info(message);
+          return;
+        }
+
         let authHeaders: Record<string, string>;
         try {
           authHeaders = await getAuthHeaders();
@@ -200,7 +228,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         setIsLinking(false);
       }
     },
-    [session, modularAccount?.address, user?.address, getAuthHeaders],
+    [session, modularAccount?.address, user?.address, getAuthHeaders, isWalletAuthReady],
   );
 
   useEffect(() => {
@@ -261,7 +289,7 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
 
         const wallet = modularAccount?.address || user?.address;
         if (wallet) {
-          await linkProfile(wallet);
+          void linkProfile(wallet).catch(() => undefined);
         } else {
           setLinkStatus('needs_wallet');
           toast.info(

--- a/docs/platform-api.md
+++ b/docs/platform-api.md
@@ -2,6 +2,16 @@
 
 Tiered access for read-only Platform API routes used by Creative Platform apps (Mixtape), administrators, and external AI agents.
 
+## Canonical playback resolver URL
+
+```
+GET https://tv.creativeplatform.xyz/api/video-assets/by-asset-id/{uuid}/playback
+```
+
+- `{uuid}` is the Livepeer asset id from `/discover/{uuid}` (not the playback id).
+- For watch pages, use `/watch/{playbackId}` directly — no resolver call needed.
+- There is no `/api/platform/...` prefix in Phase 1.
+
 ## Tiers
 
 | Tier | Auth | Fee |

--- a/docs/platform-api.md
+++ b/docs/platform-api.md
@@ -1,0 +1,116 @@
+# Creative TV Platform API
+
+Tiered access for read-only Platform API routes used by Creative Platform apps (Mixtape), administrators, and external AI agents.
+
+## Tiers
+
+| Tier | Auth | Fee |
+|------|------|-----|
+| **Admin** | `Authorization: Bearer <admin secret>` | None |
+| **Partner** | `Authorization: Bearer <partner secret>` | None |
+| **Public / agents** | `X-Payment-Proof` header after USDC payment | Micro-USDC per call |
+| **Unauthenticated** | — | HTTP 402 Payment Required |
+
+Gating is active when `PLATFORM_API_ACCESS_ENABLED=true`, or when admin/partner keys or `X402_API_RECIPIENT` are configured. Set `PLATFORM_API_ACCESS_ENABLED=false` to disable gating in local dev.
+
+## Generate API keys (local only)
+
+```bash
+pnpm tsx scripts/generate-platform-api-key.ts --tier admin
+pnpm tsx scripts/generate-platform-api-key.ts --tier partner --id mixtape
+```
+
+Never commit generated secrets. Store in Vercel env vars only.
+
+## Environment variables (CRTV)
+
+```env
+PLATFORM_API_ACCESS_ENABLED=true
+CREATIVE_PLATFORM_ADMIN_API_KEYS=crtv_admin_...
+CREATIVE_PLATFORM_PARTNER_API_KEYS=mixtape:crtv_pk_mixtape_...
+X402_API_RECIPIENT=0x...
+X402_PLAYBACK_RESOLVE_PRICE=10000
+X402_PUBLISHED_LIST_PRICE=25000
+X402_PLAYBACK_INFO_PRICE=50000
+X402_VIEWS_METRICS_PRICE=50000
+```
+
+Prices are USDC base units (6 decimals). `10000` = $0.01 USDC.
+
+## Gated routes (Phase 1 + 2)
+
+| Route | Resource id | Default price |
+|-------|-------------|---------------|
+| `GET /api/video-assets/by-asset-id/{uuid}/playback` | `playback.resolve` | 10000 |
+| `GET /api/video-assets/published` | `videos.published` | 25000 |
+| `GET /api/livepeer/playback-info?playbackId=` | `playback.info` | 50000 |
+| `GET /api/livepeer/views/{playbackId}` | `views.metrics` | 50000 |
+
+## Mixtape integration (air.creativeplatform.xyz)
+
+**Use a server-side proxy.** Do not expose the partner key in the browser.
+
+1. Generate a partner key: `--tier partner --id mixtape`
+2. Set on CRTV: `CREATIVE_PLATFORM_PARTNER_API_KEYS=mixtape:<secret>`
+3. Set on Mixtape server: `MIXTAPE_CRTV_API_KEY=<secret>` and `CRTV_API_BASE=https://tv.creativeplatform.xyz`
+
+### Mixtape server route example
+
+```ts
+// app/api/crtv/resolve-playback/route.ts (Mixtape)
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  const uuid = extractDiscoverUuid(url);
+  if (!uuid) {
+    return Response.json({ error: "Invalid discover URL" }, { status: 400 });
+  }
+
+  const res = await fetch(
+    `${process.env.CRTV_API_BASE}/api/video-assets/by-asset-id/${uuid}/playback`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.MIXTAPE_CRTV_API_KEY}`,
+      },
+    },
+  );
+
+  return Response.json(await res.json(), { status: res.status });
+}
+```
+
+Mixtape client calls `/api/crtv/resolve-playback`, not CRTV directly.
+
+## x402 payment flow (agents)
+
+1. `GET` a gated route without auth → **402** with `accepts[]` (USDC on Base).
+2. Send USDC to `payTo` for at least `maxAmountRequired`.
+3. Retry with header:
+
+```
+X-Payment-Proof: <base64url(JSON.stringify({ transactionHash, amount }))>
+```
+
+Example proof JSON before encoding:
+
+```json
+{ "transactionHash": "0x...", "amount": "10000" }
+```
+
+## Discover URL → playbackId
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_KEY" \
+  "https://tv.creativeplatform.xyz/api/video-assets/by-asset-id/{uuid}/playback"
+```
+
+Response:
+
+```json
+{
+  "playbackId": "...",
+  "title": "...",
+  "thumbnailUri": "...",
+  "requiresMetoken": false,
+  "fallbackUrl": "https://tv.creativeplatform.xyz/discover/{uuid}"
+}
+```

--- a/hooks/useCreativeTVUrlResolve.ts
+++ b/hooks/useCreativeTVUrlResolve.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  resolveCreativeTVPlayback,
+  type ResolveCreativeTVPlaybackOptions,
+  type ResolveCreativeTVPlaybackResult,
+} from "@/lib/utils/resolve-creative-tv-playback";
+
+export type CreativeTVUrlResolveState =
+  | { status: "idle" }
+  | { status: "loading"; input: string }
+  | { status: "resolved"; input: string; result: Extract<ResolveCreativeTVPlaybackResult, { ok: true }> }
+  | { status: "fallback"; input: string; result: Extract<ResolveCreativeTVPlaybackResult, { ok: false }> };
+
+export type UseCreativeTVUrlResolveOptions = ResolveCreativeTVPlaybackOptions;
+
+export function useCreativeTVUrlResolve(opts?: UseCreativeTVUrlResolveOptions) {
+  const [state, setState] = useState<CreativeTVUrlResolveState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState({ status: "idle" });
+  }, []);
+
+  const resolveFromInput = useCallback(async (input: string) => {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      reset();
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState({ status: "loading", input: trimmed });
+
+    try {
+      const result = await resolveCreativeTVPlayback(trimmed, {
+        ...optsRef.current,
+        signal: controller.signal,
+      });
+
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      if (result.ok) {
+        const useFallback = result.requiresMetoken;
+        setState(
+          useFallback
+            ? {
+                status: "fallback",
+                input: trimmed,
+                result: {
+                  ok: false,
+                  reason: "not_found",
+                  fallbackUrl: result.fallbackUrl,
+                  parsed: result.parsed,
+                  message: "This video requires a MeToken subscription. Open on Creative TV to watch.",
+                },
+              }
+            : { status: "resolved", input: trimmed, result },
+        );
+        return;
+      }
+
+      setState({ status: "fallback", input: trimmed, result });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setState({
+        status: "fallback",
+        input: trimmed,
+        result: {
+          ok: false,
+          reason: "network_error",
+          message: error instanceof Error ? error.message : "Failed to resolve URL",
+        },
+      });
+    }
+  }, [reset]);
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const pasted = event.clipboardData.getData("text");
+      if (!pasted.trim()) {
+        return;
+      }
+      event.preventDefault();
+      void resolveFromInput(pasted);
+    },
+    [resolveFromInput],
+  );
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return {
+    state,
+    resolveFromInput,
+    handlePaste,
+    reset,
+  };
+}

--- a/lib/middleware/paymentReplayGuard.ts
+++ b/lib/middleware/paymentReplayGuard.ts
@@ -1,0 +1,41 @@
+import { supabaseService } from "@/lib/sdk/supabase/service";
+import { serverLogger } from "@/lib/utils/logger";
+
+export type ConsumePaymentReceiptResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Records a payment transaction hash so the same proof cannot be reused.
+ * Returns an error when the hash was already consumed.
+ */
+export async function consumePaymentReceipt(
+  transactionHash: string,
+  resource: string,
+): Promise<ConsumePaymentReceiptResult> {
+  const normalizedHash = transactionHash.trim().toLowerCase();
+  if (!normalizedHash.startsWith("0x")) {
+    return { ok: false, error: "Invalid transaction hash" };
+  }
+
+  const supabase = supabaseService;
+  if (!supabase) {
+    serverLogger.error("[paymentReplayGuard] Supabase service client unavailable");
+    return { ok: false, error: "Payment receipt storage unavailable" };
+  }
+
+  const { error } = await supabase.from("platform_api_payment_receipts").insert({
+    transaction_hash: normalizedHash,
+    resource,
+  });
+
+  if (error) {
+    if (error.code === "23505") {
+      return { ok: false, error: "Payment proof already used" };
+    }
+    serverLogger.error("[paymentReplayGuard] Failed to record payment receipt", error);
+    return { ok: false, error: "Unable to record payment receipt" };
+  }
+
+  return { ok: true };
+}

--- a/lib/middleware/platformApiAccess.test.ts
+++ b/lib/middleware/platformApiAccess.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockVerifyX402PaymentFromRequest = vi.fn();
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: {
+    apiKey: vi.fn(async () => null),
+  },
+}));
+
+vi.mock("@/lib/middleware/x402Gate", () => ({
+  PLATFORM_API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+  },
+  buildX402PaymentRequiredResponse: vi.fn(() =>
+    Response.json({ error: "Payment Required", accepts: [{ payTo: "0xrecipient" }] }, { status: 402 }),
+  ),
+  getX402PriceForResource: vi.fn(() => "10000"),
+  getX402Recipient: vi.fn(() => "0xrecipient"),
+  verifyX402PaymentFromRequest: (...args: unknown[]) =>
+    mockVerifyX402PaymentFromRequest(...args),
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { requirePlatformApiAccess } from "@/lib/middleware/platformApiAccess";
+
+describe("requirePlatformApiAccess", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PLATFORM_API_ACCESS_ENABLED = "true";
+    process.env.CREATIVE_PLATFORM_ADMIN_API_KEYS = "crtv_admin_test";
+    process.env.CREATIVE_PLATFORM_PARTNER_API_KEYS = "mixtape:crtv_pk_mixtape_test";
+    process.env.X402_API_RECIPIENT = "0x31ee83aef931a1af321c505053040e98545a5614";
+    process.env.X402_PLAYBACK_RESOLVE_PRICE = "10000";
+    mockVerifyX402PaymentFromRequest.mockResolvedValue({
+      ok: false,
+      error: "Missing payment proof",
+    });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it("allows admin API key", async () => {
+    const request = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer crtv_admin_test" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("admin");
+    }
+  });
+
+  it("allows partner API key", async () => {
+    const request = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer crtv_pk_mixtape_test" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("partner");
+      expect(result.keyId).toBe("mixtape");
+    }
+  });
+
+  it("returns 401 for invalid API key", async () => {
+    const request = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer invalid" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("returns 402 when no auth and no payment", async () => {
+    const request = new NextRequest("http://localhost/api/test");
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.response.status).toBe(402);
+    }
+  });
+
+  it("allows x402 payment proof", async () => {
+    mockVerifyX402PaymentFromRequest.mockResolvedValueOnce({ ok: true });
+    const request = new NextRequest("http://localhost/api/test", {
+      headers: { "X-Payment-Proof": "proof" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("x402");
+    }
+  });
+
+  it("bypasses gating when access is disabled", async () => {
+    process.env.PLATFORM_API_ACCESS_ENABLED = "false";
+    delete process.env.CREATIVE_PLATFORM_ADMIN_API_KEYS;
+    delete process.env.CREATIVE_PLATFORM_PARTNER_API_KEYS;
+    delete process.env.X402_API_RECIPIENT;
+
+    const request = new NextRequest("http://localhost/api/test");
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("public");
+    }
+  });
+});

--- a/lib/middleware/platformApiAccess.ts
+++ b/lib/middleware/platformApiAccess.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import {
+  extractBearerToken,
+  isPlatformApiAccessConfigured,
+  matchPlatformApiKey,
+  parsePlatformApiKeysFromEnv,
+} from "@/lib/middleware/platformApiKeys";
+import {
+  buildX402PaymentRequiredResponse,
+  getX402PriceForResource,
+  getX402Recipient,
+  PLATFORM_API_CORS_HEADERS,
+  verifyX402PaymentFromRequest,
+} from "@/lib/middleware/x402Gate";
+import { serverLogger } from "@/lib/utils/logger";
+
+export type PlatformApiAccessTier = "admin" | "partner" | "x402" | "public";
+
+export type PlatformApiAccessOptions = {
+  resource: string;
+  priceUsdc?: string;
+};
+
+export type PlatformApiAccessResult =
+  | { allowed: true; tier: PlatformApiAccessTier; keyId?: string }
+  | { allowed: false; response: NextResponse };
+
+function unauthorizedResponse(message: string): NextResponse {
+  return NextResponse.json(
+    { error: message, code: "UNAUTHORIZED" },
+    { status: 401, headers: PLATFORM_API_CORS_HEADERS },
+  );
+}
+
+export async function requirePlatformApiAccess(
+  request: NextRequest,
+  options: PlatformApiAccessOptions,
+): Promise<PlatformApiAccessResult> {
+  if (!isPlatformApiAccessConfigured()) {
+    return { allowed: true, tier: "public" };
+  }
+
+  const keys = parsePlatformApiKeysFromEnv();
+  const bearer = extractBearerToken(request.headers.get("authorization"));
+
+  if (bearer) {
+    const match = matchPlatformApiKey(bearer, keys);
+    if (match) {
+      if (match.tier === "partner") {
+        const rl = await rateLimiters.apiKey(request, match.keyId ?? "partner");
+        if (rl) {
+          const headers = new Headers(rl.headers);
+          for (const [key, value] of Object.entries(PLATFORM_API_CORS_HEADERS)) {
+            headers.set(key, value);
+          }
+          return {
+            allowed: false,
+            response: new NextResponse(rl.body, { status: rl.status, headers }),
+          };
+        }
+      }
+
+      serverLogger.debug("[platformApiAccess] allowed", {
+        tier: match.tier,
+        keyId: match.keyId,
+        resource: options.resource,
+      });
+
+      return { allowed: true, tier: match.tier, keyId: match.keyId };
+    }
+
+    return { allowed: false, response: unauthorizedResponse("Invalid API key") };
+  }
+
+  const recipient = getX402Recipient();
+  const priceUsdc = options.priceUsdc ?? getX402PriceForResource(options.resource);
+
+  if (!recipient) {
+    return {
+      allowed: false,
+      response: unauthorizedResponse(
+        "API key required. Configure CREATIVE_PLATFORM_*_API_KEYS or X402_API_RECIPIENT.",
+      ),
+    };
+  }
+
+  const payment = await verifyX402PaymentFromRequest(request, { recipient, priceUsdc });
+  if (payment.ok) {
+    serverLogger.debug("[platformApiAccess] x402 payment verified", {
+      resource: options.resource,
+    });
+    return { allowed: true, tier: "x402" };
+  }
+
+  if (payment.error !== "Missing payment proof") {
+    return {
+      allowed: false,
+      response: NextResponse.json(
+        { error: payment.error, code: "PAYMENT_INVALID" },
+        { status: 402, headers: PLATFORM_API_CORS_HEADERS },
+      ),
+    };
+  }
+
+  return {
+    allowed: false,
+    response: buildX402PaymentRequiredResponse({
+      resource: options.resource,
+      priceUsdc,
+      recipient,
+      requestUrl: request.url,
+    }),
+  };
+}
+
+export function platformApiOptionsResponse(): NextResponse {
+  return new NextResponse(null, {
+    status: 200,
+    headers: PLATFORM_API_CORS_HEADERS,
+  });
+}

--- a/lib/middleware/platformApiAccess.ts
+++ b/lib/middleware/platformApiAccess.ts
@@ -3,8 +3,8 @@ import { rateLimiters } from "@/lib/middleware/rateLimit";
 import {
   extractBearerToken,
   isPlatformApiAccessConfigured,
+  getPlatformApiKeysFromEnv,
   matchPlatformApiKey,
-  parsePlatformApiKeysFromEnv,
 } from "@/lib/middleware/platformApiKeys";
 import {
   buildX402PaymentRequiredResponse,
@@ -41,7 +41,7 @@ export async function requirePlatformApiAccess(
     return { allowed: true, tier: "public" };
   }
 
-  const keys = parsePlatformApiKeysFromEnv();
+  const keys = getPlatformApiKeysFromEnv();
   const bearer = extractBearerToken(request.headers.get("authorization"));
 
   if (bearer) {
@@ -85,7 +85,11 @@ export async function requirePlatformApiAccess(
     };
   }
 
-  const payment = await verifyX402PaymentFromRequest(request, { recipient, priceUsdc });
+  const payment = await verifyX402PaymentFromRequest(request, {
+    recipient,
+    priceUsdc,
+    resource: options.resource,
+  });
   if (payment.ok) {
     serverLogger.debug("[platformApiAccess] x402 payment verified", {
       resource: options.resource,

--- a/lib/middleware/platformApiKeys.test.ts
+++ b/lib/middleware/platformApiKeys.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractBearerToken,
+  matchPlatformApiKey,
+  parsePlatformApiKeysFromEnv,
+} from "@/lib/middleware/platformApiKeys";
+
+describe("platformApiKeys", () => {
+  it("parses admin and partner keys from env", () => {
+    const keys = parsePlatformApiKeysFromEnv({
+      CREATIVE_PLATFORM_ADMIN_API_KEYS: "admin_a,admin_b",
+      CREATIVE_PLATFORM_PARTNER_API_KEYS: "mixtape:secret_mixtape,create:secret_create",
+    });
+
+    expect(keys.adminSecrets).toEqual(["admin_a", "admin_b"]);
+    expect(keys.partnerKeys.get("mixtape")).toBe("secret_mixtape");
+    expect(keys.partnerKeys.get("create")).toBe("secret_create");
+  });
+
+  it("extracts bearer token", () => {
+    expect(extractBearerToken("Bearer crtv_admin_abc")).toBe("crtv_admin_abc");
+    expect(extractBearerToken("Basic abc")).toBeNull();
+  });
+
+  it("matches admin and partner keys with constant-time compare semantics", () => {
+    const keys = parsePlatformApiKeysFromEnv({
+      CREATIVE_PLATFORM_ADMIN_API_KEYS: "crtv_admin_test",
+      CREATIVE_PLATFORM_PARTNER_API_KEYS: "mixtape:partner_secret",
+    });
+
+    expect(matchPlatformApiKey("crtv_admin_test", keys)?.tier).toBe("admin");
+    expect(matchPlatformApiKey("partner_secret", keys)).toEqual({
+      tier: "partner",
+      keyId: "mixtape",
+    });
+    expect(matchPlatformApiKey("wrong", keys)).toBeNull();
+  });
+});

--- a/lib/middleware/platformApiKeys.ts
+++ b/lib/middleware/platformApiKeys.ts
@@ -26,6 +26,13 @@ function parseCommaList(raw: string | undefined): string[] {
     .filter(Boolean);
 }
 
+let cachedKeys: ParsedPlatformApiKeys | null = null;
+let cachedEnvFingerprint: string | null = null;
+
+function platformApiKeysEnvFingerprint(env: NodeJS.ProcessEnv): string {
+  return `${env.CREATIVE_PLATFORM_ADMIN_API_KEYS ?? ""}|${env.CREATIVE_PLATFORM_PARTNER_API_KEYS ?? ""}`;
+}
+
 export function parsePlatformApiKeysFromEnv(env: NodeJS.ProcessEnv = process.env): ParsedPlatformApiKeys {
   const adminSecrets = parseCommaList(env.CREATIVE_PLATFORM_ADMIN_API_KEYS);
 
@@ -43,6 +50,22 @@ export function parsePlatformApiKeysFromEnv(env: NodeJS.ProcessEnv = process.env
   }
 
   return { adminSecrets, partnerKeys };
+}
+
+/** Cached in production to avoid re-parsing env on every Platform API request. */
+export function getPlatformApiKeysFromEnv(env: NodeJS.ProcessEnv = process.env): ParsedPlatformApiKeys {
+  if (env.NODE_ENV !== "production") {
+    return parsePlatformApiKeysFromEnv(env);
+  }
+
+  const fingerprint = platformApiKeysEnvFingerprint(env);
+  if (cachedKeys && cachedEnvFingerprint === fingerprint) {
+    return cachedKeys;
+  }
+
+  cachedKeys = parsePlatformApiKeysFromEnv(env);
+  cachedEnvFingerprint = fingerprint;
+  return cachedKeys;
 }
 
 export function extractBearerToken(authorizationHeader: string | null): string | null {
@@ -80,7 +103,7 @@ export function isPlatformApiAccessConfigured(env: NodeJS.ProcessEnv = process.e
     return true;
   }
 
-  const keys = parsePlatformApiKeysFromEnv(env);
+  const keys = getPlatformApiKeysFromEnv(env);
   return (
     keys.adminSecrets.length > 0 ||
     keys.partnerKeys.size > 0 ||

--- a/lib/middleware/platformApiKeys.ts
+++ b/lib/middleware/platformApiKeys.ts
@@ -1,0 +1,89 @@
+import { timingSafeEqual } from "crypto";
+
+export type PlatformApiKeyTier = "admin" | "partner";
+
+export type ParsedPlatformApiKeys = {
+  adminSecrets: string[];
+  partnerKeys: Map<string, string>;
+};
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+function parseCommaList(raw: string | undefined): string[] {
+  if (!raw?.trim()) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function parsePlatformApiKeysFromEnv(env: NodeJS.ProcessEnv = process.env): ParsedPlatformApiKeys {
+  const adminSecrets = parseCommaList(env.CREATIVE_PLATFORM_ADMIN_API_KEYS);
+
+  const partnerKeys = new Map<string, string>();
+  for (const entry of parseCommaList(env.CREATIVE_PLATFORM_PARTNER_API_KEYS)) {
+    const colonIndex = entry.indexOf(":");
+    if (colonIndex <= 0) {
+      continue;
+    }
+    const id = entry.slice(0, colonIndex).trim();
+    const secret = entry.slice(colonIndex + 1).trim();
+    if (id && secret) {
+      partnerKeys.set(id, secret);
+    }
+  }
+
+  return { adminSecrets, partnerKeys };
+}
+
+export function extractBearerToken(authorizationHeader: string | null): string | null {
+  if (!authorizationHeader) {
+    return null;
+  }
+  const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+export function matchPlatformApiKey(
+  token: string,
+  keys: ParsedPlatformApiKeys,
+): { tier: PlatformApiKeyTier; keyId?: string } | null {
+  for (const secret of keys.adminSecrets) {
+    if (safeEqual(token, secret)) {
+      return { tier: "admin" };
+    }
+  }
+
+  for (const [keyId, secret] of keys.partnerKeys.entries()) {
+    if (safeEqual(token, secret)) {
+      return { tier: "partner", keyId };
+    }
+  }
+
+  return null;
+}
+
+export function isPlatformApiAccessConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.PLATFORM_API_ACCESS_ENABLED === "false") {
+    return false;
+  }
+  if (env.PLATFORM_API_ACCESS_ENABLED === "true") {
+    return true;
+  }
+
+  const keys = parsePlatformApiKeysFromEnv(env);
+  return (
+    keys.adminSecrets.length > 0 ||
+    keys.partnerKeys.size > 0 ||
+    Boolean(env.X402_API_RECIPIENT?.trim())
+  );
+}

--- a/lib/middleware/verifyUsdcPayment.ts
+++ b/lib/middleware/verifyUsdcPayment.ts
@@ -1,0 +1,134 @@
+import { decodeEventLog } from "viem";
+import { USDC_TOKEN_ADDRESSES } from "@/lib/contracts/USDCToken";
+
+const DEFAULT_PAYMENT_MAX_AGE_MS = 10 * 60 * 1000;
+
+async function getPublicClient() {
+  const { publicClient } = await import("@/lib/viem");
+  return publicClient;
+}
+
+export type UsdcPaymentProof = {
+  transactionHash: string;
+  amount: string;
+};
+
+export type VerifyUsdcPaymentResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+/**
+ * Verifies a USDC transfer on Base to the expected recipient with at least the required amount.
+ */
+export async function verifyUsdcPaymentProof(
+  proof: UsdcPaymentProof,
+  options: {
+    recipient: string;
+    requiredAmount: bigint;
+    maxAgeMs?: number;
+  },
+): Promise<VerifyUsdcPaymentResult> {
+  const { transactionHash, amount } = proof;
+  const { recipient, requiredAmount, maxAgeMs = DEFAULT_PAYMENT_MAX_AGE_MS } = options;
+
+  let claimedAmount: bigint;
+  try {
+    claimedAmount = BigInt(amount);
+  } catch {
+    return { valid: false, error: "Invalid payment amount" };
+  }
+
+  if (claimedAmount < requiredAmount) {
+    return { valid: false, error: "Payment amount is less than required" };
+  }
+
+  try {
+    const publicClient = await getPublicClient();
+    const receipt = await publicClient.getTransactionReceipt({
+      hash: transactionHash as `0x${string}`,
+    });
+
+    if (!receipt) {
+      return { valid: false, error: "Transaction not found" };
+    }
+    if (receipt.status !== "success") {
+      return { valid: false, error: "Transaction failed" };
+    }
+
+    const now = Date.now();
+    const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
+    const blockTime = Number(block.timestamp) * 1000;
+    if (now - blockTime > maxAgeMs) {
+      return { valid: false, error: "Payment too old; please pay again and retry" };
+    }
+
+    const usdcAddress = USDC_TOKEN_ADDRESSES.base.toLowerCase();
+    const recipientLower = recipient.toLowerCase();
+    let foundTransfer = false;
+    let transferValue = 0n;
+
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== usdcAddress) {
+        continue;
+      }
+      try {
+        const decoded = decodeEventLog({
+          abi: [
+            {
+              type: "event",
+              name: "Transfer",
+              inputs: [
+                { name: "from", type: "address", indexed: true },
+                { name: "to", type: "address", indexed: true },
+                { name: "value", type: "uint256", indexed: false },
+              ],
+            },
+          ],
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "Transfer") {
+          const args = decoded.args as { from: string; to: string; value: bigint };
+          if (args.to.toLowerCase() === recipientLower) {
+            foundTransfer = true;
+            transferValue = args.value;
+            break;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    if (!foundTransfer || transferValue < requiredAmount) {
+      return {
+        valid: false,
+        error: "No valid USDC transfer to the service recipient found for this transaction",
+      };
+    }
+
+    return { valid: true };
+  } catch (err) {
+    return {
+      valid: false,
+      error: err instanceof Error ? err.message : "Payment verification failed",
+    };
+  }
+}
+
+export function parsePaymentProofHeader(headerValue: string | null): UsdcPaymentProof | null {
+  if (!headerValue?.trim()) {
+    return null;
+  }
+
+  try {
+    const json = Buffer.from(headerValue.trim(), "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as { transactionHash?: string; amount?: string };
+    if (!parsed.transactionHash || !parsed.amount) {
+      return null;
+    }
+    return { transactionHash: parsed.transactionHash, amount: parsed.amount };
+  } catch {
+    return null;
+  }
+}

--- a/lib/middleware/x402Gate.ts
+++ b/lib/middleware/x402Gate.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { USDC_TOKEN_ADDRESSES } from "@/lib/contracts/USDCToken";
+import {
+  parsePaymentProofHeader,
+  verifyUsdcPaymentProof,
+} from "@/lib/middleware/verifyUsdcPayment";
+
+export type X402GateOptions = {
+  resource: string;
+  priceUsdc: string;
+  recipient: string;
+  requestUrl?: string;
+};
+
+export const PLATFORM_API_CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, X-Payment-Proof, X-PAYMENT",
+};
+
+export function getX402Recipient(env: NodeJS.ProcessEnv = process.env): string | null {
+  const recipient = env.X402_API_RECIPIENT?.trim();
+  return recipient || null;
+}
+
+export function getX402PriceForResource(
+  resource: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const envKey = `X402_${resource.replace(/[.-]/g, "_").toUpperCase()}_PRICE`;
+  const specific = env[envKey]?.trim();
+  if (specific) {
+    return specific;
+  }
+
+  const defaults: Record<string, string> = {
+    "playback.resolve": env.X402_PLAYBACK_RESOLVE_PRICE?.trim() || "10000",
+    "videos.published": env.X402_PUBLISHED_LIST_PRICE?.trim() || "25000",
+    "playback.info": env.X402_PLAYBACK_INFO_PRICE?.trim() || "50000",
+    "views.metrics": env.X402_VIEWS_METRICS_PRICE?.trim() || "50000",
+  };
+
+  return defaults[resource] || env.X402_DEFAULT_PRICE?.trim() || "10000";
+}
+
+export function buildX402PaymentRequiredResponse(options: X402GateOptions): NextResponse {
+  return NextResponse.json(
+    {
+      error: "Payment Required",
+      x402Version: 1,
+      accepts: [
+        {
+          scheme: "exact",
+          network: "base",
+          maxAmountRequired: options.priceUsdc,
+          resource: options.resource,
+          description: `Creative TV Platform API: ${options.resource}`,
+          mimeType: "application/json",
+          payTo: options.recipient,
+          maxTimeoutSeconds: 300,
+          asset: USDC_TOKEN_ADDRESSES.base,
+        },
+      ],
+      paymentInstructions: {
+        header: "X-Payment-Proof",
+        format: "base64url(JSON.stringify({ transactionHash, amount }))",
+        note: "Send a Base USDC transfer to payTo, then retry with the proof header.",
+      },
+    },
+    {
+      status: 402,
+      headers: PLATFORM_API_CORS_HEADERS,
+    },
+  );
+}
+
+export async function verifyX402PaymentFromRequest(
+  request: NextRequest,
+  options: { recipient: string; priceUsdc: string },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const proof =
+    parsePaymentProofHeader(request.headers.get("X-Payment-Proof")) ||
+    parsePaymentProofHeader(request.headers.get("X-PAYMENT"));
+
+  if (!proof) {
+    return { ok: false, error: "Missing payment proof" };
+  }
+
+  const verification = await verifyUsdcPaymentProof(proof, {
+    recipient: options.recipient,
+    requiredAmount: BigInt(options.priceUsdc),
+  });
+
+  if (!verification.valid) {
+    return { ok: false, error: verification.error };
+  }
+
+  return { ok: true };
+}

--- a/lib/middleware/x402Gate.ts
+++ b/lib/middleware/x402Gate.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { USDC_TOKEN_ADDRESSES } from "@/lib/contracts/USDCToken";
+import { consumePaymentReceipt } from "@/lib/middleware/paymentReplayGuard";
 import {
   parsePaymentProofHeader,
   verifyUsdcPaymentProof,
@@ -77,7 +78,7 @@ export function buildX402PaymentRequiredResponse(options: X402GateOptions): Next
 
 export async function verifyX402PaymentFromRequest(
   request: NextRequest,
-  options: { recipient: string; priceUsdc: string },
+  options: { recipient: string; priceUsdc: string; resource?: string },
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const proof =
     parsePaymentProofHeader(request.headers.get("X-Payment-Proof")) ||
@@ -87,13 +88,26 @@ export async function verifyX402PaymentFromRequest(
     return { ok: false, error: "Missing payment proof" };
   }
 
+  let requiredAmount: bigint;
+  try {
+    requiredAmount = BigInt(options.priceUsdc);
+  } catch {
+    return { ok: false, error: "Invalid price configuration" };
+  }
+
   const verification = await verifyUsdcPaymentProof(proof, {
     recipient: options.recipient,
-    requiredAmount: BigInt(options.priceUsdc),
+    requiredAmount,
   });
 
   if (!verification.valid) {
     return { ok: false, error: verification.error };
+  }
+
+  const resource = options.resource?.trim() || "platform-api";
+  const replay = await consumePaymentReceipt(proof.transactionHash, resource);
+  if (!replay.ok) {
+    return { ok: false, error: replay.error };
   }
 
   return { ok: true };

--- a/lib/sdk/orb/config.ts
+++ b/lib/sdk/orb/config.ts
@@ -27,6 +27,17 @@ function readClientEnv(...keys: string[]): string | undefined {
   return undefined;
 }
 
+/** Resolve relative app proxy paths to absolute URLs for Orb SDK fetch calls. */
+function resolveClientUrl(pathOrUrl: string): string {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+    return pathOrUrl;
+  }
+  if (typeof window !== 'undefined') {
+    return new URL(pathOrUrl, window.location.origin).toString();
+  }
+  return pathOrUrl;
+}
+
 /** Resolved Orb/Lens auth + media config from app env (@orbclub/modules does not read env). */
 export function getOrbLoginConfig(): OrbLoginConfig {
   const qr: QrAuthPluginConfig = {};
@@ -35,12 +46,15 @@ export function getOrbLoginConfig(): OrbLoginConfig {
   const graphqlUrl = readClientEnv('NEXT_PUBLIC_LENS_GRAPHQL_URL');
   if (graphqlUrl) lens.graphqlUrl = graphqlUrl;
 
-  qr.initUrl =
+  const initPath =
     readClientEnv('NEXT_PUBLIC_QR_INIT_URL', 'NEXT_PUBLIC_ORB_QR_INIT_URL') ??
     ORB_APP_QR_INIT_PROXY;
-  qr.pollUrl =
+  const pollPath =
     readClientEnv('NEXT_PUBLIC_QR_POLL_URL', 'NEXT_PUBLIC_ORB_QR_POLL_URL') ??
     ORB_APP_QR_POLL_PROXY;
+
+  qr.initUrl = resolveClientUrl(initPath);
+  qr.pollUrl = resolveClientUrl(pollPath);
 
   return { qr, lens };
 }

--- a/lib/sdk/orb/config.ts
+++ b/lib/sdk/orb/config.ts
@@ -35,7 +35,13 @@ function resolveClientUrl(pathOrUrl: string): string {
   if (typeof window !== 'undefined') {
     return new URL(pathOrUrl, window.location.origin).toString();
   }
-  return pathOrUrl;
+
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined) ||
+    'https://tv.creativeplatform.xyz';
+
+  return new URL(pathOrUrl, siteUrl.replace(/\/$/, '')).toString();
 }
 
 /** Resolved Orb/Lens auth + media config from app env (@orbclub/modules does not read env). */

--- a/lib/sdk/orb/login.test.ts
+++ b/lib/sdk/orb/login.test.ts
@@ -30,6 +30,20 @@ describe('orb session storage', () => {
     unsubscribe();
   });
 
+  it('does not notify when session payload is unchanged', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeOrbSession(listener);
+
+    saveStoredOrbSession({ accessToken: 'same-token' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    listener.mockClear();
+
+    saveStoredOrbSession({ accessToken: 'same-token' });
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
   it('dispatches a session change event on save and clear', () => {
     const handler = vi.fn();
     window.addEventListener(ORB_SESSION_CHANGE_EVENT, handler);

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -74,11 +74,25 @@ export function getOrbSessionServerSnapshot(): StoredOrbSession | null {
 
 export function saveStoredOrbSession(session: StoredOrbSession | null): void {
   if (typeof window === 'undefined') return;
+
+  const existingRaw = localStorage.getItem(ORB_SESSION_STORAGE_KEY);
+
   if (!session?.accessToken) {
+    if (!existingRaw) {
+      return;
+    }
     localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
-  } else {
-    localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(session));
+    invalidateOrbSessionCache();
+    notifyOrbSessionChange();
+    return;
   }
+
+  const serialized = JSON.stringify(session);
+  if (existingRaw === serialized) {
+    return;
+  }
+
+  localStorage.setItem(ORB_SESSION_STORAGE_KEY, serialized);
   invalidateOrbSessionCache();
   notifyOrbSessionChange();
 }

--- a/lib/utils/creative-tv-url.test.ts
+++ b/lib/utils/creative-tv-url.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseCreativeTVUrl } from "./creative-tv-url";
+
+describe("parseCreativeTVUrl", () => {
+  const uuid = "550e8400-e29b-41d4-a716-446655440000";
+  const origin = "https://tv.creativeplatform.xyz";
+
+  it("parses absolute discover URLs", () => {
+    expect(parseCreativeTVUrl(`${origin}/discover/${uuid}`, { origin })).toEqual({
+      kind: "discover",
+      assetId: uuid,
+      fallbackUrl: `${origin}/discover/${uuid}`,
+    });
+  });
+
+  it("parses relative discover paths", () => {
+    expect(parseCreativeTVUrl(`/discover/${uuid}`, { origin })).toEqual({
+      kind: "discover",
+      assetId: uuid,
+      fallbackUrl: `${origin}/discover/${uuid}`,
+    });
+  });
+
+  it("parses bare asset UUIDs", () => {
+    expect(parseCreativeTVUrl(uuid, { origin })).toEqual({
+      kind: "discover",
+      assetId: uuid,
+      fallbackUrl: `${origin}/discover/${uuid}`,
+    });
+  });
+
+  it("parses absolute watch URLs", () => {
+    expect(parseCreativeTVUrl(`${origin}/watch/f1abc123xyz`, { origin })).toEqual({
+      kind: "watch",
+      playbackId: "f1abc123xyz",
+      fallbackUrl: `${origin}/watch/f1abc123xyz`,
+    });
+  });
+
+  it("parses relative watch paths", () => {
+    expect(parseCreativeTVUrl("/watch/f1abc123xyz", { origin })).toEqual({
+      kind: "watch",
+      playbackId: "f1abc123xyz",
+      fallbackUrl: `${origin}/watch/f1abc123xyz`,
+    });
+  });
+
+  it("returns invalid for unrelated URLs", () => {
+    expect(parseCreativeTVUrl("https://example.com/video/123", { origin })).toEqual({
+      kind: "invalid",
+      raw: "https://example.com/video/123",
+    });
+  });
+});

--- a/lib/utils/creative-tv-url.ts
+++ b/lib/utils/creative-tv-url.ts
@@ -1,0 +1,75 @@
+/** Livepeer asset UUID used in /discover/{assetId} URLs. */
+export const CREATIVE_TV_ASSET_UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type ParsedCreativeTVUrl =
+  | {
+      kind: "discover";
+      assetId: string;
+      fallbackUrl: string;
+    }
+  | {
+      kind: "watch";
+      playbackId: string;
+      fallbackUrl: string;
+    }
+  | {
+      kind: "invalid";
+      raw: string;
+    };
+
+const DISCOVER_PATH_REGEX =
+  /\/discover\/([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?:[/?#]|$)/i;
+
+const WATCH_PATH_REGEX = /\/watch\/([^/?#]+)(?:[/?#]|$)/i;
+
+function normalizeInput(raw: string): string {
+  return raw.trim();
+}
+
+function toAbsoluteFallbackUrl(pathOrUrl: string, origin?: string): string {
+  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
+    return pathOrUrl;
+  }
+
+  const base =
+    origin ??
+    (typeof window !== "undefined" ? window.location.origin : "https://tv.creativeplatform.xyz");
+
+  return `${base.replace(/\/$/, "")}${pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`}`;
+}
+
+/**
+ * Parse a Creative TV discover or watch URL/path into a structured result.
+ * Accepts absolute URLs, relative paths, or bare UUID / playbackId strings.
+ */
+export function parseCreativeTVUrl(
+  input: string,
+  opts?: { origin?: string },
+): ParsedCreativeTVUrl {
+  const raw = normalizeInput(input);
+  if (!raw) {
+    return { kind: "invalid", raw };
+  }
+
+  const discoverMatch = raw.match(DISCOVER_PATH_REGEX);
+  if (discoverMatch?.[1]) {
+    const assetId = discoverMatch[1];
+    const fallbackUrl = toAbsoluteFallbackUrl(`/discover/${assetId}`, opts?.origin);
+    return { kind: "discover", assetId, fallbackUrl };
+  }
+
+  const watchMatch = raw.match(WATCH_PATH_REGEX);
+  if (watchMatch?.[1]) {
+    const playbackId = watchMatch[1];
+    const fallbackUrl = toAbsoluteFallbackUrl(`/watch/${playbackId}`, opts?.origin);
+    return { kind: "watch", playbackId, fallbackUrl };
+  }
+
+  if (CREATIVE_TV_ASSET_UUID_REGEX.test(raw)) {
+    const fallbackUrl = toAbsoluteFallbackUrl(`/discover/${raw}`, opts?.origin);
+    return { kind: "discover", assetId: raw, fallbackUrl };
+  }
+
+  return { kind: "invalid", raw };
+}

--- a/lib/utils/creative-tv-url.ts
+++ b/lib/utils/creative-tv-url.ts
@@ -73,3 +73,27 @@ export function parseCreativeTVUrl(
 
   return { kind: "invalid", raw };
 }
+
+/** Lightweight iframe-safe embed URL for a discover asset id. */
+export function getCreativeTVEmbedDiscoverUrl(
+  assetId: string,
+  opts?: { origin?: string },
+): string {
+  return toAbsoluteFallbackUrl(`/embed/discover/${assetId}`, opts?.origin);
+}
+
+/**
+ * Embed URL suitable for iframes when resolution falls back to the full discover page.
+ */
+export function getCreativeTVEmbedUrlForParsed(
+  parsed: ParsedCreativeTVUrl,
+  opts?: { origin?: string },
+): string | undefined {
+  if (parsed.kind === "discover") {
+    return getCreativeTVEmbedDiscoverUrl(parsed.assetId, opts);
+  }
+  if (parsed.kind === "watch") {
+    return toAbsoluteFallbackUrl(`/watch/${parsed.playbackId}`, opts?.origin);
+  }
+  return undefined;
+}

--- a/lib/utils/resolve-creative-tv-playback.test.ts
+++ b/lib/utils/resolve-creative-tv-playback.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseCreativeTVUrl } from "@/lib/utils/creative-tv-url";
+import { resolveCreativeTVPlayback } from "@/lib/utils/resolve-creative-tv-playback";
+
+describe("resolveCreativeTVPlayback", () => {
+  const uuid = "550e8400-e29b-41d4-a716-446655440000";
+  const origin = "https://tv.creativeplatform.xyz";
+
+  it("resolves watch URLs without an API call", async () => {
+    const result = await resolveCreativeTVPlayback(`${origin}/watch/abc123`, {
+      siteOrigin: origin,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      playbackId: "abc123",
+      fallbackUrl: `${origin}/watch/abc123`,
+      requiresMetoken: false,
+      resolution: "direct",
+      parsed: parseCreativeTVUrl(`${origin}/watch/abc123`, { origin }),
+    });
+  });
+
+  it("resolves discover URLs via playback API", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        playbackId: "resolved-playback",
+        title: "Resolved",
+        thumbnailUri: "https://example.com/thumb.jpg",
+        requiresMetoken: false,
+        fallbackUrl: `${origin}/discover/${uuid}`,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resolveCreativeTVPlayback(`${origin}/discover/${uuid}`, {
+      siteOrigin: origin,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/video-assets/by-asset-id/${uuid}/playback`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.playbackId).toBe("resolved-playback");
+      expect(result.resolution).toBe("api");
+    }
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/lib/utils/resolve-creative-tv-playback.ts
+++ b/lib/utils/resolve-creative-tv-playback.ts
@@ -1,0 +1,104 @@
+import { parseCreativeTVUrl, type ParsedCreativeTVUrl } from "@/lib/utils/creative-tv-url";
+import {
+  fetchPlaybackByAssetId,
+  type VideoAssetPlaybackResponse,
+} from "@/lib/utils/video-assets-client";
+
+export type { VideoAssetPlaybackResponse as CreativeTVPlaybackResponse };
+
+export type ResolveCreativeTVPlaybackResult =
+  | {
+      ok: true;
+      playbackId: string;
+      title?: string;
+      thumbnailUri?: string;
+      requiresMetoken: boolean;
+      fallbackUrl: string;
+      resolution: "direct" | "api";
+      parsed: ParsedCreativeTVUrl;
+    }
+  | {
+      ok: false;
+      reason: "invalid_url" | "not_found" | "network_error";
+      fallbackUrl?: string;
+      parsed?: ParsedCreativeTVUrl;
+      message?: string;
+    };
+
+export type ResolveCreativeTVPlaybackOptions = {
+  /** API origin for cross-origin resolution (defaults to same-origin). */
+  apiBaseUrl?: string;
+  /** Site origin for fallback URLs when parsing relative paths. */
+  siteOrigin?: string;
+  signal?: AbortSignal;
+};
+
+/**
+ * Resolve a pasted Creative TV discover or watch URL to a Livepeer playbackId.
+ * Watch URLs resolve directly; discover URLs call the playback API.
+ */
+export async function resolveCreativeTVPlayback(
+  input: string,
+  opts?: ResolveCreativeTVPlaybackOptions,
+): Promise<ResolveCreativeTVPlaybackResult> {
+  const parsed = parseCreativeTVUrl(input, { origin: opts?.siteOrigin });
+
+  if (parsed.kind === "invalid") {
+    return { ok: false, reason: "invalid_url", parsed, message: "Unrecognized Creative TV URL" };
+  }
+
+  if (parsed.kind === "watch") {
+    return {
+      ok: true,
+      playbackId: parsed.playbackId,
+      fallbackUrl: parsed.fallbackUrl,
+      requiresMetoken: false,
+      resolution: "direct",
+      parsed,
+    };
+  }
+
+  try {
+    const data = await fetchPlaybackByAssetId(parsed.assetId, {
+      apiBaseUrl: opts?.apiBaseUrl,
+      signal: opts?.signal,
+    });
+
+    if (!data?.playbackId) {
+      return {
+        ok: false,
+        reason: "not_found",
+        fallbackUrl: parsed.fallbackUrl,
+        parsed,
+        message: "Video not found or not published",
+      };
+    }
+
+    return {
+      ok: true,
+      playbackId: data.playbackId,
+      title: data.title,
+      thumbnailUri: data.thumbnailUri,
+      requiresMetoken: Boolean(data.requiresMetoken),
+      fallbackUrl: data.fallbackUrl || parsed.fallbackUrl,
+      resolution: "api",
+      parsed,
+    };
+  } catch (error) {
+    const isAbort =
+      error instanceof DOMException && error.name === "AbortError" ||
+      (error instanceof Error && error.name === "AbortError");
+
+    if (isAbort) {
+      throw error;
+    }
+
+    return {
+      ok: false,
+      reason: "network_error",
+      fallbackUrl: parsed.fallbackUrl,
+      parsed,
+      message: error instanceof Error ? error.message : "Network error",
+    };
+  }
+}

--- a/lib/utils/video-assets-client.ts
+++ b/lib/utils/video-assets-client.ts
@@ -13,6 +13,14 @@ export interface VideoAssetResponse {
   [key: string]: any;
 }
 
+export interface VideoAssetPlaybackResponse {
+  playbackId: string;
+  title?: string;
+  thumbnailUri?: string;
+  requiresMetoken?: boolean;
+  fallbackUrl: string;
+}
+
 /**
  * Fetch video asset by playback ID (client-safe)
  */
@@ -97,6 +105,40 @@ export async function fetchVideoAssetByPlaybackId(
       `[fetchVideoAssetByPlaybackId] Error fetching asset for playbackId ${playbackId}:`,
       error
     );
+    throw error;
+  }
+}
+
+/**
+ * Fetch published playback metadata by Livepeer asset UUID (client-safe, CORS-enabled).
+ */
+export async function fetchPlaybackByAssetId(
+  assetId: string,
+  opts?: { apiBaseUrl?: string; signal?: AbortSignal },
+): Promise<VideoAssetPlaybackResponse | null> {
+  const path = `/api/video-assets/by-asset-id/${encodeURIComponent(assetId)}/playback`;
+  const url = opts?.apiBaseUrl
+    ? `${opts.apiBaseUrl.replace(/\/$/, "")}${path}`
+    : path;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      signal: opts?.signal,
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch playback (${response.status})`);
+    }
+
+    return (await response.json()) as VideoAssetPlaybackResponse;
+  } catch (error) {
+    logger.error(`[fetchPlaybackByAssetId] Error fetching playback for ${assetId}:`, error);
     throw error;
   }
 }

--- a/lib/utils/video-assets-client.ts
+++ b/lib/utils/video-assets-client.ts
@@ -138,6 +138,12 @@ export async function fetchPlaybackByAssetId(
 
     return (await response.json()) as VideoAssetPlaybackResponse;
   } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     logger.error(`[fetchPlaybackByAssetId] Error fetching playback for ${assetId}:`, error);
     throw error;
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-crtv-embed-route", "1");
+  return NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+}
+
+export const config = {
+  matcher: ["/embed/:path*"],
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -344,7 +344,32 @@ const nextConfig = {
     ],
   },
   async headers() {
+    const embedCsp = [
+      "default-src 'self'",
+      "img-src 'self' blob: data: https:",
+      "media-src 'self' blob: data: https:",
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://va.vercel-scripts.com https://vercel.live",
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss: ws:",
+      "frame-src 'self' https:",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors *",
+      "upgrade-insecure-requests",
+    ].join("; ");
+
     return [
+      {
+        source: "/embed/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: embedCsp,
+          },
+        ],
+      },
       {
         // Apply to all routes
         source: '/(.*)',

--- a/scripts/generate-platform-api-key.ts
+++ b/scripts/generate-platform-api-key.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env tsx
+import { randomBytes } from "crypto";
+import { appendFileSync, existsSync } from "fs";
+import path from "path";
+
+type Tier = "admin" | "partner";
+
+function parseArgs(argv: string[]) {
+  let tier: Tier = "partner";
+  let id = "mixtape";
+  let writeEnv = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--tier" && argv[i + 1]) {
+      tier = argv[++i] as Tier;
+    } else if (arg === "--id" && argv[i + 1]) {
+      id = argv[++i];
+    } else if (arg === "--write-env") {
+      writeEnv = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  if (tier === "partner" && !id) {
+    console.error("Error: --id is required for partner keys (e.g. mixtape).");
+    process.exit(1);
+  }
+
+  if (tier !== "admin" && tier !== "partner") {
+    console.error("Error: --tier must be admin or partner.");
+    process.exit(1);
+  }
+
+  return { tier, id, writeEnv };
+}
+
+function printHelp() {
+  console.log(`Usage:
+  pnpm tsx scripts/generate-platform-api-key.ts --tier admin
+  pnpm tsx scripts/generate-platform-api-key.ts --tier partner --id mixtape
+
+Options:
+  --tier admin|partner   Key tier (default: partner)
+  --id <partnerId>       Partner id for partner tier (default: mixtape)
+  --write-env            Append to .env.local (never commit this file)
+`);
+}
+
+function generateSecret(tier: Tier, partnerId?: string): string {
+  const random = randomBytes(32).toString("hex");
+  if (tier === "admin") {
+    return `crtv_admin_${random}`;
+  }
+  return `crtv_pk_${partnerId}_${random}`;
+}
+
+function main() {
+  const { tier, id, writeEnv } = parseArgs(process.argv.slice(2));
+  const secret = generateSecret(tier, tier === "partner" ? id : undefined);
+
+  console.log("\nCreative TV Platform API key generated\n");
+  console.log("⚠️  Save this secret now. It will not be shown again.\n");
+
+  if (tier === "admin") {
+    console.log(`Admin secret:\n  ${secret}\n`);
+    console.log("Add to CRTV Vercel env:");
+    console.log(`  CREATIVE_PLATFORM_ADMIN_API_KEYS=${secret}`);
+    console.log("\nUse in requests:");
+    console.log(`  Authorization: Bearer ${secret}`);
+  } else {
+    const envEntry = `${id}:${secret}`;
+    console.log(`Partner id: ${id}`);
+    console.log(`Partner secret:\n  ${secret}\n`);
+    console.log("Add to CRTV Vercel env (append if multiple partners):");
+    console.log(`  CREATIVE_PLATFORM_PARTNER_API_KEYS=${envEntry}`);
+    console.log(`\nAdd to ${id} app server env (e.g. Mixtape):`);
+    console.log(`  MIXTAPE_CRTV_API_KEY=${secret}`);
+    console.log("\nMixtape server request example:");
+    console.log(`  Authorization: Bearer ${secret}`);
+  }
+
+  if (writeEnv) {
+    const envPath = path.resolve(process.cwd(), ".env.local");
+    if (!existsSync(envPath)) {
+      console.error("\nError: .env.local not found. Create it first or omit --write-env.");
+      process.exit(1);
+    }
+
+    const varName =
+      tier === "admin"
+        ? "CREATIVE_PLATFORM_ADMIN_API_KEYS"
+        : "CREATIVE_PLATFORM_PARTNER_API_KEYS";
+    const line =
+      tier === "admin"
+        ? `${varName}=${secret}\n`
+        : `${varName}=${id}:${secret}\n`;
+
+    appendFileSync(envPath, `\n# Added by generate-platform-api-key.ts\n${line}`, "utf8");
+    console.log(`\nAppended to ${envPath}`);
+  }
+
+  console.log("\nEnable gating:");
+  console.log("  PLATFORM_API_ACCESS_ENABLED=true");
+  console.log("  X402_API_RECIPIENT=0x...  # for paid external/agent access\n");
+}
+
+main();

--- a/supabase/migrations/20260603120000_create_platform_api_payment_receipts.sql
+++ b/supabase/migrations/20260603120000_create_platform_api_payment_receipts.sql
@@ -1,0 +1,12 @@
+-- Track consumed x402 payment transaction hashes to prevent replay within the payment window.
+CREATE TABLE IF NOT EXISTS platform_api_payment_receipts (
+  transaction_hash text PRIMARY KEY,
+  resource text NOT NULL,
+  used_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS platform_api_payment_receipts_used_at_idx
+  ON platform_api_payment_receipts (used_at);
+
+COMMENT ON TABLE platform_api_payment_receipts IS
+  'One row per consumed USDC payment proof for Platform API x402 access.';


### PR DESCRIPTION
## Summary
- Add tiered Platform API access (admin/partner keys, x402 USDC payments) on playback resolve, published catalog, playback-info, and views routes, plus docs and a local API key generator script.
- Add discover/watch URL playback resolution helpers and a reusable embed component for Creative TV links.
- Fix Orb/Lens auth hangs by deduplicating session persistence, timing out sync, resolving QR proxy URLs, and linking profiles asynchronously after QR sign-in.
- Improve mobile Joyride tour with menu-aware steps, responsive tooltip layout, and target-not-found recovery.

## Test plan
- [ ] Run `npx vitest run lib/middleware/platformApiAccess.test.ts lib/sdk/orb/login.test.ts lib/utils/creative-tv-url.test.ts`
- [ ] Generate partner key with `pnpm tsx scripts/generate-platform-api-key.ts --tier partner --id mixtape` and verify gated playback route with `Authorization: Bearer`
- [ ] Confirm Orb QR sign-in completes without hanging and profile link proceeds in background
- [ ] Walk through Joyride on mobile (375px) and desktop; verify menu opens on mobile steps and all steps remain visible


Made with [Cursor](https://cursor.com)