### PR TITLE
Fix CreativeTVUrlEmbed TypeScript build errors

### DIFF
--- a/components/Videos/CreativeTVUrlEmbed.tsx
+++ b/components/Videos/CreativeTVUrlEmbed.tsx
@@ -43,11 +43,12 @@ export function CreativeTVUrlEmbed({
       return;
     }
 
+    const playbackId = state.result.playbackId;
     let cancelled = false;
 
     async function loadSources() {
       try {
-        const sources = await getDetailPlaybackSource(state.result.playbackId);
+        const sources = await getDetailPlaybackSource(playbackId);
         if (!cancelled) {
           setPlaybackSources(sources);
           if (!sources?.length) {
@@ -179,9 +180,11 @@ export function CreativeTVUrlEmbed({
           </div>
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <ExternalLink className="h-4 w-4" />
-            <Link href={fallbackUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
-              Open on Creative TV
-            </Link>
+            {fallbackUrl ? (
+              <Link href={fallbackUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                Open on Creative TV
+              </Link>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/components/Videos/CreativeTVUrlEmbed.tsx
+++ b/components/Videos/CreativeTVUrlEmbed.tsx
@@ -44,29 +44,30 @@ export function CreativeTVUrlEmbed({
     }
 
     const playbackId = state.result.playbackId;
-    let cancelled = false;
+    const controller = new AbortController();
 
     async function loadSources() {
       try {
-        const sources = await getDetailPlaybackSource(playbackId);
-        if (!cancelled) {
-          setPlaybackSources(sources);
-          if (!sources?.length) {
-            setPlayerError("Unable to load playback sources.");
-          }
-        }
-      } catch (error) {
-        if (!cancelled) {
-          logger.error("[CreativeTVUrlEmbed] Failed to load playback sources:", error);
+        const sources = await getDetailPlaybackSource(playbackId, {
+          signal: controller.signal,
+        });
+        setPlaybackSources(sources);
+        if (!sources?.length) {
           setPlayerError("Unable to load playback sources.");
         }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        logger.error("[CreativeTVUrlEmbed] Failed to load playback sources:", error);
+        setPlayerError("Unable to load playback sources.");
       }
     }
 
     void loadSources();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [state]);
 
@@ -178,14 +179,14 @@ export function CreativeTVUrlEmbed({
               loading="lazy"
             />
           </div>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <ExternalLink className="h-4 w-4" />
-            {fallbackUrl ? (
+          {fallbackUrl ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <ExternalLink className="h-4 w-4" />
               <Link href={fallbackUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
                 Open on Creative TV
               </Link>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary
- Capture `playbackId` after the `"resolved"` state guard so TypeScript narrows correctly inside the async `loadSources()` closure
- Guard the fallback "Open on Creative TV" link so `href` is only rendered when `fallbackUrl` is defined

Fixes the Vercel production build failure:
```
Property 'result' does not exist on type 'CreativeTVUrlResolveState'
```

## Test plan
- [ ] Run `npx tsc --noEmit` and confirm no errors in `components/Videos/CreativeTVUrlEmbed.tsx`
- [ ] Run `yarn run build` on Vercel / locally and confirm the TypeScript step passes
- [ ] Paste a Creative TV discover/watch URL in the embed component and verify playback loads


Made with [Cursor](https://cursor.com)