### PR TITLE
Fix production video playback blocked by Platform API gating

### DIFF
--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
-import { LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
+import { isLivepeerConfigured, LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
 import {
   platformApiOptionsResponse,
@@ -20,9 +20,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    if (!process.env.LIVEPEER_FULL_API_KEY?.trim()) {
+    if (!isLivepeerConfigured()) {
       return NextResponse.json(
-        { error: 'Livepeer playback is not configured on this deployment' },
+        { error: 'Livepeer playback is not configured on this deployment', code: LIVEPEER_NOT_CONFIGURED },
         { status: 503 },
       );
     }

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, forwardRef, useMemo } from "react";
+import React, { useState, useEffect, forwardRef, useMemo, useCallback } from "react";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -168,6 +168,8 @@ export default function VideoDetails({
   tokenId,
 }: VideoDetailsProps) {
   const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
+  const [sourcesLoading, setSourcesLoading] = useState(true);
+  const [sourcesError, setSourcesError] = useState<string | null>(null);
   const [conditionalProps, setConditionalProps] = useState<any>({});
   const [dbStatus, setDbStatus] = useState<"draft" | "published" | "minted" | "archived" | null>(null);
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
@@ -177,11 +179,35 @@ export default function VideoDetails({
   const { openAuthModal } = useAuthModal();
   const isConnected = !!user;
 
+  const loadPlaybackSources = useCallback(async () => {
+    if (!asset?.playbackId) {
+      setSourcesLoading(false);
+      setSourcesError("No playback ID available.");
+      setPlaybackSources(null);
+      return;
+    }
+
+    setSourcesLoading(true);
+    setSourcesError(null);
+    setPlaybackSources(null);
+
+    try {
+      const sources = await getDetailPlaybackSource(asset.playbackId);
+      if (!sources?.length) {
+        setSourcesError("Unable to load playback sources.");
+        setPlaybackSources(null);
+      } else {
+        setPlaybackSources(sources);
+      }
+    } catch {
+      setSourcesError("Unable to load playback sources.");
+      setPlaybackSources(null);
+    } finally {
+      setSourcesLoading(false);
+    }
+  }, [asset?.playbackId]);
+
   useEffect(() => {
-    const fetchPlaybackSources = async () => {
-      const sources = await getDetailPlaybackSource(asset?.playbackId || "");
-      setPlaybackSources(sources);
-    };
     const fetchDbStatus = async () => {
       try {
         if (!asset?.playbackId) return;
@@ -227,7 +253,7 @@ export default function VideoDetails({
         setThumbnailUrl("/Creative_TV.png");
       }
     };
-    fetchPlaybackSources();
+    void loadPlaybackSources();
     fetchDbStatus();
     // Wrap in try-catch to prevent unhandled promise rejection
     fetchThumbnail().catch(() => {
@@ -249,7 +275,7 @@ export default function VideoDetails({
         return prev;
       return conProps;
     });
-  }, [account, asset]);
+  }, [account, asset, loadPlaybackSources]);
 
   const Seek = forwardRef<HTMLButtonElement, Player.SeekProps>(
     ({ children, ...props }, forwardedRef) => (
@@ -550,6 +576,16 @@ export default function VideoDetails({
                   </Button>
                 </div>
               </div>
+            </div>
+          ) : sourcesLoading ? (
+            <Skeleton className="h-96 w-full" />
+          ) : sourcesError ? (
+            <div className="relative flex aspect-video w-full flex-col items-center justify-center gap-4 overflow-hidden rounded-lg bg-gray-800 p-8 text-center">
+              <p className="text-lg font-medium text-white">Failed to load video</p>
+              <p className="text-sm text-gray-300">{sourcesError}</p>
+              <Button type="button" variant="outline" onClick={() => void loadPlaybackSources()}>
+                Retry
+              </Button>
             </div>
           ) : playbackSources ? (
             <>

--- a/lib/middleware/platformApiAccess.test.ts
+++ b/lib/middleware/platformApiAccess.test.ts
@@ -120,4 +120,60 @@ describe("requirePlatformApiAccess", () => {
       expect(result.tier).toBe("public");
     }
   });
+
+  it("allows same-origin requests without auth when gating is enabled", async () => {
+    const request = new NextRequest("http://localhost/api/livepeer/playback-info", {
+      headers: { "Sec-Fetch-Site": "same-origin" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.info" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("public");
+    }
+  });
+
+  it("allows same-site requests without auth when gating is enabled", async () => {
+    const request = new NextRequest("http://localhost/api/livepeer/playback-info", {
+      headers: { "Sec-Fetch-Site": "same-site" },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.info" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("public");
+    }
+  });
+
+  it("returns 402 for cross-site requests without auth", async () => {
+    const request = new NextRequest("http://localhost/api/livepeer/playback-info", {
+      headers: {
+        "Sec-Fetch-Site": "cross-site",
+        Origin: "https://evil.example.com",
+      },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.info" });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.response.status).toBe(402);
+    }
+  });
+
+  it("allows partner API key on cross-origin requests", async () => {
+    const request = new NextRequest("https://tv.creativeplatform.xyz/api/video-assets/by-asset-id/uuid/playback", {
+      headers: {
+        Authorization: "Bearer crtv_pk_mixtape_test",
+        Origin: "https://air.creativeplatform.xyz",
+        "Sec-Fetch-Site": "cross-site",
+      },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("partner");
+      expect(result.keyId).toBe("mixtape");
+    }
+  });
 });

--- a/lib/middleware/platformApiAccess.ts
+++ b/lib/middleware/platformApiAccess.ts
@@ -33,11 +33,63 @@ function unauthorizedResponse(message: string): NextResponse {
   );
 }
 
+function getConfiguredSiteOrigins(): string[] {
+  const origins: string[] = [];
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (siteUrl) {
+    try {
+      origins.push(new URL(siteUrl).origin);
+    } catch {
+      // ignore invalid URL
+    }
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    origins.push("https://tv.creativeplatform.xyz");
+  } else {
+    origins.push("http://localhost:3000");
+  }
+
+  return [...new Set(origins)];
+}
+
+/** Allow first-party Creative TV browser traffic without Platform API credentials. */
+export function isSameOriginAppRequest(request: NextRequest): boolean {
+  const fetchSite = request.headers.get("sec-fetch-site");
+  if (fetchSite === "same-origin" || fetchSite === "same-site") {
+    return true;
+  }
+
+  const allowedOrigins = getConfiguredSiteOrigins();
+  const origin = request.headers.get("origin");
+  if (origin && allowedOrigins.includes(origin)) {
+    return true;
+  }
+
+  const referer = request.headers.get("referer");
+  if (referer) {
+    try {
+      const refererOrigin = new URL(referer).origin;
+      if (allowedOrigins.includes(refererOrigin)) {
+        return true;
+      }
+    } catch {
+      // ignore invalid referer
+    }
+  }
+
+  return false;
+}
+
 export async function requirePlatformApiAccess(
   request: NextRequest,
   options: PlatformApiAccessOptions,
 ): Promise<PlatformApiAccessResult> {
   if (!isPlatformApiAccessConfigured()) {
+    return { allowed: true, tier: "public" };
+  }
+
+  if (isSameOriginAppRequest(request)) {
     return { allowed: true, tier: "public" };
   }
 


### PR DESCRIPTION
## Summary
- Exempt same-origin Creative TV browser requests from Platform API x402/key gating so in-app playback routes (`/api/livepeer/playback-info`, published videos, view metrics) work again in production.
- Use `isLivepeerConfigured()` in playback-info so deployments with only `LIVEPEER_API_KEY` still serve playback.
- Show explicit retryable playback errors in Discover `VideoDetails` instead of an infinite skeleton.

## Test plan
- [ ] `pnpm test lib/middleware/platformApiAccess.test.ts`
- [ ] After deploy: Discover, Watch, and home video grids load in production
- [ ] DevTools: same-origin `/api/livepeer/playback-info` returns 200 (not 402)
- [ ] Cross-origin requests without auth still return 402; partner Bearer keys still work


Made with [Cursor](https://cursor.com)