### PR TITLE
Harden Platform API bypass and fix account menu wallet display

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,7 +16,6 @@ import {
   useLogout,
   useUser,
   useChain,
-  useSmartAccountClient,
 } from "@account-kit/react";
 import ThemeToggleComponent from "./ThemeToggle/toggleComponent";
 import { toast } from "sonner";
@@ -39,7 +38,7 @@ import {
   TrendingUp,
 } from "lucide-react";
 import type { User as AccountUser } from "@account-kit/signer";
-import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
+import { useSmartWalletDisplayAddress } from "@/lib/hooks/accountkit/useSmartWalletDisplayAddress";
 import { base } from "@account-kit/infra";
 import { TokenBalance } from "./wallet/balance/TokenBalance";
 import { MeTokenBalances } from "./wallet/balance/MeTokenBalances";
@@ -105,14 +104,6 @@ const mobileMemberNavLinkClass = `
   text-[#EC406A]
 `;
 
-// Simplified truncateAddress - ENS resolution disabled to prevent webpack chunk loading errors
-const truncateAddress = (address: string) => {
-  if (!address) return "";
-  // Simply truncate the address without ENS resolution
-  // This prevents webpack chunk loading issues with CCIP utilities
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-};
-
 // Add this near the top with other utility functions
 const getChainGradient = (chain: ViemChain) => {
   switch (chain.id) {
@@ -168,9 +159,13 @@ export default function Navbar() {
   const unifiedLogout = useUnifiedLogout();
   const { logout: orbLogout } = useOrbSession();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
-  const { account: modularAccount } = useModularAccount();
-  const [displayAddress, setDisplayAddress] = useState<string>("");
-  const { client: smartAccountClient } = useSmartAccountClient({});
+  const {
+    primaryAddress,
+    signerAddress,
+    displayAddress,
+    walletLabel,
+    client: smartAccountClient,
+  } = useSmartWalletDisplayAddress();
   const [isNetworkConnected, setIsNetworkConnected] = useState(true);
   const { isVerified, hasMembership } = useMembershipVerification();
 
@@ -179,18 +174,6 @@ export default function Navbar() {
   const { holdings, loading: holdingsLoading } = useMeTokenHoldings();
   const hasMetokens = !!userMeToken || holdings.length > 0;
   const shouldShowMetokens = hasMetokens || meTokenLoading || holdingsLoading;
-
-  // Update display address when user changes
-  useEffect(() => {
-    // Smart Wallet is the primary public identity for Creative TV
-    // EOA is kept in background for signing and permissions
-    const addressToDisplay = modularAccount?.address || user?.address;
-
-    if (addressToDisplay) {
-      const resolved = truncateAddress(addressToDisplay);
-      setDisplayAddress(resolved);
-    }
-  }, [modularAccount?.address, user?.address]);
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const accountDropdownRef = useRef<AccountDropdownHandle>(null);
@@ -262,8 +245,7 @@ export default function Navbar() {
   };
 
   const copyToClipboard = async () => {
-    // Prioritize Smart Account address, fallback to EOA
-    const addressToCopy = modularAccount?.address || user?.address;
+    const addressToCopy = primaryAddress;
 
     if (addressToCopy) {
       try {
@@ -298,8 +280,6 @@ export default function Navbar() {
     ? "shadow-md bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm"
     : "bg-white dark:bg-gray-900"
     }`;
-
-  const smartAccountAddress = modularAccount?.address;
 
   return (
     <header className={headerClassName}>
@@ -397,23 +377,20 @@ export default function Navbar() {
                       <div className="flex items-center space-x-2">
                         <Avatar className="h-8 w-8">
                           <AvatarImage
-                            src={makeBlockie(modularAccount?.address || user?.address || "0x")}
+                            src={makeBlockie(primaryAddress || user?.address || "0x")}
                             alt="Wallet avatar"
                           />
                         </Avatar>
                         <div>
                           <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {user?.type === "sca" ? "Smart Wallet" : "EOA"}
+                            {walletLabel}
                           </p>
                           <p className="text-sm font-medium font-mono">
-                            {displayAddress}
+                            {displayAddress || "Loading..."}
                           </p>
-                          {user?.address &&
-                            smartAccountAddress &&
-                            user.address.toLowerCase() !==
-                              smartAccountAddress.toLowerCase() && (
+                          {signerAddress && (
                               <p className="text-xs text-gray-500 dark:text-gray-400">
-                                Signer: {shortenAddress(user.address)}
+                                Signer: {shortenAddress(signerAddress)}
                               </p>
                             )}
                           <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -512,14 +489,14 @@ export default function Navbar() {
                         Options
                       </div>
                       <Link
-                        href={`/profile/${smartAccountAddress || user?.address}`}
+                        href={`/profile/${primaryAddress ?? ""}`}
                         className={mobileMemberNavLinkClass}
                         onClick={handleLinkClick}
                       >
                         <ShieldUser className="mr-2 h-4 w-4" /> Profile
                       </Link>
                       <Link
-                        href={`/upload/${smartAccountAddress || user?.address}`}
+                        href={`/upload/${primaryAddress ?? ""}`}
                         className={mobileMemberNavLinkClass}
                         onClick={handleLinkClick}
                         id="nav-upload-link"

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -33,7 +33,6 @@ import {
   useAuthModal,
   useUser,
   useChain,
-  useSmartAccountClient,
   useSendUserOperation,
 } from "@account-kit/react";
 import { useUnifiedLogout } from "@/hooks/useUnifiedLogout";
@@ -85,7 +84,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import CoinbaseFundButton from "@/components/wallet/buy/coinbase-fund-button";
 import { LoginButton } from "@/components/auth/LoginButton";
 import { AlchemySwapWidget } from "@/components/wallet/swap/AlchemySwapWidget";
-import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
+import { useSmartWalletDisplayAddress } from "@/lib/hooks/accountkit/useSmartWalletDisplayAddress";
 import { TokenBalance } from "@/components/wallet/balance/TokenBalance";
 import { MeTokenBalances } from "@/components/wallet/balance/MeTokenBalances";
 import makeBlockie from "ethereum-blockies-base64";
@@ -276,7 +275,15 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
   const user = useUser();
   const unifiedLogout = useUnifiedLogout();
   const { chain, setChain, isSettingChain } = useChain();
-  const [displayAddress, setDisplayAddress] = useState<string>("");
+  const {
+    primaryAddress,
+    smartAccountAddress,
+    signerAddress,
+    displayAddress,
+    walletLabel,
+    client,
+    account,
+  } = useSmartWalletDisplayAddress();
   const [isNetworkConnected, setIsNetworkConnected] = useState(true);
   const [copySuccess, setCopySuccess] = useState(false);
   const [isArrowUp, setIsArrowUp] = useState(true);
@@ -317,8 +324,6 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
     },
   });
 
-  const { account, address: smartAccountAddress } = useModularAccount();
-  const { client } = useSmartAccountClient({});
   const validationClient = chain
     ? (client?.extend(installValidationActions as any) as any)
     : undefined;
@@ -337,23 +342,9 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
     logger.debug('Account state:', {
       "EOA Address (user.address)": user?.address,
       "Smart Contract Account Address": smartAccountAddress,
+      "Primary display address": primaryAddress,
     });
-  }, [smartAccountAddress, user]);
-
-  useEffect(() => {
-    let newDisplayAddress = "";
-    // Smart Wallet is the primary public identity for Creative TV
-    // EOA is kept in background for signing and permissions
-    if (smartAccountAddress) {
-      newDisplayAddress = `${smartAccountAddress.slice(0, 6)}...${smartAccountAddress.slice(-4)}`;
-    } else if (user?.address) {
-      // Fallback to EOA only if Smart Wallet is not available
-      newDisplayAddress = `${user.address.slice(0, 6)}...${user.address.slice(-4)}`;
-    }
-    // Only update if value actually changes
-    if (displayAddress !== newDisplayAddress)
-      setDisplayAddress(newDisplayAddress);
-  }, [user, smartAccountAddress, displayAddress]);
+  }, [smartAccountAddress, primaryAddress, user]);
 
   useEffect(() => {
     const checkNetworkStatus = async () => {
@@ -435,9 +426,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
   }, [client, smartAccountAddress, dialogAction, isDialogOpen, chain?.id]);
 
   const copyToClipboard = async () => {
-    // Copy Smart Wallet address as primary identity
-    // EOA is kept in background for signing operations
-    const addressToCopy = smartAccountAddress || user?.address;
+    const addressToCopy = primaryAddress;
     if (addressToCopy) {
       try {
         await navigator.clipboard.writeText(addressToCopy);
@@ -1324,7 +1313,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
           >
             <Avatar className="h-8 w-8">
               <AvatarImage
-                src={makeBlockie(smartAccountAddress || user?.address || "0x")}
+                src={makeBlockie(primaryAddress || user?.address || "0x")}
                 alt="Wallet avatar"
               />
             </Avatar>
@@ -1334,7 +1323,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
           </Button>
         }
       >
-        <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen} modal={false}>
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
@@ -1343,7 +1332,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
             >
               <Avatar className="h-8 w-8">
                 <AvatarImage
-                  src={makeBlockie(smartAccountAddress || user?.address || "0x")}
+                  src={makeBlockie(primaryAddress || user?.address || "0x")}
                   alt="Wallet avatar"
                 />
               </Avatar>
@@ -1352,10 +1341,8 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               </span>
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-[320px] md:w-80 max-h-[80vh] overflow-y-auto"
-            align="end"
-          >
+          <DropdownMenuContent className="w-[320px] md:w-80 p-0" align="end">
+            <div className="max-h-[min(80vh,32rem)] overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] p-1">
             <DropdownMenuLabel className="font-normal">
               <div
                 className={`flex items-center justify-between cursor-pointer 
@@ -1364,12 +1351,12 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               >
                 <div className="flex flex-col space-y-1">
                   <p className="text-xs text-gray-500">
-                    {smartAccountAddress ? "Smart Wallet" : user?.address ? "EOA" : "Not Connected"}
+                    {walletLabel}
                   </p>
-                  <p className="font-mono text-sm">{displayAddress}</p>
-                  {user?.address && smartAccountAddress && user.address.toLowerCase() !== smartAccountAddress.toLowerCase() && (
+                  <p className="font-mono text-sm">{displayAddress || "Loading..."}</p>
+                  {signerAddress && (
                     <p className="text-xs text-gray-500">
-                      Signer (EOA): {shortenAddress(user.address)}
+                      Signer (EOA): {shortenAddress(signerAddress)}
                     </p>
                   )}
                 </div>
@@ -1404,7 +1391,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                       className="flex-1 text-xs"
                       disabled={isOrbLinking}
                       onClick={() =>
-                        linkProfile(smartAccountAddress || user?.address)
+                        linkProfile(primaryAddress)
                       }
                     >
                       {isOrbLinking ? "Linking…" : "Sync profile"}
@@ -1451,7 +1438,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                   }
                   onClick={() => setIsDropdownOpen(false)}
                 >
-                  <Link href={`/profile/${smartAccountAddress || user?.address}`}>
+                  <Link href={`/profile/${primaryAddress ?? ""}`}>
                     <ShieldUser className="h-3 w-3 mb-1" />
                     <span className="text-xs">Profile</span>
                   </Link>
@@ -1465,7 +1452,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                   }
                   onClick={() => setIsDropdownOpen(false)}
                 >
-                  <Link href={`/upload/${smartAccountAddress || user?.address}`} id="nav-upload-link">
+                  <Link href={`/upload/${primaryAddress ?? ""}`} id="nav-upload-link">
                     <CloudUpload className="h-3 w-3 mb-1" />
                     <span className="text-xs">Upload</span>
                   </Link>
@@ -1690,6 +1677,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                 <LogOut className="mr-2 h-4 w-4" />
                 <span className="text-sm">Logout</span>
               </DropdownMenuItem>
+            </div>
             </div>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/docs/platform-api.md
+++ b/docs/platform-api.md
@@ -23,6 +23,8 @@ GET https://tv.creativeplatform.xyz/api/video-assets/by-asset-id/{uuid}/playback
 
 Gating is active when `PLATFORM_API_ACCESS_ENABLED=true`, or when admin/partner keys or `X402_API_RECIPIENT` are configured. Set `PLATFORM_API_ACCESS_ENABLED=false` to disable gating in local dev.
 
+Same-origin browser traffic from the Creative TV web app (`Sec-Fetch-Site: same-origin` or `same-site`) is exempt from x402/key checks so in-app playback works. External cross-origin callers still require partner/admin keys or x402 payment. Same-origin requests are rate-limited per IP.
+
 ## Generate API keys (local only)
 
 ```bash

--- a/lib/hooks/accountkit/useSmartWalletDisplayAddress.ts
+++ b/lib/hooks/accountkit/useSmartWalletDisplayAddress.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import { useUser } from "@account-kit/react";
+import useModularAccount from "./useModularAccount";
+import { shortenAddress } from "@/lib/utils/utils";
+
+/**
+ * Resolves the public wallet identity for UI: smart account first, EOA only for pure EOA users.
+ * Avoids briefly showing the signer address while the modular account client is still loading.
+ */
+export function useSmartWalletDisplayAddress() {
+  const user = useUser();
+  const {
+    address: smartAccountAddress,
+    smartAccountClient: client,
+    account,
+    loading: isSmartAccountLoading,
+  } = useModularAccount();
+
+  const primaryAddress = useMemo(() => {
+    if (smartAccountAddress) return smartAccountAddress;
+    if (user?.type === "eoa" && user.address) return user.address;
+    return undefined;
+  }, [smartAccountAddress, user?.type, user?.address]);
+
+  const signerAddress = useMemo(() => {
+    if (!user?.address || !primaryAddress) return undefined;
+    if (user.address.toLowerCase() === primaryAddress.toLowerCase()) return undefined;
+    return user.address;
+  }, [user?.address, primaryAddress]);
+
+  const displayAddress = useMemo(() => {
+    if (primaryAddress) return shortenAddress(primaryAddress);
+    if (isSmartAccountLoading && user?.type === "sca") return "Loading...";
+    return "";
+  }, [primaryAddress, isSmartAccountLoading, user?.type]);
+
+  const walletLabel =
+    smartAccountAddress || user?.type === "sca"
+      ? "Smart Wallet"
+      : user?.address
+        ? "EOA"
+        : "Not Connected";
+
+  return {
+    primaryAddress,
+    smartAccountAddress,
+    signerAddress,
+    displayAddress,
+    walletLabel,
+    isSmartAccountLoading,
+    client,
+    account,
+    user,
+  };
+}

--- a/lib/middleware/platformApiAccess.test.ts
+++ b/lib/middleware/platformApiAccess.test.ts
@@ -6,6 +6,7 @@ const mockVerifyX402PaymentFromRequest = vi.fn();
 vi.mock("@/lib/middleware/rateLimit", () => ({
   rateLimiters: {
     apiKey: vi.fn(async () => null),
+    generous: vi.fn(async () => null),
   },
 }));
 
@@ -170,6 +171,22 @@ describe("requirePlatformApiAccess", () => {
     });
 
     const result = await requirePlatformApiAccess(request, { resource: "playback.resolve" });
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.tier).toBe("partner");
+      expect(result.keyId).toBe("mixtape");
+    }
+  });
+
+  it("prefers partner API key over same-origin bypass", async () => {
+    const request = new NextRequest("http://localhost/api/livepeer/playback-info", {
+      headers: {
+        Authorization: "Bearer crtv_pk_mixtape_test",
+        "Sec-Fetch-Site": "same-origin",
+      },
+    });
+
+    const result = await requirePlatformApiAccess(request, { resource: "playback.info" });
     expect(result.allowed).toBe(true);
     if (result.allowed) {
       expect(result.tier).toBe("partner");

--- a/lib/middleware/platformApiAccess.ts
+++ b/lib/middleware/platformApiAccess.ts
@@ -33,52 +33,33 @@ function unauthorizedResponse(message: string): NextResponse {
   );
 }
 
-function getConfiguredSiteOrigins(): string[] {
-  const origins: string[] = [];
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
-  if (siteUrl) {
-    try {
-      origins.push(new URL(siteUrl).origin);
-    } catch {
-      // ignore invalid URL
-    }
+function mergePlatformApiHeaders(response: NextResponse): NextResponse {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(PLATFORM_API_CORS_HEADERS)) {
+    headers.set(key, value);
   }
-
-  if (process.env.NODE_ENV === "production") {
-    origins.push("https://tv.creativeplatform.xyz");
-  } else {
-    origins.push("http://localhost:3000");
-  }
-
-  return [...new Set(origins)];
+  return new NextResponse(response.body, { status: response.status, headers });
 }
 
 /** Allow first-party Creative TV browser traffic without Platform API credentials. */
 export function isSameOriginAppRequest(request: NextRequest): boolean {
   const fetchSite = request.headers.get("sec-fetch-site");
-  if (fetchSite === "same-origin" || fetchSite === "same-site") {
-    return true;
+  return fetchSite === "same-origin" || fetchSite === "same-site";
+}
+
+async function tryAllowSameOriginAppRequest(
+  request: NextRequest,
+): Promise<PlatformApiAccessResult | null> {
+  if (!isSameOriginAppRequest(request)) {
+    return null;
   }
 
-  const allowedOrigins = getConfiguredSiteOrigins();
-  const origin = request.headers.get("origin");
-  if (origin && allowedOrigins.includes(origin)) {
-    return true;
+  const rl = await rateLimiters.generous(request);
+  if (rl) {
+    return { allowed: false, response: mergePlatformApiHeaders(rl) };
   }
 
-  const referer = request.headers.get("referer");
-  if (referer) {
-    try {
-      const refererOrigin = new URL(referer).origin;
-      if (allowedOrigins.includes(refererOrigin)) {
-        return true;
-      }
-    } catch {
-      // ignore invalid referer
-    }
-  }
-
-  return false;
+  return { allowed: true, tier: "public" };
 }
 
 export async function requirePlatformApiAccess(
@@ -86,10 +67,6 @@ export async function requirePlatformApiAccess(
   options: PlatformApiAccessOptions,
 ): Promise<PlatformApiAccessResult> {
   if (!isPlatformApiAccessConfigured()) {
-    return { allowed: true, tier: "public" };
-  }
-
-  if (isSameOriginAppRequest(request)) {
     return { allowed: true, tier: "public" };
   }
 
@@ -102,13 +79,9 @@ export async function requirePlatformApiAccess(
       if (match.tier === "partner") {
         const rl = await rateLimiters.apiKey(request, match.keyId ?? "partner");
         if (rl) {
-          const headers = new Headers(rl.headers);
-          for (const [key, value] of Object.entries(PLATFORM_API_CORS_HEADERS)) {
-            headers.set(key, value);
-          }
           return {
             allowed: false,
-            response: new NextResponse(rl.body, { status: rl.status, headers }),
+            response: mergePlatformApiHeaders(rl),
           };
         }
       }
@@ -123,6 +96,11 @@ export async function requirePlatformApiAccess(
     }
 
     return { allowed: false, response: unauthorizedResponse("Invalid API key") };
+  }
+
+  const sameOriginResult = await tryAllowSameOriginAppRequest(request);
+  if (sameOriginResult) {
+    return sameOriginResult;
   }
 
   const recipient = getX402Recipient();


### PR DESCRIPTION
## Summary
- Check Bearer partner/admin keys before same-origin bypass so external keys keep rate limiting and tier attribution.
- Rate-limit same-origin public-tier requests and restrict bypass to `Sec-Fetch-Site` only (no spoofable Origin/Referer).
- Fix account menu showing signer address instead of smart wallet while the modular account client loads.
- Fix mobile account dropdown scrolling with an inner touch-scroll container and `modal={false}`.

## Test plan
- [ ] `pnpm test lib/middleware/platformApiAccess.test.ts`
- [ ] Mobile: account dropdown scrolls through all menu items
- [ ] Connected smart wallet shows smart account address as primary; signer shown separately when different
- [ ] Cross-origin requests without auth still return 402; partner Bearer keys still work


Made with [Cursor](https://cursor.com)