### PR TITLE
Fix Songchain Orb sessions and Lens primitive configuration

### DIFF
--- a/app/api/songchain/config-check/route.ts
+++ b/app/api/songchain/config-check/route.ts
@@ -71,6 +71,9 @@ export async function GET() {
       'Set NEXT_PUBLIC_SONGCHAIN_FEED_ID (and related vars) in your deployment environment.',
       'Ensure NEXT_PUBLIC_LENS_ENV matches the network where feeds were created.',
     );
+    if (config.resolutionNotes.length > 0) {
+      hints.push(...config.resolutionNotes);
+    }
   }
   if (publicFeed.configured && !publicFeed.registered) {
     hints.push(

--- a/app/api/songchain/config-check/route.ts
+++ b/app/api/songchain/config-check/route.ts
@@ -5,31 +5,106 @@ import {
   getLensNetworkLabel,
   truncateFeedId,
 } from '@/lib/songchain/feed-diagnostics';
+import { checkLensFeedExists } from '@/lib/songchain/lens-feed';
+import { checkLensGraphExists } from '@/lib/songchain/lens-graph';
+import { resolveSongchainConfig } from '@/lib/songchain/resolve-lens-app';
 
 export const dynamic = 'force-dynamic';
 
+async function checkConfiguredFeed(
+  feedId: string | null,
+): Promise<{ configured: boolean; feedId: string; registered: boolean; error: string | null }> {
+  if (!feedId) {
+    return {
+      configured: false,
+      feedId: 'not configured',
+      registered: false,
+      error: null,
+    };
+  }
+
+  const check = await checkLensFeedExists(feedId);
+  return {
+    configured: true,
+    feedId: truncateFeedId(feedId),
+    registered: check.exists,
+    error: check.error,
+  };
+}
+
+async function checkConfiguredGraph(
+  graphId: string | null,
+): Promise<{ configured: boolean; graphId: string; registered: boolean; error: string | null }> {
+  if (!graphId) {
+    return {
+      configured: false,
+      graphId: 'not configured',
+      registered: false,
+      error: null,
+    };
+  }
+
+  const check = await checkLensGraphExists(graphId);
+  return {
+    configured: true,
+    graphId: truncateFeedId(graphId),
+    registered: check.exists,
+    error: check.error,
+  };
+}
+
 /** Public health check for Songchain / Lens env (no secrets). */
 export async function GET() {
-  const config = getSongchainConfig();
+  const raw = getSongchainConfig();
+  const config = await resolveSongchainConfig(raw);
   const network = getLensNetwork();
 
+  const [publicFeed, exclusiveFeed, graph] = await Promise.all([
+    checkConfiguredFeed(config.publicFeedId),
+    checkConfiguredFeed(config.exclusiveFeedId),
+    checkConfiguredGraph(config.graphId),
+  ]);
+
+  const hints: string[] = [];
+  if (!config.enabled) {
+    hints.push(
+      'Set NEXT_PUBLIC_SONGCHAIN_FEED_ID (and related vars) in your deployment environment.',
+      'Ensure NEXT_PUBLIC_LENS_ENV matches the network where feeds were created.',
+    );
+  }
+  if (publicFeed.configured && !publicFeed.registered) {
+    hints.push(
+      'Public feed is not registered on Lens. Use a feed contract address — not your Lens app contract. Set NEXT_PUBLIC_SONGCHAIN_APP_ID for the app and leave FEED_ID empty to auto-resolve, or set FEED_ID to a feed linked in the app dashboard.',
+    );
+  }
+  if (exclusiveFeed.configured && !exclusiveFeed.registered) {
+    hints.push(
+      'Exclusive feed address is set but not registered on Lens. Verify NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID.',
+    );
+  }
+  if (graph.configured && !graph.registered) {
+    hints.push(
+      'Graph address is not registered on Lens. Set NEXT_PUBLIC_SONGCHAIN_GRAPH_ID or resolve via NEXT_PUBLIC_SONGCHAIN_APP_ID.',
+    );
+  }
+
   return NextResponse.json({
-    ok: config.enabled,
+    ok:
+      config.enabled &&
+      (!publicFeed.configured || publicFeed.registered) &&
+      (!exclusiveFeed.configured || exclusiveFeed.registered) &&
+      (!graph.configured || graph.registered),
     lensNetwork: network,
     lensNetworkLabel: getLensNetworkLabel(network),
+    appId: truncateFeedId(config.appId),
+    resolutionNotes: config.resolutionNotes,
     feeds: {
-      publicConfigured: Boolean(config.publicFeedId),
-      publicFeedId: truncateFeedId(config.publicFeedId),
-      exclusiveConfigured: Boolean(config.exclusiveFeedId),
-      exclusiveFeedId: truncateFeedId(config.exclusiveFeedId),
+      public: publicFeed,
+      exclusive: exclusiveFeed,
       groupConfigured: Boolean(config.groupId),
       groupId: truncateFeedId(config.groupId),
+      graph,
     },
-    hints: config.enabled
-      ? []
-      : [
-          'Set NEXT_PUBLIC_SONGCHAIN_FEED_ID (and related vars) in your deployment environment.',
-          'Ensure NEXT_PUBLIC_LENS_ENV matches the network where feeds were created.',
-        ],
+    hints,
   });
 }

--- a/app/songchain/page.tsx
+++ b/app/songchain/page.tsx
@@ -1,5 +1,6 @@
 import { SongchainPageClient } from "@/components/songchain/SongchainPageClient";
 import { getSongchainConfig } from "@/lib/songchain/config";
+import { resolveSongchainConfig } from "@/lib/songchain/resolve-lens-app";
 import type { Metadata } from "next";
 
 /** Read Songchain env on each request (Vercel runtime vars, not build-time snapshot). */
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
   description: "Music on Lens Chain — feeds, community group, and GHO onramp.",
 };
 
-export default function SongchainPage() {
-  const config = getSongchainConfig();
+export default async function SongchainPage() {
+  const config = await resolveSongchainConfig(getSongchainConfig());
   return <SongchainPageClient config={config} />;
 }

--- a/components/songchain/SongchainBookmarksSection.tsx
+++ b/components/songchain/SongchainBookmarksSection.tsx
@@ -5,7 +5,15 @@ import { Button } from "@/components/ui/button";
 import { useSongchainBookmarks } from "@/hooks/useSongchainBookmarks";
 import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
 
-export function SongchainBookmarksSection() {
+import type { SongchainConfig } from "@/lib/songchain/config";
+
+type SongchainBookmarksSectionProps = {
+  graphId?: string | null;
+};
+
+export function SongchainBookmarksSection({
+  graphId = null,
+}: SongchainBookmarksSectionProps) {
   const { posts, loading, error, reload, canWrite, promptWriteAccess } =
     useSongchainBookmarks();
 
@@ -49,7 +57,12 @@ export function SongchainBookmarksSection() {
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {posts.map((post) => (
-            <SongchainPostCard key={post.id} post={post} onReactionChange={reload} />
+            <SongchainPostCard
+              key={post.id}
+              post={post}
+              graphId={graphId}
+              onReactionChange={reload}
+            />
           ))}
         </div>
       )}

--- a/components/songchain/SongchainComposePost.tsx
+++ b/components/songchain/SongchainComposePost.tsx
@@ -13,7 +13,8 @@ type SongchainComposePostProps = {
 
 export function SongchainComposePost({ feedId, onPosted }: SongchainComposePostProps) {
   const [content, setContent] = useState("");
-  const { createPost, isPosting, canWrite, promptWriteAccess } = useSongchainPost();
+  const { createPost, isPosting, canWrite, needsOrbReauth, promptWriteAccess } =
+    useSongchainPost();
 
   if (!feedId) return null;
 
@@ -30,7 +31,9 @@ export function SongchainComposePost({ feedId, onPosted }: SongchainComposePostP
       <h3 className="text-sm font-semibold">Create a post</h3>
       {!canWrite && (
         <p className="text-xs text-muted-foreground">
-          Connect wallet, sign in with Orb, and link your profile to post to this feed.
+          {needsOrbReauth
+            ? "Your Orb session expired partially — sign in again with Orb to post."
+            : "Connect wallet, sign in with Orb, and link your profile to post to this feed."}
         </p>
       )}
       <Textarea
@@ -44,7 +47,7 @@ export function SongchainComposePost({ feedId, onPosted }: SongchainComposePostP
       <div className="flex justify-end gap-2">
         {!canWrite ? (
           <Button type="button" variant="outline" size="sm" onClick={promptWriteAccess}>
-            Link Orb to post
+            {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
           </Button>
         ) : (
           <Button

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -10,6 +10,7 @@ type SongchainFeedSectionProps = {
   title: string;
   description: string;
   feedId: string | null;
+  graphId?: string | null;
   emptyDescription: string;
 };
 
@@ -48,7 +49,14 @@ function FeedDiagnostics({
       {isEmpty && !error && feedId && (
         <p>
           Feed is reachable but has no posts yet. Posts must be created on this custom feed
-          address (not the global Lens feed).
+          address (not the global Lens timeline).
+        </p>
+      )}
+      {error && error.includes('not registered on') && (
+        <p>
+          Fix <code className="text-[10px]">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code> in your
+          deployment env, then redeploy. Use the feed contract address from the Lens / Orb
+          dashboard — not the feed display name.
         </p>
       )}
     </div>
@@ -59,6 +67,7 @@ export function SongchainFeedSection({
   title,
   description,
   feedId,
+  graphId = null,
   emptyDescription,
 }: SongchainFeedSectionProps) {
   const { posts, loading, error, hasMore, reload, loadMore } = useSongchainFeed({
@@ -113,6 +122,7 @@ export function SongchainFeedSection({
               key={post.id}
               post={post}
               feedId={feedId}
+              graphId={graphId}
               onReactionChange={reload}
             />
           ))}

--- a/components/songchain/SongchainGraphPanel.tsx
+++ b/components/songchain/SongchainGraphPanel.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { AnyClient } from "@lens-protocol/client";
+import {
+  fetchFollowStatus,
+  fetchFollowing,
+  fetchGraph,
+} from "@lens-protocol/client/actions";
+import { evmAddress } from "@lens-protocol/types";
+import { createLensClient } from "@/lib/sdk/lens/create-client";
+import { Button } from "@/components/ui/button";
+import { Loader2, Share2, UserPlus } from "lucide-react";
+import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { useSongchainFollow } from "@/hooks/useSongchainFollow";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
+import { checkLensGraphExists } from "@/lib/songchain/lens-graph";
+import { toast } from "sonner";
+
+type SongchainGraphPanelProps = {
+  graphId: string | null;
+  groupId: string | null;
+};
+
+function accountLabel(address: string, username?: string | null): string {
+  if (username) return `@${username}`;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export function SongchainGraphPanel({ graphId, groupId }: SongchainGraphPanelProps) {
+  const { canWrite, lensAccount, getSessionClient } = useLensOrbWrite();
+  const { followAccount, unfollowAccount } = useSongchainFollow(graphId);
+  const [name, setName] = useState<string | null>(null);
+  const [description, setDescription] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [following, setFollowing] = useState<
+    Array<{ address: string; username?: string | null }>
+  >([]);
+
+  const loadGraph = useCallback(async () => {
+    if (!graphId) return;
+    setLoading(true);
+    setConfigError(null);
+    try {
+      const check = await checkLensGraphExists(graphId);
+      if (!check.exists) {
+        setConfigError(check.error);
+        setName(null);
+        setFollowing([]);
+        return;
+      }
+
+      let client: AnyClient = createLensClient();
+      if (canWrite) {
+        try {
+          client = await getSessionClient();
+        } catch (err) {
+          clearStaleOrbSessionIfNeeded(err);
+          client = createLensClient();
+        }
+      }
+
+      const graphResult = await fetchGraph(client, {
+        graph: evmAddress(graphId),
+      });
+      if (graphResult.isErr()) throw new Error(graphResult.error.message);
+      const graph = graphResult.value;
+      if (!graph) {
+        setConfigError("Graph not found on this Lens network.");
+        return;
+      }
+
+      setName(graph.metadata?.name ?? "Songchain graph");
+      setDescription(
+        graph.metadata && "description" in graph.metadata
+          ? String(graph.metadata.description ?? "")
+          : null,
+      );
+
+      if (lensAccount) {
+        const followingResult = await fetchFollowing(client, {
+          account: evmAddress(lensAccount),
+          filter: {
+            graphs: [{ graph: evmAddress(graphId) }],
+          },
+          pageSize: "TEN",
+        });
+        if (followingResult.isOk()) {
+          setFollowing(
+            followingResult.value.items.map((item) => ({
+              address: item.following.address,
+              username: item.following.username?.localName ?? null,
+            })),
+          );
+        }
+      } else {
+        setFollowing([]);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to load graph");
+    } finally {
+      setLoading(false);
+    }
+  }, [graphId, canWrite, lensAccount, getSessionClient]);
+
+  useEffect(() => {
+    void loadGraph();
+  }, [loadGraph]);
+
+  if (!graphId) {
+    return (
+      <section className="rounded-lg border border-dashed border-border/60 p-8 text-center text-muted-foreground">
+        <Share2 className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <p className="text-sm">Graph address not configured yet.</p>
+        <p className="mt-2 text-xs">
+          Set <code>NEXT_PUBLIC_SONGCHAIN_GRAPH_ID</code> or{" "}
+          <code>NEXT_PUBLIC_SONGCHAIN_APP_ID</code> (auto-resolves from the app).
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-border/60 bg-card p-6 space-y-6">
+      {loading && !name ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          <div>
+            <h2 className="text-2xl font-bold flex items-center gap-2">
+              <Share2 className="h-6 w-6 text-violet-400" />
+              {name ?? "Social graph"}
+            </h2>
+            {description && (
+              <p className="mt-2 text-sm text-muted-foreground max-w-xl">{description}</p>
+            )}
+            <p className="mt-2 text-xs text-muted-foreground font-mono">{graphId}</p>
+          </div>
+
+          {configError && (
+            <p className="text-sm text-destructive">{configError}</p>
+          )}
+
+          <p className="text-sm text-muted-foreground">
+            Follows on this graph use the Creative Member Social Graph. Following is
+            group-gated — join the Songchain group
+            {groupId ? ` (${groupId.slice(0, 6)}…${groupId.slice(-4)})` : ""} first,
+            then follow creators from feed posts or here.
+          </p>
+
+          {canWrite && lensAccount ? (
+            <div>
+              <h3 className="text-sm font-semibold mb-2">
+                You follow on this graph
+              </h3>
+              {following.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Not following anyone on this graph yet.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {following.map((item) => (
+                    <li
+                      key={item.address}
+                      className="flex items-center justify-between gap-2 text-sm"
+                    >
+                      <span>{accountLabel(item.address, item.username)}</span>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          void unfollowAccount(item.address).then((ok) => {
+                            if (ok) void loadGraph();
+                          })
+                        }
+                      >
+                        Unfollow
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground flex items-center gap-2">
+              <UserPlus className="h-4 w-4 shrink-0" />
+              Connect Orb and link your profile to follow on this graph.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+type SongchainFollowButtonProps = {
+  graphId: string | null;
+  accountAddress: string;
+  className?: string;
+};
+
+/** Follow / unfollow an account on the configured Songchain graph. */
+export function SongchainFollowButton({
+  graphId,
+  accountAddress,
+  className,
+}: SongchainFollowButtonProps) {
+  const { canWrite, lensAccount, promptWriteAccess } = useLensOrbWrite();
+  const { followAccount, unfollowAccount, graphAddress } =
+    useSongchainFollow(graphId);
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const [pending, setPending] = useState(false);
+
+  const isSelf =
+    !!lensAccount &&
+    lensAccount.toLowerCase() === accountAddress.toLowerCase();
+
+  useEffect(() => {
+    if (!graphAddress || !lensAccount || isSelf) {
+      setChecking(false);
+      setIsFollowing(false);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const client = createLensClient();
+        const result = await fetchFollowStatus(client, {
+          pairs: [
+            {
+              graph: evmAddress(graphAddress),
+              follower: evmAddress(lensAccount),
+              account: evmAddress(accountAddress),
+            },
+          ],
+        });
+        if (!cancelled && result.isOk() && result.value[0]) {
+          setIsFollowing(Boolean(result.value[0].isFollowing));
+        }
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [graphAddress, lensAccount, accountAddress, isSelf]);
+
+  if (!graphId || isSelf) return null;
+
+  const toggle = async () => {
+    if (!canWrite) {
+      promptWriteAccess();
+      return;
+    }
+    setPending(true);
+    try {
+      const ok = isFollowing
+        ? await unfollowAccount(accountAddress)
+        : await followAccount(accountAddress);
+      if (ok) setIsFollowing(!isFollowing);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={isFollowing ? "secondary" : "outline"}
+      className={className}
+      disabled={checking || pending}
+      onClick={() => void toggle()}
+    >
+      {pending ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : isFollowing ? (
+        "Following"
+      ) : (
+        "Follow"
+      )}
+    </Button>
+  );
+}

--- a/components/songchain/SongchainGraphPanel.tsx
+++ b/components/songchain/SongchainGraphPanel.tsx
@@ -242,6 +242,8 @@ export function SongchainFollowButton({
         if (!cancelled && result.isOk() && result.value[0]) {
           setIsFollowing(Boolean(result.value[0].isFollowing));
         }
+      } catch {
+        if (!cancelled) setIsFollowing(false);
       } finally {
         if (!cancelled) setChecking(false);
       }

--- a/components/songchain/SongchainOrbConnect.tsx
+++ b/components/songchain/SongchainOrbConnect.tsx
@@ -19,7 +19,7 @@ export function SongchainOrbConnect() {
           {lensWrite.lensAccount
             ? ` · ${lensWrite.lensAccount.slice(0, 6)}…${lensWrite.lensAccount.slice(-4)}`
             : ''}
-          — you can like posts and join the group.
+          — you can post, like, and join the group.
         </span>
       </div>
     );
@@ -30,9 +30,11 @@ export function SongchainOrbConnect() {
       <div className="flex items-start gap-2 text-sm">
         <Link2 className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
         <span>
-          {lensWrite.needsLink
-            ? 'Orb signed in — link your wallet profile to unlock likes and group join.'
-            : 'Browse feeds in read-only mode. Sign in with Orb and link your account to interact.'}
+          {lensWrite.needsOrbReauth
+            ? 'Your Orb session needs a fresh sign-in before you can post or interact on Lens.'
+            : lensWrite.needsLink
+              ? 'Orb signed in — link your wallet profile to unlock likes and group join.'
+              : 'Browse feeds in read-only mode. Sign in with Orb and link your account to interact.'}
         </span>
       </div>
       <Button
@@ -40,15 +42,19 @@ export function SongchainOrbConnect() {
         variant="secondary"
         disabled={isLinking}
         onClick={() =>
-          lensWrite.needsLink ? void linkProfile() : orb.openLoginModal()
+          lensWrite.needsLink && !lensWrite.needsOrbReauth
+            ? void linkProfile()
+            : orb.openLoginModal()
         }
       >
         <LogIn className="h-4 w-4 mr-2" />
         {isLinking
           ? 'Linking…'
-          : lensWrite.needsLink
-            ? 'Sync profile'
-            : 'Sign in with Orb'}
+          : lensWrite.needsOrbReauth
+            ? 'Sign in again'
+            : lensWrite.needsLink
+              ? 'Sync profile'
+              : 'Sign in with Orb'}
       </Button>
     </div>
   );

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect";
 import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
 import { SongchainGroupPanel } from "@/components/songchain/SongchainGroupPanel";
+import { SongchainGraphPanel } from "@/components/songchain/SongchainGraphPanel";
 import { SongchainComposePost } from "@/components/songchain/SongchainComposePost";
 import { SongchainBookmarksSection } from "@/components/songchain/SongchainBookmarksSection";
 import { SongchainLensAdvancedPanel } from "@/components/songchain/SongchainLensAdvancedPanel";
@@ -64,6 +65,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
           <TabsTrigger value="feed">Feed</TabsTrigger>
           <TabsTrigger value="exclusive">Exclusive</TabsTrigger>
           <TabsTrigger value="group">Group</TabsTrigger>
+          <TabsTrigger value="graph">Graph</TabsTrigger>
           <TabsTrigger value="bookmarks">Bookmarks</TabsTrigger>
         </TabsList>
 
@@ -77,6 +79,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Songchain feed"
             description="Posts from the main Songchain Lens feed (Orb)."
             feedId={config.publicFeedId}
+            graphId={config.graphId}
             emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled, so publish a new post directly to this feed if it should appear here."
           />
         </TabsContent>
@@ -91,6 +94,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Exclusive feed"
             description="Members-only drops and announcements on Lens."
             feedId={config.exclusiveFeedId}
+            graphId={config.graphId}
             emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
           />
         </TabsContent>
@@ -99,8 +103,12 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
           <SongchainGroupPanel groupId={config.groupId} />
         </TabsContent>
 
+        <TabsContent value="graph">
+          <SongchainGraphPanel graphId={config.graphId} groupId={config.groupId} />
+        </TabsContent>
+
         <TabsContent value="bookmarks">
-          <SongchainBookmarksSection />
+          <SongchainBookmarksSection graphId={config.graphId} />
         </TabsContent>
       </Tabs>
 
@@ -109,9 +117,12 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
       {!config.enabled && (
         <p className="mt-10 text-center text-sm text-muted-foreground">
           Configure{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code>,{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID</code>, and{" "}
-          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GROUP_ID</code> with your Lens
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_APP_ID</code> (Lens app),{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_FEED_ID</code> /{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID</code> (feed
+          contracts), and{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GROUP_ID</code>,{" "}
+          <code className="text-xs">NEXT_PUBLIC_SONGCHAIN_GRAPH_ID</code> with your Lens
           primitives, then redeploy if you added them after the last build. See{" "}
           <code className="text-xs">env.example</code> in the repo.
         </p>

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -40,6 +40,7 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { groveService } from "@/lib/sdk/grove/service";
 import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { SongchainAuthorTimeline } from "@/components/songchain/SongchainAuthorTimeline";
+import { SongchainFollowButton } from "@/components/songchain/SongchainGraphPanel";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
 
@@ -81,6 +82,7 @@ function authorLabel(post: AnyPost): string {
 type SongchainPostCardProps = {
   post: AnyPost;
   feedId?: string | null;
+  graphId?: string | null;
   compact?: boolean;
   onReactionChange?: () => void;
 };
@@ -88,6 +90,7 @@ type SongchainPostCardProps = {
 export function SongchainPostCard({
   post,
   feedId,
+  graphId = null,
   compact = false,
   onReactionChange,
 }: SongchainPostCardProps) {
@@ -269,13 +272,21 @@ export function SongchainPostCard({
           </div>
         )}
         <div className="flex flex-1 flex-col gap-3 p-4">
-          <button
-            type="button"
-            className="text-xs text-muted-foreground text-left hover:text-violet-400 w-fit"
-            onClick={() => setTimelineOpen(true)}
-          >
-            {authorLabel(post)}
-          </button>
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              className="text-xs text-muted-foreground text-left hover:text-violet-400 w-fit"
+              onClick={() => setTimelineOpen(true)}
+            >
+              {authorLabel(post)}
+            </button>
+            {content && (
+              <SongchainFollowButton
+                graphId={graphId}
+                accountAddress={content.author.address}
+              />
+            )}
+          </div>
           {postText(post) && (
             <p className="text-sm leading-relaxed whitespace-pre-wrap">
               {postText(post)}

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -18,6 +18,8 @@ import {
   clearStoredOrbSession,
   subscribeOrbSession,
   getOrbSessionServerSnapshot,
+  hasOrbWriteCredentials,
+  normalizeOrbAuthTokens,
   type StoredOrbSession,
 } from '@/lib/sdk/orb/login';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
@@ -116,16 +118,24 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
         invalidateOrbSession();
         return null;
       }
-      const stored: StoredOrbSession = {
+      const merged = normalizeOrbAuthTokens({
         accessToken: synced.accessToken,
         refreshToken: synced.refreshToken ?? session.refreshToken,
         authenticationId: synced.authenticationId ?? session.authenticationId,
         idToken: synced.idToken ?? session.idToken,
-      };
-      persistSession(stored);
-      return stored;
+      });
+      if (!merged || !hasOrbWriteCredentials(merged)) {
+        invalidateOrbSession();
+        return null;
+      }
+      persistSession(merged);
+      return merged;
     } catch (err) {
       if (isStaleOrbSessionError(err)) {
+        invalidateOrbSession();
+        return null;
+      }
+      if (!hasOrbWriteCredentials(session)) {
         invalidateOrbSession();
         return null;
       }
@@ -284,12 +294,15 @@ export function OrbSessionProvider({ children }: { children: React.ReactNode }) 
           },
         });
 
-        const stored: StoredOrbSession = {
-          accessToken: result.accessToken,
-          refreshToken: result.refreshToken,
-          authenticationId: result.authenticationId,
-          idToken: result.idToken,
-        };
+        const stored = normalizeOrbAuthTokens(
+          result as unknown as Record<string, unknown>,
+        );
+
+        if (!stored?.refreshToken?.trim()) {
+          throw new Error(
+            'Orb sign-in did not return a refresh token. Try signing in again.',
+          );
+        }
         persistSession(stored);
         setIsLoginModalOpen(false);
         bumpAccountMenuRefresh();

--- a/env.example
+++ b/env.example
@@ -7,14 +7,25 @@ NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID=
 # --- Lens / Songchain ---
 # Network: omit or set anything except "production" for Lens testnet (Sepolia).
 # Set to "production" for Lens mainnet feeds and API.
-NEXT_PUBLIC_LENS_ENV=testnet
+NEXT_PUBLIC_LENS_ENV=production
 
-# Custom feed contract addresses (lowercase 0x…). Required for /songchain feeds.
+# Lens *app* contract (Creative TV). Not a feed — posts cannot target this address.
+NEXT_PUBLIC_SONGCHAIN_APP_ID=
+
+# Feed contract for the public Songchain tab. Optional when APP_ID is set (auto-resolves
+# from feeds linked to the app). Do NOT paste the app address here.
 NEXT_PUBLIC_SONGCHAIN_FEED_ID=
+
+# Group-gated / default app feed for the exclusive tab. Optional when APP_ID is set.
 NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID=
 NEXT_PUBLIC_SONGCHAIN_GROUP_ID=
 
+# Lens social graph for follows (Creative Member Social Graph). Optional when APP_ID is set.
+NEXT_PUBLIC_SONGCHAIN_GRAPH_ID=
+
 # Optional server-only fallbacks (no NEXT_PUBLIC_ prefix)
+# SONGCHAIN_APP_ID=
+# SONGCHAIN_GRAPH_ID=
 # SONGCHAIN_FEED_ID=
 # SONGCHAIN_EXCLUSIVE_FEED_ID=
 # SONGCHAIN_GROUP_ID=

--- a/hooks/useLensOrbWrite.test.ts
+++ b/hooks/useLensOrbWrite.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { hasOrbWriteCredentials } from '@/lib/sdk/orb/login';
+
+/** Mirrors useLensOrbWrite gating (kept in sync with hooks/useLensOrbWrite.ts). */
+function lensOrbWriteFlags(
+  session: { accessToken: string; refreshToken?: string } | null,
+  isAuthenticated: boolean,
+  linkStatus: 'idle' | 'linked' | 'needs_wallet' | 'failed',
+) {
+  const hasWriteCredentials = hasOrbWriteCredentials(session);
+  return {
+    canWrite:
+      isAuthenticated && linkStatus === 'linked' && hasWriteCredentials,
+    needsOrbReauth:
+      isAuthenticated && linkStatus === 'linked' && !hasWriteCredentials,
+  };
+}
+
+describe('useLensOrbWrite gating', () => {
+  it('canWrite is false when linked but refresh token is missing', () => {
+    const flags = lensOrbWriteFlags(
+      { accessToken: 'access-only' },
+      true,
+      'linked',
+    );
+    expect(flags.canWrite).toBe(false);
+    expect(flags.needsOrbReauth).toBe(true);
+  });
+
+  it('canWrite is true when linked with full credentials', () => {
+    const flags = lensOrbWriteFlags(
+      { accessToken: 'access', refreshToken: 'refresh' },
+      true,
+      'linked',
+    );
+    expect(flags.canWrite).toBe(true);
+    expect(flags.needsOrbReauth).toBe(false);
+  });
+});

--- a/hooks/useLensOrbWrite.ts
+++ b/hooks/useLensOrbWrite.ts
@@ -4,6 +4,10 @@ import { useCallback, useMemo } from 'react';
 import { useAuthModal } from '@account-kit/react';
 import { useOrbSession } from '@/context/OrbSessionContext';
 import { resumeLensSessionFromOrb } from '@/lib/sdk/lens/orb-session-client';
+import {
+  hasOrbWriteCredentials,
+  ORB_INCOMPLETE_SESSION_MESSAGE,
+} from '@/lib/sdk/orb/login';
 import type { SessionClient } from '@lens-protocol/client';
 
 export type LensOrbWriteAccess = {
@@ -13,6 +17,8 @@ export type LensOrbWriteAccess = {
   needsLink: boolean;
   /** No Orb session */
   needsOrbLogin: boolean;
+  /** Linked but missing refresh token — must re-sign with Orb */
+  needsOrbReauth: boolean;
   lensAccount: string | null;
   getSessionClient: () => Promise<SessionClient>;
   promptWriteAccess: () => void;
@@ -30,36 +36,51 @@ export function useLensOrbWrite(): LensOrbWriteAccess {
   } = useOrbSession();
   const { openAuthModal } = useAuthModal();
 
-  const canWrite = isAuthenticated && linkStatus === 'linked';
+  const hasWriteCredentials = hasOrbWriteCredentials(session);
+  const needsOrbReauth =
+    isAuthenticated && linkStatus === 'linked' && !hasWriteCredentials;
+  const canWrite =
+    isAuthenticated && linkStatus === 'linked' && hasWriteCredentials;
   const needsLink = isAuthenticated && linkStatus !== 'linked';
   const needsOrbLogin = !isAuthenticated;
 
   const getSessionClient = useCallback(async () => {
-    if (!canWrite) {
+    if (!isAuthenticated || linkStatus !== 'linked') {
       throw new Error('Link your Orb account to interact on Lens');
     }
     if (!session?.accessToken) {
       throw new Error('Orb session expired — sign in again');
     }
     const synced = (await syncSession()) ?? session;
+    if (!hasOrbWriteCredentials(synced)) {
+      throw new Error(ORB_INCOMPLETE_SESSION_MESSAGE);
+    }
     return resumeLensSessionFromOrb(synced);
-  }, [canWrite, session, syncSession]);
+  }, [isAuthenticated, linkStatus, session, syncSession]);
 
   const promptWriteAccess = useCallback(() => {
     if (!hasWallet) {
       openAuthModal();
       return;
     }
-    if (needsOrbLogin || needsLink) {
+    if (needsOrbLogin || needsLink || needsOrbReauth) {
       openLoginModal();
     }
-  }, [needsOrbLogin, needsLink, hasWallet, openLoginModal, openAuthModal]);
+  }, [
+    needsOrbLogin,
+    needsLink,
+    needsOrbReauth,
+    hasWallet,
+    openLoginModal,
+    openAuthModal,
+  ]);
 
   return useMemo(
     () => ({
       canWrite,
       needsLink,
       needsOrbLogin,
+      needsOrbReauth,
       lensAccount,
       getSessionClient,
       promptWriteAccess,
@@ -68,6 +89,7 @@ export function useLensOrbWrite(): LensOrbWriteAccess {
       canWrite,
       needsLink,
       needsOrbLogin,
+      needsOrbReauth,
       lensAccount,
       getSessionClient,
       promptWriteAccess,

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -12,6 +12,7 @@ import {
   extractLensContractAddress,
   getLensContractAddressError,
 } from '@/lib/sdk/lens/primitive-id';
+import { checkLensFeedExists } from '@/lib/songchain/lens-feed';
 
 type UseSongchainFeedOptions = {
   feedId: string | null;
@@ -42,13 +43,21 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
       setLoading(true);
       setError(null);
       try {
+        const feedCheck = await checkLensFeedExists(feedId);
+        if (!feedCheck.exists) {
+          setPosts([]);
+          cursorRef.current = null;
+          setHasMore(false);
+          setError(feedCheck.error);
+          return;
+        }
+
         let client: AnyClient = createLensClient();
         if (canWrite) {
           try {
             client = await getSessionClient();
           } catch (err) {
             clearStaleOrbSessionIfNeeded(err);
-            // Always fall back to read-only public client for feed browsing.
             client = createLensClient();
           }
         }

--- a/hooks/useSongchainFollow.ts
+++ b/hooks/useSongchainFollow.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback } from 'react';
+import { follow, unfollow } from '@lens-protocol/client/actions';
+import { evmAddress } from '@lens-protocol/types';
+import { useLensOrbWrite } from '@/hooks/useLensOrbWrite';
+import { clearStaleOrbSessionIfNeeded } from '@/lib/sdk/orb/session-errors';
+import { resolveSongchainGraphAddress } from '@/lib/songchain/lens-graph';
+import { toast } from 'sonner';
+
+export function useSongchainFollow(graphId: string | null) {
+  const { canWrite, lensAccount, getSessionClient, promptWriteAccess } =
+    useLensOrbWrite();
+
+  const graphAddress = resolveSongchainGraphAddress(graphId);
+
+  const followAccount = useCallback(
+    async (accountAddress: string) => {
+      if (!graphAddress) {
+        toast.error('Songchain graph is not configured.');
+        return false;
+      }
+      if (!canWrite) {
+        promptWriteAccess();
+        toast.info('Link Orb and join the group to follow on this graph.');
+        return false;
+      }
+      if (lensAccount?.toLowerCase() === accountAddress.toLowerCase()) {
+        return false;
+      }
+
+      try {
+        const client = await getSessionClient();
+        const result = await follow(client, {
+          account: evmAddress(accountAddress),
+          graph: evmAddress(graphAddress),
+        });
+        if (result.isErr()) throw new Error(result.error.message);
+        toast.success('Following on Creative graph');
+        return true;
+      } catch (err) {
+        clearStaleOrbSessionIfNeeded(err);
+        toast.error(err instanceof Error ? err.message : 'Follow failed');
+        return false;
+      }
+    },
+    [graphAddress, canWrite, lensAccount, getSessionClient, promptWriteAccess],
+  );
+
+  const unfollowAccount = useCallback(
+    async (accountAddress: string) => {
+      if (!graphAddress || !canWrite) return false;
+      try {
+        const client = await getSessionClient();
+        const result = await unfollow(client, {
+          account: evmAddress(accountAddress),
+          graph: evmAddress(graphAddress),
+        });
+        if (result.isErr()) throw new Error(result.error.message);
+        toast.success('Unfollowed');
+        return true;
+      } catch (err) {
+        clearStaleOrbSessionIfNeeded(err);
+        toast.error(err instanceof Error ? err.message : 'Unfollow failed');
+        return false;
+      }
+    },
+    [graphAddress, canWrite, getSessionClient],
+  );
+
+  return {
+    graphAddress,
+    followAccount,
+    unfollowAccount,
+  };
+}

--- a/hooks/useSongchainPost.ts
+++ b/hooks/useSongchainPost.ts
@@ -5,7 +5,17 @@ import { textOnly } from "@lens-protocol/metadata";
 import { post } from "@lens-protocol/client/actions";
 import { evmAddress, uri } from "@lens-protocol/client";
 import { groveService } from "@/lib/sdk/grove/service";
-import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
+import {
+  clearStaleOrbSessionIfNeeded,
+  isIncompleteOrbSessionError,
+} from "@/lib/sdk/orb/session-errors";
+import { formatOrbAuthError } from "@/lib/sdk/orb/format-auth-error";
+import {
+  checkLensFeedExists,
+  formatLensFeedPostError,
+  resolveSongchainFeedAddress,
+} from "@/lib/songchain/lens-feed";
+import { getLensContractAddressError } from "@/lib/sdk/lens/primitive-id";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { toast } from "sonner";
 
@@ -17,7 +27,12 @@ export type CreateSongchainPostParams = {
 
 export function useSongchainPost() {
   const [isPosting, setIsPosting] = useState(false);
-  const { canWrite, getSessionClient, promptWriteAccess } = useLensOrbWrite();
+  const {
+    canWrite,
+    needsOrbReauth,
+    getSessionClient,
+    promptWriteAccess,
+  } = useLensOrbWrite();
 
   const createPost = useCallback(
     async ({ content, feedId, title = "Songchain post" }: CreateSongchainPostParams) => {
@@ -30,9 +45,26 @@ export function useSongchainPost() {
         toast.error("Feed is not configured.");
         return false;
       }
+
+      const feedAddress = resolveSongchainFeedAddress(feedId);
+      if (!feedAddress) {
+        toast.error(getLensContractAddressError(feedId, "Feed contract ID") ?? "Invalid feed ID.");
+        return false;
+      }
+
+      const feedCheck = await checkLensFeedExists(feedId);
+      if (!feedCheck.exists) {
+        toast.error(feedCheck.error ?? "Feed is not available on this Lens network.");
+        return false;
+      }
+
       if (!canWrite) {
         promptWriteAccess();
-        toast.info("Link your Orb account to post on Lens.");
+        toast.info(
+          needsOrbReauth
+            ? "Sign in again with Orb to post on Lens."
+            : "Link your Orb account to post on Lens.",
+        );
         return false;
       }
 
@@ -51,7 +83,7 @@ export function useSongchainPost() {
 
         const result = await post(client, {
           contentUri: uri(uploadResult.url),
-          feed: evmAddress(feedId),
+          feed: evmAddress(feedAddress),
         });
 
         if (result.isErr()) {
@@ -61,15 +93,22 @@ export function useSongchainPost() {
         toast.success("Posted to Songchain feed!");
         return true;
       } catch (err) {
-        clearStaleOrbSessionIfNeeded(err);
-        toast.error(err instanceof Error ? err.message : "Posting failed");
+        const cleared = clearStaleOrbSessionIfNeeded(err);
+        if (cleared || isIncompleteOrbSessionError(err)) {
+          promptWriteAccess();
+        }
+        toast.error(
+          isIncompleteOrbSessionError(err)
+            ? formatOrbAuthError(err)
+            : formatLensFeedPostError(err, feedId),
+        );
         return false;
       } finally {
         setIsPosting(false);
       }
     },
-    [canWrite, getSessionClient, promptWriteAccess],
+    [canWrite, needsOrbReauth, getSessionClient, promptWriteAccess],
   );
 
-  return { createPost, isPosting, canWrite, promptWriteAccess };
+  return { createPost, isPosting, canWrite, needsOrbReauth, promptWriteAccess };
 }

--- a/lib/sdk/lens/primitive-id.test.ts
+++ b/lib/sdk/lens/primitive-id.test.ts
@@ -19,8 +19,9 @@ describe('Lens primitive IDs', () => {
     ).toBe('0xdef0000000000000000000000000000000000002');
   });
 
-  it('reports IDs that do not include a contract address', () => {
-    expect(extractLensContractAddress('creative-feed')).toBeNull();
+  it('returns null for labels without a contract address', () => {
+    expect(normalizeLensPrimitiveId('Lens Public Feed')).toBeNull();
+    expect(normalizeLensPrimitiveId('creative-feed')).toBeNull();
     expect(getLensContractAddressError('creative-feed', 'Feed contract ID')).toContain(
       '0x contract address',
     );

--- a/lib/sdk/lens/primitive-id.ts
+++ b/lib/sdk/lens/primitive-id.ts
@@ -14,7 +14,7 @@ export function normalizeLensPrimitiveId(value: string | null | undefined): stri
   const trimmed = value?.trim();
   if (!trimmed) return null;
 
-  return extractLensContractAddress(trimmed) ?? trimmed.toLowerCase();
+  return extractLensContractAddress(trimmed);
 }
 
 export function getLensContractAddressError(

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { formatOrbAuthError } from './format-auth-error';
 
 describe('formatOrbAuthError', () => {
+  it('maps incomplete Orb session to re-sign copy', () => {
+    expect(
+      formatOrbAuthError(new Error('Orb session is missing a refresh token')),
+    ).toMatch(/sign in again with orb/i);
+  });
   it('maps access denied to security-checks copy', () => {
     expect(formatOrbAuthError(new Error('Access denied'))).toMatch(/security checks/i);
     expect(formatOrbAuthError(new Error('Access denied'))).not.toMatch(/VPN/i);

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -1,4 +1,7 @@
-import { isRevokedOrbSessionError } from '@/lib/sdk/orb/session-errors';
+import {
+  isIncompleteOrbSessionError,
+  isRevokedOrbSessionError,
+} from '@/lib/sdk/orb/session-errors';
 
 /** User-facing copy for Orb QR / link failures (init proxy, poll, SDK). */
 export function formatOrbAuthError(error: unknown): string {
@@ -31,6 +34,9 @@ export function formatOrbAuthError(error: unknown): string {
   }
   if (isRevokedOrbSessionError(error)) {
     return 'Your Orb session was signed out. Sign in again with Orb to interact on Lens.';
+  }
+  if (isIncompleteOrbSessionError(error)) {
+    return 'Sign in again with Orb to post and interact on Lens.';
   }
   if (lower.includes('wallet not connected') || lower.includes('sign in with your wallet')) {
     return 'Connect your wallet with Get Started before linking your Lens identity.';

--- a/lib/sdk/orb/login.test.ts
+++ b/lib/sdk/orb/login.test.ts
@@ -3,11 +3,58 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ORB_SESSION_CHANGE_EVENT,
   ORB_SESSION_STORAGE_KEY,
+  hasOrbWriteCredentials,
   invalidateOrbSessionCache,
   loadStoredOrbSession,
+  normalizeOrbAuthTokens,
   saveStoredOrbSession,
   subscribeOrbSession,
 } from './login';
+
+describe('hasOrbWriteCredentials', () => {
+  it('returns false when session is null or missing tokens', () => {
+    expect(hasOrbWriteCredentials(null)).toBe(false);
+    expect(hasOrbWriteCredentials({ accessToken: 'a' })).toBe(false);
+    expect(hasOrbWriteCredentials({ refreshToken: 'r' } as never)).toBe(false);
+  });
+
+  it('returns true when both access and refresh are present', () => {
+    expect(
+      hasOrbWriteCredentials({
+        accessToken: 'access',
+        refreshToken: 'refresh',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('normalizeOrbAuthTokens', () => {
+  it('maps snake_case poll fields to StoredOrbSession', () => {
+    expect(
+      normalizeOrbAuthTokens({
+        access_token: 'at',
+        refresh_token: 'rt',
+        authentication_id: 'auth-1',
+        id_token: 'id',
+      }),
+    ).toEqual({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      authenticationId: 'auth-1',
+      idToken: 'id',
+    });
+  });
+
+  it('returns null when access token is missing', () => {
+    expect(normalizeOrbAuthTokens({ refresh_token: 'rt' })).toBeNull();
+  });
+
+  it('access-only merge after sync is not writable', () => {
+    const merged = normalizeOrbAuthTokens({ accessToken: 'new-access' });
+    expect(merged).not.toBeNull();
+    expect(hasOrbWriteCredentials(merged)).toBe(false);
+  });
+});
 
 describe('orb session storage', () => {
   afterEach(() => {

--- a/lib/sdk/orb/login.ts
+++ b/lib/sdk/orb/login.ts
@@ -18,6 +18,47 @@ export type StoredOrbSession = {
   idToken?: string;
 };
 
+/** User-facing message when access token exists but refresh is missing. */
+export const ORB_INCOMPLETE_SESSION_MESSAGE =
+  'Orb session is incomplete. Sign in again with Orb to post and interact.';
+
+/** Lens writes require both access and refresh tokens (see resumeLensSessionFromOrb). */
+export function hasOrbWriteCredentials(
+  session: StoredOrbSession | null | undefined,
+): boolean {
+  if (!session) return false;
+  return (
+    !!session.accessToken?.trim() && !!session.refreshToken?.trim()
+  );
+}
+
+/**
+ * Normalize Orb QR poll / sync payloads (camelCase or snake_case from orbapi.xyz).
+ */
+export function normalizeOrbAuthTokens(
+  raw: Record<string, unknown>,
+): StoredOrbSession | null {
+  const accessToken = String(
+    raw.accessToken ?? raw.access_token ?? '',
+  ).trim();
+  if (!accessToken) return null;
+
+  const refreshToken = String(
+    raw.refreshToken ?? raw.refresh_token ?? '',
+  ).trim();
+  const authenticationId = String(
+    raw.authenticationId ?? raw.authentication_id ?? '',
+  ).trim();
+  const idToken = String(raw.idToken ?? raw.id_token ?? '').trim();
+
+  return {
+    accessToken,
+    refreshToken: refreshToken || undefined,
+    authenticationId: authenticationId || undefined,
+    idToken: idToken || undefined,
+  };
+}
+
 export const ORB_SESSION_STORAGE_KEY = 'crtv_orb_session';
 
 /** Dispatched on the same tab when Orb session is saved or cleared. */

--- a/lib/sdk/orb/session-errors.test.ts
+++ b/lib/sdk/orb/session-errors.test.ts
@@ -1,78 +1,64 @@
-/** @vitest-environment jsdom */
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
   clearStaleOrbSessionIfNeeded,
-  getOrbErrorMessage,
-  isRevokedOrbSessionError,
+  isIncompleteOrbSessionError,
   isStaleOrbSessionError,
 } from './session-errors';
-import { ORB_SESSION_STORAGE_KEY } from './login';
 
-describe('getOrbErrorMessage', () => {
-  afterEach(() => {
-    localStorage.clear();
-  });
-  it('reads message from plain objects', () => {
-    expect(getOrbErrorMessage({ message: 'GraphQL failure' })).toBe(
-      'GraphQL failure',
-    );
-  });
-});
+vi.mock('@/lib/sdk/orb/login', () => ({
+  clearStoredOrbSession: vi.fn(),
+}));
 
-describe('isRevokedOrbSessionError', () => {
-  it('detects Lens revoked refresh copy', () => {
+import { clearStoredOrbSession } from '@/lib/sdk/orb/login';
+
+describe('isIncompleteOrbSessionError', () => {
+  it('detects missing refresh token and incomplete session messages', () => {
     expect(
-      isRevokedOrbSessionError(
-        new Error('You are trying to renew a revoked authentication'),
+      isIncompleteOrbSessionError(
+        new Error('Orb session is missing a refresh token'),
       ),
     ).toBe(true);
-  });
-
-  it('ignores unrelated errors', () => {
-    expect(isRevokedOrbSessionError(new Error('Network request failed'))).toBe(
-      false,
-    );
-  });
-});
-
-describe('isStaleOrbSessionError', () => {
-  it('detects 401 and unauthorized', () => {
-    expect(isStaleOrbSessionError(new Error('401 Unauthorized'))).toBe(true);
-    expect(isStaleOrbSessionError(new Error('invalid orb access token'))).toBe(
-      true,
-    );
+    expect(
+      isIncompleteOrbSessionError(
+        new Error('Orb session is incomplete. Sign in again'),
+      ),
+    ).toBe(true);
+    expect(isIncompleteOrbSessionError(new Error('network error'))).toBe(false);
   });
 });
 
 describe('clearStaleOrbSessionIfNeeded', () => {
   afterEach(() => {
-    localStorage.clear();
+    vi.mocked(clearStoredOrbSession).mockClear();
   });
 
-  it('clears storage for stale sessions', () => {
-    localStorage.setItem(
-      ORB_SESSION_STORAGE_KEY,
-      JSON.stringify({ accessToken: 'stale' }),
+  it('clears storage for incomplete session errors', () => {
+    const cleared = clearStaleOrbSessionIfNeeded(
+      new Error('Orb session is missing a refresh token'),
     );
+    expect(cleared).toBe(true);
+    expect(clearStoredOrbSession).toHaveBeenCalledOnce();
+  });
 
-    expect(
-      clearStaleOrbSessionIfNeeded(
-        new Error('You are trying to renew a revoked authentication'),
-      ),
-    ).toBe(true);
-    expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).toBeNull();
+  it('clears storage for stale session errors', () => {
+    const cleared = clearStaleOrbSessionIfNeeded(new Error('401 unauthorized'));
+    expect(cleared).toBe(true);
+    expect(clearStoredOrbSession).toHaveBeenCalledOnce();
   });
 
   it('does not clear for unrelated errors', () => {
-    localStorage.setItem(
-      ORB_SESSION_STORAGE_KEY,
-      JSON.stringify({ accessToken: 'keep' }),
-    );
+    const cleared = clearStaleOrbSessionIfNeeded(new Error('upload failed'));
+    expect(cleared).toBe(false);
+    expect(clearStoredOrbSession).not.toHaveBeenCalled();
+  });
+});
 
-    expect(clearStaleOrbSessionIfNeeded(new Error('Network failed'))).toBe(
-      false,
-    );
-    expect(localStorage.getItem(ORB_SESSION_STORAGE_KEY)).not.toBeNull();
-    localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
+describe('isStaleOrbSessionError', () => {
+  it('includes incomplete session as stale', () => {
+    expect(
+      isStaleOrbSessionError(
+        new Error('Orb session is missing a refresh token'),
+      ),
+    ).toBe(true);
   });
 });

--- a/lib/sdk/orb/session-errors.ts
+++ b/lib/sdk/orb/session-errors.ts
@@ -25,9 +25,19 @@ export function isRevokedOrbSessionError(error: unknown): boolean {
   );
 }
 
+/** Session has access token but cannot resume Lens writes (missing refresh). */
+export function isIncompleteOrbSessionError(error: unknown): boolean {
+  const lower = getOrbErrorMessage(error).toLowerCase();
+  return (
+    lower.includes('missing a refresh token') ||
+    lower.includes('orb session is incomplete')
+  );
+}
+
 /** Auth failures that mean the cached Orb session should be dropped. */
 export function isStaleOrbSessionError(error: unknown): boolean {
   if (isRevokedOrbSessionError(error)) return true;
+  if (isIncompleteOrbSessionError(error)) return true;
 
   const lower = getOrbErrorMessage(error).toLowerCase();
   return (

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -44,6 +44,17 @@ describe('getSongchainConfig', () => {
     );
   });
 
+  it('reads app id separately from feed ids', () => {
+    process.env.NEXT_PUBLIC_SONGCHAIN_APP_ID =
+      '0x3412C2509EeF4f9A133E6D3638B9B3c06fc30111';
+    process.env.NEXT_PUBLIC_SONGCHAIN_GRAPH_ID =
+      '0x2B36706E8E352a273c34D108A5854A55cb2302A6';
+    const config = getSongchainConfig();
+    expect(config.appId).toBe('0x3412c2509eef4f9a133e6d3638b9b3c06fc30111');
+    expect(config.graphId).toBe('0x2b36706e8e352a273c34d108a5854a55cb2302a6');
+    expect(config.enabled).toBe(true);
+  });
+
   it('falls back to server-only env keys when NEXT_PUBLIC vars are unset', () => {
     delete process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID;
     process.env.SONGCHAIN_FEED_ID =

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -9,9 +9,13 @@ import { normalizeLensPrimitiveId } from '@/lib/sdk/lens/primitive-id';
 
 export type SongchainConfig = {
   enabled: boolean;
+  /** Lens app contract — used to resolve feed addresses (not a post target). */
+  appId: string | null;
   publicFeedId: string | null;
   exclusiveFeedId: string | null;
   groupId: string | null;
+  /** Lens social graph — required for follow/unfollow on Songchain. */
+  graphId: string | null;
   hallidayApiKey: string | null;
   /** Halliday Payments SDK `outputs` entry, e.g. `lens:0x…800a`. */
   hallidayOutputAsset: string;
@@ -41,6 +45,12 @@ function readLensPrimitiveEnv(...keys: string[]): string | null {
  * components should receive the result via props instead of calling this directly.
  */
 export function getSongchainConfig(): SongchainConfig {
+  const appId = readLensPrimitiveEnv(
+    'NEXT_PUBLIC_SONGCHAIN_APP_ID',
+    'SONGCHAIN_APP_ID',
+    'NEXT_PUBLIC_LENS_APP_ID',
+    'LENS_APP_ID',
+  );
   const publicFeedId = readLensPrimitiveEnv(
     'NEXT_PUBLIC_SONGCHAIN_FEED_ID',
     'SONGCHAIN_FEED_ID',
@@ -52,6 +62,10 @@ export function getSongchainConfig(): SongchainConfig {
   const groupId = readLensPrimitiveEnv(
     'NEXT_PUBLIC_SONGCHAIN_GROUP_ID',
     'SONGCHAIN_GROUP_ID',
+  );
+  const graphId = readLensPrimitiveEnv(
+    'NEXT_PUBLIC_SONGCHAIN_GRAPH_ID',
+    'SONGCHAIN_GRAPH_ID',
   );
 
   const tokenOverride = readEnv(
@@ -67,10 +81,12 @@ export function getSongchainConfig(): SongchainConfig {
   const network = getLensNetwork();
 
   return {
-    enabled: Boolean(publicFeedId || exclusiveFeedId || groupId),
+    enabled: Boolean(appId || publicFeedId || exclusiveFeedId || groupId || graphId),
+    appId,
     publicFeedId,
     exclusiveFeedId,
     groupId,
+    graphId,
     hallidayApiKey,
     hallidayOutputAsset: buildHallidayOutputAsset(
       network,

--- a/lib/songchain/lens-feed.test.ts
+++ b/lib/songchain/lens-feed.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildFeedNotFoundMessage, formatLensFeedPostError } from './lens-feed';
+
+describe('lens-feed', () => {
+  it('builds a feed-not-found message with network context', () => {
+    const msg = buildFeedNotFoundMessage(
+      '0xfa3059b8939f08cd40caf51f566252ec9fece73d',
+      'mainnet',
+    );
+    expect(msg).toContain('Lens mainnet');
+    expect(msg).toContain('app contract');
+  });
+
+  it('maps GraphQL feed errors to configuration guidance', () => {
+    const msg = formatLensFeedPostError(
+      new Error('[GraphQL] Bad user input - Params validation error: Feed does not exist'),
+      '0xfa3059b8939f08cd40caf51f566252ec9fece73d',
+      'mainnet',
+    );
+    expect(msg).toContain('not registered on Lens mainnet');
+  });
+});

--- a/lib/songchain/lens-feed.ts
+++ b/lib/songchain/lens-feed.ts
@@ -1,0 +1,87 @@
+import { fetchFeed } from '@lens-protocol/client/actions';
+import { evmAddress } from '@lens-protocol/types';
+import { createLensClient } from '@/lib/sdk/lens/create-client';
+import { getLensNetwork, type LensNetwork } from '@/lib/sdk/lens/chains';
+import {
+  extractLensContractAddress,
+  getLensContractAddressError,
+} from '@/lib/sdk/lens/primitive-id';
+import { getLensNetworkLabel, truncateFeedId } from '@/lib/songchain/feed-diagnostics';
+import { getOrbErrorMessage } from '@/lib/sdk/orb/session-errors';
+
+export type LensFeedCheckResult = {
+  feedAddress: `0x${string}` | null;
+  exists: boolean;
+  error: string | null;
+};
+
+export function resolveSongchainFeedAddress(
+  feedId: string | null | undefined,
+): `0x${string}` | null {
+  return extractLensContractAddress(feedId);
+}
+
+/** Query Lens API to confirm the feed primitive exists on the configured network. */
+export async function checkLensFeedExists(
+  feedId: string | null | undefined,
+  network: LensNetwork = getLensNetwork(),
+): Promise<LensFeedCheckResult> {
+  const feedAddress = resolveSongchainFeedAddress(feedId);
+  if (!feedAddress) {
+    return {
+      feedAddress: null,
+      exists: false,
+      error: getLensContractAddressError(feedId, 'Feed contract ID'),
+    };
+  }
+
+  const client = createLensClient();
+  const result = await fetchFeed(client, { feed: evmAddress(feedAddress) });
+
+  if (result.isErr()) {
+    return {
+      feedAddress,
+      exists: false,
+      error: result.error.message,
+    };
+  }
+
+  if (!result.value) {
+    return {
+      feedAddress,
+      exists: false,
+      error: buildFeedNotFoundMessage(feedId, network),
+    };
+  }
+
+  return { feedAddress, exists: true, error: null };
+}
+
+export function buildFeedNotFoundMessage(
+  feedId: string | null | undefined,
+  network: LensNetwork = getLensNetwork(),
+): string {
+  const label = getLensNetworkLabel(network);
+  const display = truncateFeedId(resolveSongchainFeedAddress(feedId) ?? feedId ?? null);
+  return (
+    `Feed ${display} is not registered on ${label}. ` +
+    'Posts target a Lens feed contract, not an app contract. ' +
+    'Set NEXT_PUBLIC_SONGCHAIN_APP_ID to your Lens app and omit FEED_ID to auto-resolve, ' +
+    'or set NEXT_PUBLIC_SONGCHAIN_FEED_ID to a feed address from the app dashboard.'
+  );
+}
+
+export function formatLensFeedPostError(
+  error: unknown,
+  feedId: string | null | undefined,
+  network: LensNetwork = getLensNetwork(),
+): string {
+  const message = getOrbErrorMessage(error);
+  const lower = message.toLowerCase();
+
+  if (lower.includes('feed does not exist') || lower.includes('feed is not registered')) {
+    return buildFeedNotFoundMessage(feedId, network);
+  }
+
+  return message;
+}

--- a/lib/songchain/lens-graph.ts
+++ b/lib/songchain/lens-graph.ts
@@ -1,0 +1,69 @@
+import { fetchGraph } from '@lens-protocol/client/actions';
+import { evmAddress } from '@lens-protocol/types';
+import { createLensClient } from '@/lib/sdk/lens/create-client';
+import { getLensNetwork, type LensNetwork } from '@/lib/sdk/lens/chains';
+import {
+  extractLensContractAddress,
+  getLensContractAddressError,
+} from '@/lib/sdk/lens/primitive-id';
+import { getLensNetworkLabel, truncateFeedId } from '@/lib/songchain/feed-diagnostics';
+
+export type LensGraphCheckResult = {
+  graphAddress: `0x${string}` | null;
+  exists: boolean;
+  error: string | null;
+};
+
+export function resolveSongchainGraphAddress(
+  graphId: string | null | undefined,
+): `0x${string}` | null {
+  return extractLensContractAddress(graphId);
+}
+
+export async function checkLensGraphExists(
+  graphId: string | null | undefined,
+  network: LensNetwork = getLensNetwork(),
+): Promise<LensGraphCheckResult> {
+  const graphAddress = resolveSongchainGraphAddress(graphId);
+  if (!graphAddress) {
+    return {
+      graphAddress: null,
+      exists: false,
+      error: getLensContractAddressError(graphId, 'Graph contract ID'),
+    };
+  }
+
+  const client = createLensClient();
+  const result = await fetchGraph(client, { graph: evmAddress(graphAddress) });
+
+  if (result.isErr()) {
+    return {
+      graphAddress,
+      exists: false,
+      error: result.error.message,
+    };
+  }
+
+  if (!result.value) {
+    return {
+      graphAddress,
+      exists: false,
+      error: buildGraphNotFoundMessage(graphId, network),
+    };
+  }
+
+  return { graphAddress, exists: true, error: null };
+}
+
+export function buildGraphNotFoundMessage(
+  graphId: string | null | undefined,
+  network: LensNetwork = getLensNetwork(),
+): string {
+  const label = getLensNetworkLabel(network);
+  const display = truncateFeedId(resolveSongchainGraphAddress(graphId) ?? graphId ?? null);
+  return (
+    `Graph ${display} is not registered on ${label}. ` +
+    'Set NEXT_PUBLIC_SONGCHAIN_GRAPH_ID to your Lens graph contract, ' +
+    'or NEXT_PUBLIC_SONGCHAIN_APP_ID to resolve it from the app.'
+  );
+}

--- a/lib/songchain/resolve-lens-app.test.ts
+++ b/lib/songchain/resolve-lens-app.test.ts
@@ -128,6 +128,21 @@ describe('resolveSongchainConfig', () => {
     expect(resolved.resolutionNotes.some((n) => n.includes('not found'))).toBe(true);
   });
 
+  it('marks config disabled when only app id is set and fetchApp throws', async () => {
+    const app = '0x3412c2509eef4f9a133e6d3638b9b3c06fc30111';
+
+    fetchAppMock.mockRejectedValue(new Error('network timeout'));
+
+    const resolved = await resolveSongchainConfig({
+      ...baseConfig,
+      enabled: true,
+      appId: app,
+    });
+
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.resolutionNotes.some((n) => n.includes('network error'))).toBe(true);
+  });
+
   it('treats lens existence check failures as missing', async () => {
     fetchFeedMock.mockRejectedValue(new Error('network timeout'));
 

--- a/lib/songchain/resolve-lens-app.test.ts
+++ b/lib/songchain/resolve-lens-app.test.ts
@@ -107,4 +107,38 @@ describe('resolveSongchainConfig', () => {
     expect(resolved.graphId).toBe(graph);
     expect(resolved.resolutionNotes.some((n) => n.includes('graph'))).toBe(true);
   });
+
+  it('marks config disabled when only app id is set and fetchApp fails', async () => {
+    const app = '0x3412c2509eef4f9a133e6d3638b9b3c06fc30111';
+
+    fetchAppMock.mockResolvedValue({
+      isOk: () => false,
+      isErr: () => true,
+      value: null,
+    });
+
+    const resolved = await resolveSongchainConfig({
+      ...baseConfig,
+      enabled: true,
+      appId: app,
+    });
+
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.publicFeedId).toBeNull();
+    expect(resolved.resolutionNotes.some((n) => n.includes('not found'))).toBe(true);
+  });
+
+  it('treats lens existence check failures as missing', async () => {
+    fetchFeedMock.mockRejectedValue(new Error('network timeout'));
+
+    const resolved = await resolveSongchainConfig({
+      ...baseConfig,
+      publicFeedId: '0xabc0000000000000000000000000000000000001',
+    });
+
+    expect(resolved.appId).toBeNull();
+    expect(resolved.publicFeedId).toBe(
+      '0xabc0000000000000000000000000000000000001',
+    );
+  });
 });

--- a/lib/songchain/resolve-lens-app.test.ts
+++ b/lib/songchain/resolve-lens-app.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const fetchAppMock = vi.fn();
+const fetchAppFeedsMock = vi.fn();
+const fetchFeedMock = vi.fn();
+
+vi.mock('@lens-protocol/client/actions', () => ({
+  fetchApp: (...args: unknown[]) => fetchAppMock(...args),
+  fetchAppFeeds: (...args: unknown[]) => fetchAppFeedsMock(...args),
+  fetchFeed: (...args: unknown[]) => fetchFeedMock(...args),
+}));
+
+vi.mock('@/lib/sdk/lens/create-client', () => ({
+  createLensClient: () => ({}),
+}));
+
+import { resolveSongchainConfig } from './resolve-lens-app';
+import type { SongchainConfig } from './config';
+
+const baseConfig: SongchainConfig = {
+  enabled: true,
+  appId: null,
+  publicFeedId: null,
+  exclusiveFeedId: null,
+  groupId: null,
+  graphId: null,
+  hallidayApiKey: null,
+  hallidayOutputAsset: 'lens:0x0',
+  hallidayInputAssets: ['usd'],
+  hallidaySandbox: false,
+};
+
+describe('resolveSongchainConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects app address mistakenly set as public feed id', async () => {
+    const app = '0x3412c2509eef4f9a133e6d3638b9b3c06fc30111';
+    const defaultFeed = '0x3c336f772167d789d8f781a7002c33451120d74d';
+    const publicFeed = '0xcb5e109ffc0e15565082d78e68dddf2573703580';
+
+    fetchFeedMock.mockImplementation(async (_client, req) => ({
+      isOk: () => true,
+      isErr: () => false,
+      value:
+        String(req.feed).toLowerCase() === defaultFeed
+          ? { address: defaultFeed }
+          : null,
+    }));
+    fetchAppMock.mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        defaultFeedAddress: defaultFeed,
+        graphAddress: '0x2b36706e8e352a273c34d108a5854a55cb2302a6',
+      },
+    });
+    fetchAppFeedsMock.mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        items: [{ feed: defaultFeed }, { feed: publicFeed }],
+      },
+    });
+
+    const resolved = await resolveSongchainConfig({
+      ...baseConfig,
+      publicFeedId: app,
+      exclusiveFeedId: defaultFeed,
+    });
+
+    expect(resolved.appId).toBe(app);
+    expect(resolved.publicFeedId).toBe(publicFeed);
+    expect(resolved.exclusiveFeedId).toBe(defaultFeed);
+    expect(resolved.resolutionNotes.some((n) => n.includes('app address'))).toBe(true);
+  });
+
+  it('resolves graph from app when graph id is omitted', async () => {
+    const app = '0x3412c2509eef4f9a133e6d3638b9b3c06fc30111';
+    const graph = '0x2b36706e8e352a273c34d108a5854a55cb2302a6';
+
+    fetchFeedMock.mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: { address: '0xfeed' },
+    });
+    fetchAppMock.mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        defaultFeedAddress: '0xfeed',
+        graphAddress: graph,
+      },
+    });
+    fetchAppFeedsMock.mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: { items: [{ feed: '0xfeed' }] },
+    });
+
+    const resolved = await resolveSongchainConfig({
+      ...baseConfig,
+      appId: app,
+    });
+
+    expect(resolved.graphId).toBe(graph);
+    expect(resolved.resolutionNotes.some((n) => n.includes('graph'))).toBe(true);
+  });
+});

--- a/lib/songchain/resolve-lens-app.ts
+++ b/lib/songchain/resolve-lens-app.ts
@@ -15,16 +15,56 @@ function normalizeAddress(value: string | null | undefined): string | null {
   return normalizeLensPrimitiveId(value);
 }
 
+function hasSongchainPrimitives(parts: {
+  publicFeedId: string | null;
+  exclusiveFeedId: string | null;
+  groupId: string | null;
+  graphId: string | null;
+}): boolean {
+  return Boolean(
+    parts.publicFeedId ||
+      parts.exclusiveFeedId ||
+      parts.groupId ||
+      parts.graphId,
+  );
+}
+
+function buildResolvedConfig(
+  config: SongchainConfig,
+  resolved: {
+    appId: string | null;
+    publicFeedId: string | null;
+    exclusiveFeedId: string | null;
+    groupId: string | null;
+    graphId: string | null;
+    resolutionNotes: string[];
+  },
+): ResolvedSongchainConfig {
+  return {
+    ...config,
+    ...resolved,
+    enabled: hasSongchainPrimitives(resolved),
+  };
+}
+
 async function lensAppExists(appAddress: string): Promise<boolean> {
-  const client = createLensClient();
-  const result = await fetchApp(client, { app: evmAddress(appAddress) });
-  return result.isOk() && !!result.value;
+  try {
+    const client = createLensClient();
+    const result = await fetchApp(client, { app: evmAddress(appAddress) });
+    return result.isOk() && !!result.value;
+  } catch {
+    return false;
+  }
 }
 
 async function lensFeedExists(feedAddress: string): Promise<boolean> {
-  const client = createLensClient();
-  const result = await fetchFeed(client, { feed: evmAddress(feedAddress) });
-  return result.isOk() && !!result.value;
+  try {
+    const client = createLensClient();
+    const result = await fetchFeed(client, { feed: evmAddress(feedAddress) });
+    return result.isOk() && !!result.value;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -62,22 +102,42 @@ export async function resolveSongchainConfig(
   }
 
   if (!appId) {
-    return {
-      ...config,
+    return buildResolvedConfig(config, {
       appId: null,
       publicFeedId,
       exclusiveFeedId,
       groupId,
       graphId,
       resolutionNotes: notes,
-    };
+    });
   }
 
   const client = createLensClient();
-  const appResult = await fetchApp(client, { app: evmAddress(appId) });
+  let appResult;
+  try {
+    appResult = await fetchApp(client, { app: evmAddress(appId) });
+  } catch {
+    notes.push(`Lens app ${appId} could not be loaded (network error).`);
+    return buildResolvedConfig(config, {
+      appId,
+      publicFeedId,
+      exclusiveFeedId,
+      groupId,
+      graphId,
+      resolutionNotes: notes,
+    });
+  }
+
   if (appResult.isErr() || !appResult.value) {
     notes.push(`Lens app ${appId} was not found on this network.`);
-    return { ...config, appId, publicFeedId, exclusiveFeedId, groupId, graphId, resolutionNotes: notes };
+    return buildResolvedConfig(config, {
+      appId,
+      publicFeedId,
+      exclusiveFeedId,
+      groupId,
+      graphId,
+      resolutionNotes: notes,
+    });
   }
 
   const app = appResult.value;
@@ -118,14 +178,12 @@ export async function resolveSongchainConfig(
     notes.push('Public feed env matched the app contract; substituted the app feed address.');
   }
 
-  return {
-    ...config,
-    enabled: Boolean(publicFeedId || exclusiveFeedId || groupId || graphId),
+  return buildResolvedConfig(config, {
     appId,
     publicFeedId,
     exclusiveFeedId,
     groupId,
     graphId,
     resolutionNotes: notes,
-  };
+  });
 }

--- a/lib/songchain/resolve-lens-app.ts
+++ b/lib/songchain/resolve-lens-app.ts
@@ -1,0 +1,131 @@
+import { fetchApp, fetchAppFeeds, fetchFeed } from '@lens-protocol/client/actions';
+import { evmAddress } from '@lens-protocol/types';
+import { createLensClient } from '@/lib/sdk/lens/create-client';
+import { normalizeLensPrimitiveId } from '@/lib/sdk/lens/primitive-id';
+import type { SongchainConfig } from '@/lib/songchain/config';
+
+export type ResolvedSongchainConfig = SongchainConfig & {
+  /** Lens app contract when configured or inferred. */
+  appId: string | null;
+  /** Human-readable notes from app/feed resolution (server diagnostics). */
+  resolutionNotes: string[];
+};
+
+function normalizeAddress(value: string | null | undefined): string | null {
+  return normalizeLensPrimitiveId(value);
+}
+
+async function lensAppExists(appAddress: string): Promise<boolean> {
+  const client = createLensClient();
+  const result = await fetchApp(client, { app: evmAddress(appAddress) });
+  return result.isOk() && !!result.value;
+}
+
+async function lensFeedExists(feedAddress: string): Promise<boolean> {
+  const client = createLensClient();
+  const result = await fetchFeed(client, { feed: evmAddress(feedAddress) });
+  return result.isOk() && !!result.value;
+}
+
+/**
+ * Resolves Songchain feed IDs from a Lens app when env points at the app contract
+ * (common mistake) or when explicit feed IDs are omitted.
+ */
+export async function resolveSongchainConfig(
+  config: SongchainConfig,
+): Promise<ResolvedSongchainConfig> {
+  const notes: string[] = [];
+  let appId = normalizeAddress(config.appId);
+  let publicFeedId = normalizeAddress(config.publicFeedId);
+  let exclusiveFeedId = normalizeAddress(config.exclusiveFeedId);
+  const groupId = normalizeAddress(config.groupId);
+  let graphId = normalizeAddress(config.graphId);
+
+  if (!appId && publicFeedId && !(await lensFeedExists(publicFeedId))) {
+    if (await lensAppExists(publicFeedId)) {
+      notes.push(
+        'NEXT_PUBLIC_SONGCHAIN_FEED_ID is a Lens app address; resolving feeds from the app.',
+      );
+      appId = publicFeedId;
+      publicFeedId = null;
+    }
+  }
+
+  if (!appId && exclusiveFeedId && !(await lensFeedExists(exclusiveFeedId))) {
+    if (await lensAppExists(exclusiveFeedId)) {
+      notes.push(
+        'NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID is a Lens app address; resolving from the app.',
+      );
+      appId = exclusiveFeedId;
+      exclusiveFeedId = null;
+    }
+  }
+
+  if (!appId) {
+    return {
+      ...config,
+      appId: null,
+      publicFeedId,
+      exclusiveFeedId,
+      groupId,
+      graphId,
+      resolutionNotes: notes,
+    };
+  }
+
+  const client = createLensClient();
+  const appResult = await fetchApp(client, { app: evmAddress(appId) });
+  if (appResult.isErr() || !appResult.value) {
+    notes.push(`Lens app ${appId} was not found on this network.`);
+    return { ...config, appId, publicFeedId, exclusiveFeedId, groupId, graphId, resolutionNotes: notes };
+  }
+
+  const app = appResult.value;
+  const defaultFeed = normalizeAddress(app.defaultFeedAddress ?? null);
+  const appGraph = normalizeAddress(app.graphAddress ?? null);
+
+  if (!graphId && appGraph) {
+    graphId = appGraph;
+    notes.push(`Using app graph ${appGraph} for Songchain follows.`);
+  }
+
+  const feedsResult = await fetchAppFeeds(client, { app: evmAddress(appId) });
+  const appFeedIds = feedsResult.isOk()
+    ? feedsResult.value.items
+        .map((item) => normalizeAddress(String(item.feed)))
+        .filter((id): id is string => !!id)
+    : [];
+
+  if (!exclusiveFeedId && defaultFeed) {
+    exclusiveFeedId = defaultFeed;
+    notes.push(`Using app default feed ${defaultFeed} for the exclusive feed tab.`);
+  }
+
+  if (!publicFeedId) {
+    const alternate = appFeedIds.find(
+      (feedId) => feedId.toLowerCase() !== exclusiveFeedId?.toLowerCase(),
+    );
+    publicFeedId = alternate ?? defaultFeed;
+    if (publicFeedId) {
+      notes.push(`Using app-linked feed ${publicFeedId} for the public feed tab.`);
+    }
+  }
+
+  if (publicFeedId?.toLowerCase() === appId.toLowerCase()) {
+    publicFeedId = appFeedIds.find(
+      (feedId) => feedId.toLowerCase() !== exclusiveFeedId?.toLowerCase(),
+    ) ?? defaultFeed;
+    notes.push('Public feed env matched the app contract; substituted the app feed address.');
+  }
+
+  return {
+    ...config,
+    enabled: Boolean(publicFeedId || exclusiveFeedId || groupId || graphId),
+    appId,
+    publicFeedId,
+    exclusiveFeedId,
+    groupId,
+    graphId,
+    resolutionNotes: notes,
+  };
+}


### PR DESCRIPTION
## Summary
- Require Orb refresh tokens before enabling Songchain writes; harden QR sign-in and session sync so incomplete sessions clear instead of failing at post time.
- Validate Lens feed/graph contracts before post/load; distinguish app vs feed env mistakes and auto-resolve feeds/graph from `NEXT_PUBLIC_SONGCHAIN_APP_ID` when set.
- Add Songchain Graph tab with follow/unfollow on the configured social graph, plus Follow buttons on post cards.

## Test plan
- [ ] Sign in with Orb on `/songchain` and confirm Post is disabled until refresh token is present
- [ ] Post to public and exclusive feeds with configured feed contract addresses
- [ ] Join group, follow a creator on the Graph tab, unfollow from the graph panel
- [ ] Hit `/api/songchain/config-check` and verify `ok: true` with feeds/graph registered
- [ ] Run `npx vitest run lib/songchain/ lib/sdk/orb/ hooks/useLensOrbWrite.test.ts`


Made with [Cursor](https://cursor.com)