### PR TITLE
Fix mobile hamburger menu scroll

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -184,6 +184,27 @@ export default function Navbar() {
     window.addEventListener('crtv:open-mobile-menu', openMobileMenu);
     return () => window.removeEventListener('crtv:open-mobile-menu', openMobileMenu);
   }, []);
+
+  // Trap scroll inside the mobile menu panel (prevent background page scroll on touch)
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const html = document.documentElement;
+    const body = document.body;
+    const prevHtmlOverflow = html.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyTouchAction = body.style.touchAction;
+
+    html.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+    body.style.touchAction = "none";
+
+    return () => {
+      html.style.overflow = prevHtmlOverflow;
+      body.style.overflow = prevBodyOverflow;
+      body.style.touchAction = prevBodyTouchAction;
+    };
+  }, [isMenuOpen]);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
   const [isScrolled, setIsScrolled] = useState(false);
 
@@ -352,20 +373,26 @@ export default function Navbar() {
               <AnimatedMenuIcon isOpen={isMenuOpen} />
             </Button>
           </div>
+        </div>
+      </div>
 
-          {/* Mobile menu */}
-          <div
-            className={
-              "fixed inset-0 top-16 z-50 grid h-[calc(100vh-4rem)] grid-flow-row " +
-              "auto-rows-max overflow-auto p-4 pb-32 shadow-md md:hidden bg-white dark:bg-gray-900 " +
-              (isMenuOpen ? "animate-in slide-in-from-top-5" : "hidden")
-            }
-            aria-hidden={!isMenuOpen}
-            inert={!isMenuOpen}
-          >
+      {/* Mobile menu — sibling to header bar so fixed positioning and scroll work on touch devices */}
+      <div
+        id="mobile-nav-menu"
+        className={
+          "fixed inset-x-0 top-16 bottom-0 z-50 flex flex-col overflow-hidden md:hidden bg-white dark:bg-gray-900 shadow-md " +
+          (isMenuOpen ? "animate-in slide-in-from-top-5" : "hidden")
+        }
+        aria-hidden={!isMenuOpen}
+        inert={!isMenuOpen}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Main menu"
+      >
+        <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] p-4 pb-32">
             <div
               className={
-                "relative z-20 grid gap-4 rounded-md " +
+                "relative grid gap-4 rounded-md " +
                 "text-popover-foreground"
               }
             >
@@ -668,8 +695,6 @@ export default function Navbar() {
               {/* Navigation Links */}
 
             </div>
-          </div>
-
         </div>
       </div>
     </header>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -104,6 +104,9 @@ const mobileMemberNavLinkClass = `
   text-[#EC406A]
 `;
 
+/** Matches Tailwind `md` — mobile nav is hidden at 768px and above */
+const MOBILE_NAV_MEDIA_QUERY = "(max-width: 767px)";
+
 // Add this near the top with other utility functions
 const getChainGradient = (chain: ViemChain) => {
   switch (chain.id) {
@@ -185,9 +188,22 @@ export default function Navbar() {
     return () => window.removeEventListener('crtv:open-mobile-menu', openMobileMenu);
   }, []);
 
+  // Close menu when viewport grows past mobile (e.g. rotate tablet) so scroll lock cannot stick
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_NAV_MEDIA_QUERY);
+    const handleChange = () => {
+      if (!mq.matches) setIsMenuOpen(false);
+    };
+    mq.addEventListener("change", handleChange);
+    return () => mq.removeEventListener("change", handleChange);
+  }, []);
+
   // Trap scroll inside the mobile menu panel (prevent background page scroll on touch)
   useEffect(() => {
     if (!isMenuOpen) return;
+
+    const mq = window.matchMedia(MOBILE_NAV_MEDIA_QUERY);
+    if (!mq.matches) return;
 
     const html = document.documentElement;
     const body = document.body;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,7 @@
 // components/Navbar.tsx
 "use client";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import Image from "next/image";
 import { useState, useEffect, useRef } from "react";
 import {
@@ -179,6 +180,7 @@ export default function Navbar() {
   const shouldShowMetokens = hasMetokens || meTokenLoading || holdingsLoading;
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
   const accountDropdownRef = useRef<AccountDropdownHandle>(null);
   const [copySuccess, setCopySuccess] = useState(false);
 
@@ -209,18 +211,20 @@ export default function Navbar() {
     const body = document.body;
     const prevHtmlOverflow = html.style.overflow;
     const prevBodyOverflow = body.style.overflow;
-    const prevBodyTouchAction = body.style.touchAction;
 
     html.style.overflow = "hidden";
     body.style.overflow = "hidden";
-    body.style.touchAction = "none";
 
     return () => {
       html.style.overflow = prevHtmlOverflow;
       body.style.overflow = prevBodyOverflow;
-      body.style.touchAction = prevBodyTouchAction;
     };
   }, [isMenuOpen]);
+
+  // Close menu on navigation (e.g. logo link has no explicit close handler)
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
   const [currentChainName, setCurrentChainName] = useState(currentChain.name);
   const [isScrolled, setIsScrolled] = useState(false);
 


### PR DESCRIPTION
## Summary
- Move the mobile navigation panel outside the compact header row so fixed positioning and touch scrolling work correctly.
- Add an inner scroll container (`flex-1 min-h-0 overflow-y-auto`) so menu items scroll inside the panel instead of the page behind it.
- Lock document scroll while the hamburger menu is open.

## Context
PR #158 fixed the account dropdown (Radix) scroll and smart wallet address display. This targets the separate mobile hamburger menu in `Navbar.tsx`, which was still passing touch scroll through to the background.

## Test plan
- [ ] On mobile, open the hamburger menu and scroll through Profile, Upload, membership, wallet actions, and Logout
- [ ] Confirm the white menu panel scrolls; the page behind does not
- [ ] Close the menu and confirm normal page scroll resumes


Made with [Cursor](https://cursor.com)