### PR TITLE
Fix react-joyride v3 type error in Tour component

### DIFF
--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -361,7 +361,6 @@ export const Tour = () => {
             disableScrollParentFix={false}
             spotlightPadding={10}
             floaterProps={{
-                disableAnimation: true,
                 styles: {
                     floater: {
                         filter: 'none',
@@ -369,6 +368,9 @@ export const Tour = () => {
                 },
             }}
             styles={{
+                tooltip: {
+                    transition: 'none',
+                },
                 options: {
                     primaryColor: '#4f46e5',
                     zIndex: 10000,


### PR DESCRIPTION
## Summary
- Removes invalid `floaterProps.disableAnimation`, which is not supported on react-joyride v3 `FloaterProps` and was breaking the Vercel TypeScript build.
- Replaces it with `styles.tooltip.transition: 'none'` to preserve the no-animation tooltip behavior for mobile tour stability.
- Keeps `floaterProps.styles.floater.filter: 'none'` for the existing mobile positioning fix.

## Test plan
- [ ] Confirm `yarn build` passes TypeScript on Vercel
- [ ] Verify desktop onboarding tour renders and advances through steps
- [ ] Verify mobile tour tooltip appears without animation jitter


Made with [Cursor](https://cursor.com)