### PR TITLE
Fix mobile nav, Songchain UX, video mute, and Orb link conflicts

### DIFF
--- a/app/api/creator-profiles/link-orb/route.test.ts
+++ b/app/api/creator-profiles/link-orb/route.test.ts
@@ -10,7 +10,7 @@ const ORB_AUTH_ID = 'orb-auth-123';
 const mockGetAccountFromAccessToken = vi.fn();
 const mockRequireWalletAuthFor = vi.fn();
 const mockMaybeSingle = vi.fn();
-const mockUpdateEq = vi.fn();
+const mockUpdateIn = vi.fn();
 const mockUpsert = vi.fn();
 
 vi.mock('botid/server', () => ({
@@ -51,7 +51,7 @@ vi.mock('@/lib/sdk/supabase/service', () => ({
         }),
       }),
       update: () => ({
-        eq: mockUpdateEq,
+        in: mockUpdateIn,
       }),
       upsert: mockUpsert,
     }),
@@ -77,7 +77,7 @@ describe('link-orb POST security', () => {
     mockGetAccountFromAccessToken.mockReturnValue(TOKEN_LENS);
     mockRequireWalletAuthFor.mockResolvedValue({ address: OWNER });
     mockMaybeSingle.mockResolvedValue({ data: null, error: null });
-    mockUpdateEq.mockResolvedValue({ error: null });
+    mockUpdateIn.mockResolvedValue({ error: null });
     mockUpsert.mockReturnValue({
       select: () => ({
         single: async () => ({
@@ -178,7 +178,7 @@ describe('link-orb POST security', () => {
 
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(mockUpdateEq).toHaveBeenCalledWith('owner_address', STALE_OWNER);
+    expect(mockUpdateIn).toHaveBeenCalledWith('owner_address', [STALE_OWNER]);
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         owner_address: OWNER,

--- a/app/api/creator-profiles/link-orb/route.test.ts
+++ b/app/api/creator-profiles/link-orb/route.test.ts
@@ -4,9 +4,13 @@ import { NextRequest } from 'next/server';
 const TOKEN_LENS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const OTHER_LENS = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const OWNER = '0xcccccccccccccccccccccccccccccccccccccccc';
+const STALE_OWNER = '0xdddddddddddddddddddddddddddddddddddddddd';
+const ORB_AUTH_ID = 'orb-auth-123';
 
 const mockGetAccountFromAccessToken = vi.fn();
 const mockRequireWalletAuthFor = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpdateEq = vi.fn();
 const mockUpsert = vi.fn();
 
 vi.mock('botid/server', () => ({
@@ -41,6 +45,14 @@ vi.mock('@/lib/auth/require-wallet', () => ({
 vi.mock('@/lib/sdk/supabase/service', () => ({
   supabaseService: {
     from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+      update: () => ({
+        eq: mockUpdateEq,
+      }),
       upsert: mockUpsert,
     }),
   },
@@ -64,6 +76,8 @@ describe('link-orb POST security', () => {
   beforeEach(() => {
     mockGetAccountFromAccessToken.mockReturnValue(TOKEN_LENS);
     mockRequireWalletAuthFor.mockResolvedValue({ address: OWNER });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockUpdateEq.mockResolvedValue({ error: null });
     mockUpsert.mockReturnValue({
       select: () => ({
         single: async () => ({
@@ -143,5 +157,61 @@ describe('link-orb POST security', () => {
       }),
       { onConflict: 'owner_address' },
     );
+  });
+
+  it('clears stale orb link on another profile before upserting', async () => {
+    mockMaybeSingle
+      .mockResolvedValueOnce({
+        data: { owner_address: STALE_OWNER },
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: null, error: null });
+
+    const response = await POST(
+      linkOrbRequest({
+        accessToken: 'valid-token',
+        authenticationId: ORB_AUTH_ID,
+        owner_address: OWNER,
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockUpdateEq).toHaveBeenCalledWith('owner_address', STALE_OWNER);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner_address: OWNER,
+        orb_account_id: ORB_AUTH_ID,
+      }),
+      { onConflict: 'owner_address' },
+    );
+  });
+
+  it('returns 409 with friendly message on duplicate orb_account_id upsert', async () => {
+    mockUpsert.mockReturnValue({
+      select: () => ({
+        single: async () => ({
+          data: null,
+          error: {
+            code: '23505',
+            message:
+              'duplicate key value violates unique constraint "creator_profiles_orb_account_id_key"',
+          },
+        }),
+      }),
+    });
+
+    const response = await POST(
+      linkOrbRequest({
+        accessToken: 'valid-token',
+        owner_address: OWNER,
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('already linked');
   });
 });

--- a/app/api/creator-profiles/link-orb/route.ts
+++ b/app/api/creator-profiles/link-orb/route.ts
@@ -126,7 +126,7 @@ export async function POST(request: NextRequest) {
       existingByOrb?.owner_address &&
       existingByOrb.owner_address.toLowerCase() !== ownerAddress
     ) {
-      staleOwners.add(existingByOrb.owner_address.toLowerCase());
+      staleOwners.add(existingByOrb.owner_address);
     }
 
     const { data: existingByLens, error: lensLookupError } = await supabaseService
@@ -147,10 +147,10 @@ export async function POST(request: NextRequest) {
       existingByLens?.owner_address &&
       existingByLens.owner_address.toLowerCase() !== ownerAddress
     ) {
-      staleOwners.add(existingByLens.owner_address.toLowerCase());
+      staleOwners.add(existingByLens.owner_address);
     }
 
-    for (const staleOwner of staleOwners) {
+    if (staleOwners.size > 0) {
       const { error: clearError } = await supabaseService
         .from('creator_profiles')
         .update({
@@ -160,7 +160,7 @@ export async function POST(request: NextRequest) {
           lens_avatar_uri: null,
           updated_at: new Date().toISOString(),
         })
-        .eq('owner_address', staleOwner);
+        .in('owner_address', Array.from(staleOwners));
 
       if (clearError) {
         serverLogger.error('[link-orb] failed to clear previous orb link:', clearError);

--- a/app/api/creator-profiles/link-orb/route.ts
+++ b/app/api/creator-profiles/link-orb/route.ts
@@ -106,6 +106,71 @@ export async function POST(request: NextRequest) {
       if (!body.avatar_url) payload.avatar_url = lensAvatarUri;
     }
 
+    const staleOwners = new Set<string>();
+
+    const { data: existingByOrb, error: orbLookupError } = await supabaseService
+      .from('creator_profiles')
+      .select('owner_address')
+      .eq('orb_account_id', orbAccountId)
+      .maybeSingle();
+
+    if (orbLookupError) {
+      serverLogger.error('[link-orb] orb lookup failed:', orbLookupError);
+      return NextResponse.json(
+        { success: false, error: orbLookupError.message },
+        { status: 500 },
+      );
+    }
+
+    if (
+      existingByOrb?.owner_address &&
+      existingByOrb.owner_address.toLowerCase() !== ownerAddress
+    ) {
+      staleOwners.add(existingByOrb.owner_address.toLowerCase());
+    }
+
+    const { data: existingByLens, error: lensLookupError } = await supabaseService
+      .from('creator_profiles')
+      .select('owner_address')
+      .eq('lens_account_id', resolvedLensAccount)
+      .maybeSingle();
+
+    if (lensLookupError) {
+      serverLogger.error('[link-orb] lens lookup failed:', lensLookupError);
+      return NextResponse.json(
+        { success: false, error: lensLookupError.message },
+        { status: 500 },
+      );
+    }
+
+    if (
+      existingByLens?.owner_address &&
+      existingByLens.owner_address.toLowerCase() !== ownerAddress
+    ) {
+      staleOwners.add(existingByLens.owner_address.toLowerCase());
+    }
+
+    for (const staleOwner of staleOwners) {
+      const { error: clearError } = await supabaseService
+        .from('creator_profiles')
+        .update({
+          orb_account_id: null,
+          lens_account_id: null,
+          lens_handle: null,
+          lens_avatar_uri: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('owner_address', staleOwner);
+
+      if (clearError) {
+        serverLogger.error('[link-orb] failed to clear previous orb link:', clearError);
+        return NextResponse.json(
+          { success: false, error: clearError.message },
+          { status: 500 },
+        );
+      }
+    }
+
     const { data, error } = await supabaseService
       .from('creator_profiles')
       .upsert(payload, { onConflict: 'owner_address' })
@@ -114,9 +179,17 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       serverLogger.error('[link-orb] upsert failed:', error);
+      const isDuplicateOrb =
+        error.code === '23505' ||
+        error.message.includes('creator_profiles_orb_account_id_key');
       return NextResponse.json(
-        { success: false, error: error.message },
-        { status: 500 },
+        {
+          success: false,
+          error: isDuplicateOrb
+            ? 'This Orb account is already linked to another profile. Sign in with the wallet that originally linked it, or contact support.'
+            : error.message,
+        },
+        { status: isDuplicateOrb ? 409 : 500 },
       );
     }
 

--- a/app/api/link-preview/route.ts
+++ b/app/api/link-preview/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type LinkPreview = {
+  title?: string;
+  description?: string;
+  image?: string;
+  domain: string;
+};
+
+const CACHE = new Map<string, { data: LinkPreview; expires: number }>();
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+function extractMeta(html: string, property: string): string | undefined {
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']+)["']`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${property}["']`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+name=["']${property}["'][^>]+content=["']([^"']+)["']`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+name=["']${property}["']`,
+      "i",
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return match[1].trim();
+  }
+
+  return undefined;
+}
+
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host.startsWith("127.") ||
+    host.startsWith("10.") ||
+    host.startsWith("192.168.") ||
+    host === "0.0.0.0" ||
+    host === "[::1]"
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const rawUrl = request.nextUrl.searchParams.get("url");
+  if (!rawUrl) {
+    return NextResponse.json({ error: "Missing url" }, { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("Invalid protocol");
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid url" }, { status: 400 });
+  }
+
+  if (isBlockedHost(parsed.hostname)) {
+    return NextResponse.json({ error: "Blocked url" }, { status: 400 });
+  }
+
+  const cached = CACHE.get(rawUrl);
+  if (cached && cached.expires > Date.now()) {
+    return NextResponse.json(cached.data);
+  }
+
+  try {
+    const response = await fetch(rawUrl, {
+      headers: {
+        "User-Agent": "CreativeTV-LinkPreview/1.0",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      signal: AbortSignal.timeout(8000),
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "Failed to fetch url" }, { status: 502 });
+    }
+
+    const html = await response.text();
+    const title =
+      extractMeta(html, "og:title") ||
+      html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();
+    const description =
+      extractMeta(html, "og:description") || extractMeta(html, "description");
+    const image = extractMeta(html, "og:image");
+
+    const data: LinkPreview = {
+      title,
+      description,
+      image,
+      domain: parsed.hostname,
+    };
+
+    CACHE.set(rawUrl, { data, expires: Date.now() + CACHE_TTL_MS });
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch preview" }, { status: 502 });
+  }
+}

--- a/app/api/link-preview/route.ts
+++ b/app/api/link-preview/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import dns from "node:dns";
 
 type LinkPreview = {
   title?: string;
@@ -9,6 +10,7 @@ type LinkPreview = {
 
 const CACHE = new Map<string, { data: LinkPreview; expires: number }>();
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const MAX_HTML_BYTES = 2 * 1024 * 1024;
 
 function extractMeta(html: string, property: string): string | undefined {
   const patterns = [
@@ -38,17 +40,53 @@ function extractMeta(html: string, property: string): string | undefined {
   return undefined;
 }
 
-function isBlockedHost(hostname: string): boolean {
+function isPrivateIp(ip: string): boolean {
+  if (
+    ip.startsWith("127.") ||
+    ip.startsWith("10.") ||
+    ip.startsWith("192.168.") ||
+    ip.startsWith("169.254.") ||
+    ip.startsWith("0.")
+  ) {
+    return true;
+  }
+
+  if (ip.startsWith("172.")) {
+    const secondOctet = parseInt(ip.split(".")[1] ?? "", 10);
+    if (secondOctet >= 16 && secondOctet <= 31) {
+      return true;
+    }
+  }
+
+  if (
+    ip === "::1" ||
+    ip.startsWith("fe80:") ||
+    ip.startsWith("fc00:") ||
+    ip.startsWith("fd00:")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function isBlockedHost(hostname: string): Promise<boolean> {
   const host = hostname.toLowerCase();
-  return (
+  const isLocalString =
     host === "localhost" ||
     host.endsWith(".local") ||
-    host.startsWith("127.") ||
-    host.startsWith("10.") ||
-    host.startsWith("192.168.") ||
     host === "0.0.0.0" ||
-    host === "[::1]"
-  );
+    host === "[::1]";
+
+  if (isLocalString) return true;
+
+  try {
+    const addresses = await dns.promises.lookup(hostname, { all: true });
+    if (addresses.length === 0) return true;
+    return addresses.some(({ address }) => isPrivateIp(address));
+  } catch {
+    return true;
+  }
 }
 
 export async function GET(request: NextRequest) {
@@ -67,7 +105,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid url" }, { status: 400 });
   }
 
-  if (isBlockedHost(parsed.hostname)) {
+  if (await isBlockedHost(parsed.hostname)) {
     return NextResponse.json({ error: "Blocked url" }, { status: 400 });
   }
 
@@ -90,7 +128,24 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Failed to fetch url" }, { status: 502 });
     }
 
+    const contentType = response.headers.get("content-type") || "";
+    if (
+      !contentType.includes("text/html") &&
+      !contentType.includes("application/xhtml+xml")
+    ) {
+      return NextResponse.json({ error: "Invalid content type" }, { status: 400 });
+    }
+
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > MAX_HTML_BYTES) {
+      return NextResponse.json({ error: "File too large" }, { status: 400 });
+    }
+
     const html = await response.text();
+    if (html.length > MAX_HTML_BYTES) {
+      return NextResponse.json({ error: "File too large" }, { status: 400 });
+    }
+
     const title =
       extractMeta(html, "og:title") ||
       html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -13,7 +13,6 @@ import { HydrationSafe } from "@/components/ui/hydration-safe";
 import { Button } from "@/components/ui/button"; // Corrected import
 import {
   useAuthModal,
-  useLogout,
   useUser,
   useChain,
 } from "@account-kit/react";
@@ -48,9 +47,7 @@ import {
   type AccountDropdownHandle,
 } from "@/components/account-dropdown/AccountDropdown";
 import { MobileOrbSection } from "@/components/account-dropdown/MobileOrbSection";
-import { useOrbSession } from "@/context/OrbSessionContext";
 import { useUnifiedLogout } from "@/hooks/useUnifiedLogout";
-import { resetAppSession } from "@/lib/auth/session-recovery";
 import { shortenAddress } from "@/lib/utils/utils";
 import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerification";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
@@ -63,6 +60,10 @@ import { logger } from '@/lib/utils/logger';
 import { AnimatedMenuIcon } from "@/components/navbar/AnimatedMenuIcon";
 import { CreativePlatformAppsDrawer } from "@/components/navbar/CreativePlatformAppsDrawer";
 import { navIconButtonProps } from "@/components/navbar/navButtonStyles";
+import {
+  Sheet,
+  SheetContent,
+} from "@/components/ui/sheet";
 
 type UseUserResult = (AccountUser & { type: "eoa" | "sca" }) | null;
 
@@ -155,9 +156,7 @@ function NetworkStatus({ isConnected }: { isConnected: boolean }) {
 export default function Navbar() {
   const { openAuthModal } = useAuthModal();
   const user = useUser();
-  const { logout: walletLogout } = useLogout();
   const unifiedLogout = useUnifiedLogout();
-  const { logout: orbLogout } = useOrbSession();
   const { chain: currentChain, setChain, isSettingChain } = useChain();
   const {
     primaryAddress,
@@ -282,6 +281,7 @@ export default function Navbar() {
     }`;
 
   return (
+    <>
     <header className={headerClassName}>
       <div className="container mx-auto px-4 sm:px-6">
         <div className="flex h-16 items-center justify-between">
@@ -353,22 +353,22 @@ export default function Navbar() {
             </Button>
           </div>
 
-          {/* Mobile menu */}
-          <div
-            className={
-              "fixed inset-0 top-16 z-50 grid h-[calc(100vh-4rem)] grid-flow-row " +
-              "auto-rows-max overflow-auto p-4 pb-32 shadow-md md:hidden bg-white dark:bg-gray-900 " +
-              (isMenuOpen ? "animate-in slide-in-from-top-5" : "hidden")
-            }
-            aria-hidden={!isMenuOpen}
-            inert={!isMenuOpen}
-          >
-            <div
-              className={
-                "relative z-20 grid gap-4 rounded-md " +
-                "text-popover-foreground"
-              }
-            >
+        </div>
+      </div>
+    </header>
+
+    <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+      <SheetContent
+        side="top"
+        overlayClassName="z-[100] bg-black/50 md:hidden"
+        className={
+          "fixed inset-x-0 top-16 bottom-0 z-[101] h-auto w-full max-w-none " +
+          "border-0 p-4 pb-32 md:hidden overflow-y-auto bg-background " +
+          "[&>button]:hidden data-[state=closed]:slide-out-to-top " +
+          "data-[state=open]:slide-in-from-top"
+        }
+      >
+        <div className="relative grid gap-4 rounded-md text-popover-foreground">
               {/* User Account Section or Get Started */}
               <HydrationSafe>
                 {user ? (
@@ -633,7 +633,7 @@ export default function Navbar() {
                     )}
 
                     {/* Logout Button */}
-                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
                       <button
                         onClick={() => {
                           void unifiedLogout();
@@ -645,33 +645,13 @@ export default function Navbar() {
                         <LogOut className="mr-2 h-4 w-4" />
                         Logout
                       </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void resetAppSession({
-                            walletLogout: async () => {
-                              await walletLogout();
-                            },
-                            orbLogout,
-                          });
-                        }}
-                        className="flex w-full items-center rounded-md p-2 text-xs font-medium
-                            text-muted-foreground hover:bg-muted transition-colors"
-                      >
-                        Reset session (fix login loops)
-                      </button>
                     </div>
                   </>
                 )}
               </HydrationSafe>
-
-              {/* Navigation Links */}
-
-            </div>
-          </div>
-
         </div>
-      </div>
-    </header>
+      </SheetContent>
+    </Sheet>
+    </>
   );
 }

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -132,8 +132,8 @@ export function Player(props: {
       src={src}
       playbackId={playbackId}
       jwt={jwt}
-      autoPlay={true} // Autoplay for live streams
-      volume={0.5} // Start unmuted but low volume if possible, or muted if browser blocks
+      autoPlay={true}
+      volume={0}
       aspectRatio={16 / 9}
       lowLatency={true} // Force low latency for livestream
     >

--- a/components/Player/PreviewPlayer.tsx
+++ b/components/Player/PreviewPlayer.tsx
@@ -79,9 +79,6 @@ export const PreviewPlayer: React.FC<{
     const video = containerRef.current?.querySelector("video");
     if (video) {
       videoRef.current = video;
-
-      // Set initial volume and playback rate
-      video.volume = 0.5;
       video.playbackRate = 1.0;
     }
 
@@ -209,11 +206,6 @@ export const PreviewPlayer: React.FC<{
             title={title}
             playsInline
             controls={false}
-            onCanPlay={() => {
-              if (videoRef.current) {
-                videoRef.current.volume = 0.5;
-              }
-            }}
             onPlay={() => {
               setIsPlaying(true);
               setCurrentPlayingId(playerId);

--- a/components/Videos/VideoCard.tsx
+++ b/components/Videos/VideoCard.tsx
@@ -27,6 +27,7 @@ import { ShareDialog } from "./ShareDialog";
 import { useCreatorProfile } from "@/lib/hooks/metokens/useCreatorProfile";
 import { VideoBuyButton } from "./VideoBuyButton";
 import { logger } from '@/lib/utils/logger';
+import { useIsVideoAdmin } from "@/hooks/useIsVideoAdmin";
 
 
 interface VideoCardProps {
@@ -37,6 +38,7 @@ interface VideoCardProps {
 
 const VideoCard: React.FC<VideoCardProps> = ({ asset, playbackSources, priority = false }) => {
   const { currentPlayingId, setCurrentPlayingId } = useVideo();
+  const isVideoAdmin = useIsVideoAdmin();
   const [dbStatus, setDbStatus] = useState<"draft" | "published" | "minted" | "archived" | null>(null);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const playerRef = useRef<HTMLDivElement>(null);
@@ -227,13 +229,17 @@ const VideoCard: React.FC<VideoCardProps> = ({ asset, playbackSources, priority 
         <CardContent>
           <div className="my-2 flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Badge className={asset.status?.phase === "ready" ? "black" : "white"}>
-                {asset?.status?.phase}
-              </Badge>
-              {dbStatus && (
-                <Badge variant="secondary">
-                  {dbStatus}
-                </Badge>
+              {isVideoAdmin && (
+                <>
+                  <Badge className={asset.status?.phase === "ready" ? "black" : "white"}>
+                    {asset?.status?.phase}
+                  </Badge>
+                  {dbStatus && (
+                    <Badge variant="secondary">
+                      {dbStatus}
+                    </Badge>
+                  )}
+                </>
               )}
             </div>
             <VideoViewMetrics playbackId={asset.playbackId || ""} />

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -39,6 +39,7 @@ import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackS
 import { generateAccessKey, WebhookContext } from "@/lib/access-key";
 import { Skeleton } from "../ui/skeleton";
 import { Badge } from "../ui/badge";
+import { useIsVideoAdmin } from "@/hooks/useIsVideoAdmin";
 import { Button } from "../ui/button";
 import { fetchVideoAssetByPlaybackId } from "@/lib/utils/video-assets-client";
 import { getThumbnailUrl } from "@/lib/utils/thumbnail";
@@ -167,6 +168,7 @@ export default function VideoDetails({
   contractAddress,
   tokenId,
 }: VideoDetailsProps) {
+  const isVideoAdmin = useIsVideoAdmin();
   const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
   const [sourcesLoading, setSourcesLoading] = useState(true);
   const [sourcesError, setSourcesError] = useState<string | null>(null);
@@ -522,10 +524,10 @@ export default function VideoDetails({
         <div className="w-full space-y-6">
           <h1 className="text-2xl font-bold">{videoTitle || asset?.name}</h1>
           <div className="flex items-center gap-2 flex-wrap">
-            {asset?.status?.phase && (
+            {isVideoAdmin && asset?.status?.phase && (
               <Badge>{asset.status.phase}</Badge>
             )}
-            {dbStatus && <Badge variant="secondary">{dbStatus}</Badge>}
+            {isVideoAdmin && dbStatus && <Badge variant="secondary">{dbStatus}</Badge>}
             {livepeerAttestationId && (
               <Badge
                 variant="secondary"
@@ -592,6 +594,7 @@ export default function VideoDetails({
               <Player.Root
                 src={playbackSources}
                 playbackId={asset?.playbackId}
+                volume={0}
                 {...conditionalProps}
               >
                 <Player.Container className="aspect-video w-full overflow-hidden rounded-lg bg-gray-800">

--- a/components/Videos/VideoThumbnail.tsx
+++ b/components/Videos/VideoThumbnail.tsx
@@ -45,7 +45,7 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
   const [showPlayer, setShowPlayer] = useState(false);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [imageLoading, setImageLoading] = useState(true);
-  const [isMuted, setIsMuted] = useState(false); // Start unmuted as requested
+  const [isMuted, setIsMuted] = useState(true);
   const [retryCount, setRetryCount] = useState(0);
   const showPlayerRef = React.useRef(showPlayer);
   const observerRef = React.useRef<IntersectionObserver | null>(null);
@@ -198,36 +198,16 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
 
       vid.addEventListener('timeupdate', handleTimeUpdate);
 
-      // Attempt to play unmuted
-      vid.play().catch(err => {
-        // AbortError is expected when video is removed/unmounted
+      vid.muted = true;
+      setIsMuted(true);
+      vid.play().catch((err) => {
         if (err instanceof Error && err.name === 'AbortError') {
           return;
         }
         if (!isMounted || !previewVideoRef.current) return;
-
-        // NotAllowedError is expected when autoplay is blocked by browser policy
-        // This is normal browser behavior - we handle it by falling back to muted playback
-        const isAutoplayBlocked = err instanceof Error &&
-          (err.name === 'NotAllowedError' ||
-            err.message?.includes('user didn\'t interact') ||
-            err.message?.includes('play() failed'));
-
-        if (!isAutoplayBlocked) {
-          // Only log unexpected errors
-          logger.warn("Autoplay unmuted failed with unexpected error, trying muted", err);
+        if (err instanceof Error && err.name !== 'NotAllowedError') {
+          logger.error("Autoplay muted preview failed", err);
         }
-
-        // Fallback to muted playback (browsers allow muted autoplay)
-        vid.muted = true;
-        setIsMuted(true);
-        vid.play().catch(e => {
-          // AbortError is expected when video is removed/unmounted
-          // NotAllowedError on muted playback is also possible but less common
-          if (e instanceof Error && e.name !== 'AbortError' && e.name !== 'NotAllowedError') {
-            logger.error("Autoplay muted failed with unexpected error", e);
-          }
-        });
       });
 
       return () => {

--- a/components/songchain/CreativeTVLinkPreview.tsx
+++ b/components/songchain/CreativeTVLinkPreview.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Player, PlayerLoading } from "@/components/Player/Player";
+import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
+import { useCreativeTVUrlResolve } from "@/hooks/useCreativeTVUrlResolve";
+import { getCreativeTVEmbedUrlForParsed } from "@/lib/utils/creative-tv-url";
+import { getInternalHref } from "@/lib/utils/linkify-post-text";
+import type { Src } from "@livepeer/react";
+import { cn } from "@/lib/utils/utils";
+import { logger } from "@/lib/utils/logger";
+
+type CreativeTVLinkPreviewProps = {
+  url: string;
+  compact?: boolean;
+  className?: string;
+};
+
+export function CreativeTVLinkPreview({
+  url,
+  compact = false,
+  className,
+}: CreativeTVLinkPreviewProps) {
+  const { state, resolveFromInput } = useCreativeTVUrlResolve();
+  const [playbackSources, setPlaybackSources] = useState<Src[] | null>(null);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void resolveFromInput(url);
+  }, [url, resolveFromInput]);
+
+  useEffect(() => {
+    if (state.status !== "resolved") {
+      setPlaybackSources(null);
+      setPlayerError(null);
+      return;
+    }
+
+    const playbackId = state.result.playbackId;
+    const controller = new AbortController();
+
+    async function loadSources() {
+      try {
+        const sources = await getDetailPlaybackSource(playbackId, {
+          signal: controller.signal,
+        });
+        setPlaybackSources(sources);
+        if (!sources?.length) {
+          setPlayerError("Unable to load playback sources.");
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        logger.error("[CreativeTVLinkPreview] Failed to load playback sources:", error);
+        setPlayerError("Unable to load playback sources.");
+      }
+    }
+
+    void loadSources();
+    return () => controller.abort();
+  }, [state]);
+
+  const fallbackUrl =
+    state.status === "resolved"
+      ? state.result.fallbackUrl
+      : state.status === "fallback"
+        ? state.result.fallbackUrl
+        : undefined;
+
+  const iframeSrc = useMemo(() => {
+    const parsed =
+      state.status === "resolved"
+        ? state.result.parsed
+        : state.status === "fallback"
+          ? state.result.parsed
+          : undefined;
+
+    if (parsed) {
+      return getCreativeTVEmbedUrlForParsed(parsed) ?? fallbackUrl;
+    }
+
+    return fallbackUrl;
+  }, [state, fallbackUrl]);
+
+  const showIframeFallback =
+    state.status === "fallback" ||
+    (state.status === "resolved" && (Boolean(playerError) || !playbackSources?.length));
+
+  const resolvedTitle =
+    state.status === "resolved" ? state.result.title ?? "Creative TV Video" : "Creative TV Video";
+
+  if (state.status === "idle" || state.status === "loading") {
+    return (
+      <div className={cn("mt-2", compact && "mt-1", className)}>
+        <PlayerLoading title="Loading Creative TV preview..." />
+      </div>
+    );
+  }
+
+  if (state.status === "resolved" && !showIframeFallback) {
+    return (
+      <div className={cn("mt-2 overflow-hidden rounded-lg border", compact && "mt-1", className)}>
+        {playbackSources ? (
+          <Player
+            src={playbackSources}
+            title={resolvedTitle}
+            playbackId={state.result.playbackId}
+          />
+        ) : (
+          <div className="flex items-center justify-center py-6 text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading playback...
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (showIframeFallback && iframeSrc) {
+    return (
+      <div className={cn("mt-2 space-y-2", compact && "mt-1", className)}>
+        <div className="overflow-hidden rounded-lg border">
+          <iframe
+            src={iframeSrc}
+            title="Creative TV video"
+            className="aspect-video w-full border-0"
+            allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+            loading="lazy"
+          />
+        </div>
+        {fallbackUrl &&
+        state.status === "resolved" &&
+        (state.result.parsed.kind === "discover" ||
+          state.result.parsed.kind === "watch") ? (
+          <Link
+            href={getInternalHref(state.result.parsed)}
+            className="text-xs text-violet-400 hover:text-violet-300 hover:underline"
+          >
+            Open on Creative TV
+          </Link>
+        ) : null}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/components/songchain/ExternalLinkPreview.tsx
+++ b/components/songchain/ExternalLinkPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils/utils";
 
@@ -58,13 +58,14 @@ export function ExternalLinkPreview({
     return () => controller.abort();
   }, [url]);
 
-  const domain = preview?.domain ?? (() => {
+  const domain = useMemo(() => {
+    if (preview?.domain) return preview.domain;
     try {
       return new URL(url).hostname;
     } catch {
       return url;
     }
-  })();
+  }, [preview?.domain, url]);
 
   return (
     <span className={cn("block", className)}>

--- a/components/songchain/ExternalLinkPreview.tsx
+++ b/components/songchain/ExternalLinkPreview.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils/utils";
+
+type LinkPreviewData = {
+  title?: string;
+  description?: string;
+  image?: string;
+  domain: string;
+};
+
+type ExternalLinkPreviewProps = {
+  url: string;
+  compact?: boolean;
+  previewOnly?: boolean;
+  className?: string;
+};
+
+export function ExternalLinkPreview({
+  url,
+  compact = false,
+  previewOnly = false,
+  className,
+}: ExternalLinkPreviewProps) {
+  const [preview, setPreview] = useState<LinkPreviewData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadPreview() {
+      setLoading(true);
+      try {
+        const response = await fetch(
+          `/api/link-preview?url=${encodeURIComponent(url)}`,
+          { signal: controller.signal },
+        );
+        if (response.ok) {
+          const data = (await response.json()) as LinkPreviewData;
+          setPreview(data);
+        } else {
+          setPreview(null);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setPreview(null);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadPreview();
+    return () => controller.abort();
+  }, [url]);
+
+  const domain = preview?.domain ?? (() => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return url;
+    }
+  })();
+
+  return (
+    <span className={cn("block", className)}>
+      {!previewOnly ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 break-all text-violet-400 hover:text-violet-300 hover:underline"
+        >
+          {url}
+          <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span className="sr-only">(opens in new tab)</span>
+        </a>
+      ) : null}
+
+      {!compact && !loading && preview && (preview.title || preview.image) ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 block overflow-hidden rounded-lg border border-border/50 bg-muted/20 transition-colors hover:bg-muted/40"
+        >
+          {preview.image ? (
+            <div className="relative aspect-video w-full bg-muted">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={preview.image}
+                alt={preview.title ?? domain}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          ) : null}
+          <div className="space-y-1 p-3">
+            {preview.title ? (
+              <p className="line-clamp-2 text-sm font-medium text-foreground">
+                {preview.title}
+              </p>
+            ) : null}
+            {preview.description ? (
+              <p className="line-clamp-2 text-xs text-muted-foreground">
+                {preview.description}
+              </p>
+            ) : null}
+            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+              {domain}
+              <ExternalLink className="h-3 w-3" aria-hidden />
+            </p>
+          </div>
+        </a>
+      ) : null}
+    </span>
+  );
+}

--- a/components/songchain/SongchainAuthorTimeline.tsx
+++ b/components/songchain/SongchainAuthorTimeline.tsx
@@ -73,7 +73,12 @@ export function SongchainAuthorTimeline({
         )}
         <div className="space-y-4">
           {posts.map((post) => (
-            <SongchainPostCard key={post.id} post={post} compact />
+            <SongchainPostCard
+              key={post.id}
+              post={post}
+              compact
+              onReactionChange={load}
+            />
           ))}
         </div>
         {posts.length > 0 && (

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -11,6 +11,7 @@ type SongchainFeedSectionProps = {
   description: string;
   feedId: string | null;
   emptyDescription: string;
+  onPostUpdated?: () => void;
 };
 
 function FeedDiagnostics({
@@ -60,6 +61,7 @@ export function SongchainFeedSection({
   description,
   feedId,
   emptyDescription,
+  onPostUpdated,
 }: SongchainFeedSectionProps) {
   const { posts, loading, error, hasMore, reload, loadMore } = useSongchainFeed({
     feedId,
@@ -114,6 +116,7 @@ export function SongchainFeedSection({
               post={post}
               feedId={feedId}
               onReactionChange={reload}
+              onPostUpdated={onPostUpdated}
             />
           ))}
         </div>

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -77,6 +77,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Songchain feed"
             description="Posts from the main Songchain Lens feed (Orb)."
             feedId={config.publicFeedId}
+            onPostUpdated={bumpFeedRefresh}
             emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled, so publish a new post directly to this feed if it should appear here."
           />
         </TabsContent>
@@ -91,6 +92,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
             title="Exclusive feed"
             description="Members-only drops and announcements on Lens."
             feedId={config.exclusiveFeedId}
+            onPostUpdated={bumpFeedRefresh}
             emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
           />
         </TabsContent>

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -40,6 +40,7 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { groveService } from "@/lib/sdk/grove/service";
 import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { SongchainAuthorTimeline } from "@/components/songchain/SongchainAuthorTimeline";
+import { SongchainPostContent } from "@/components/songchain/SongchainPostContent";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
 
@@ -83,6 +84,7 @@ type SongchainPostCardProps = {
   feedId?: string | null;
   compact?: boolean;
   onReactionChange?: () => void;
+  onPostUpdated?: () => void;
 };
 
 export function SongchainPostCard({
@@ -90,6 +92,7 @@ export function SongchainPostCard({
   feedId,
   compact = false,
   onReactionChange,
+  onPostUpdated,
 }: SongchainPostCardProps) {
   const { canWrite, getSessionClient, promptWriteAccess, lensAccount } =
     useLensOrbWrite();
@@ -99,6 +102,7 @@ export function SongchainPostCard({
   const [commentText, setCommentText] = useState("");
   const [editOpen, setEditOpen] = useState(false);
   const [editText, setEditText] = useState("");
+  const [displayText, setDisplayText] = useState<string | null>(null);
   const [timelineOpen, setTimelineOpen] = useState(false);
   const [bookmarked, setBookmarked] = useState(false);
 
@@ -142,6 +146,12 @@ export function SongchainPostCard({
   useEffect(() => {
     if (showComments) void loadComments();
   }, [showComments, loadComments]);
+
+  useEffect(() => {
+    setDisplayText(null);
+  }, [content?.id, post]);
+
+  const resolvedPostText = displayText ?? postText(post);
 
   if (!content) return null;
 
@@ -235,8 +245,11 @@ export function SongchainPostCard({
         contentUri: uri(upload.url),
       });
       if (result.isErr()) throw new Error(result.error.message);
+      setDisplayText(trimmed);
       setEditOpen(false);
       toast.success("Post updated");
+      onPostUpdated?.();
+      window.setTimeout(() => onReactionChange?.(), 3000);
     });
 
   const handleDelete = () => {
@@ -253,10 +266,19 @@ export function SongchainPostCard({
     <>
       <article
         className={cn(
-          "flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card shadow-sm",
+          "relative flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card shadow-sm",
           compact && "text-sm",
+          pending === "edit" && "opacity-70",
         )}
       >
+        {pending === "edit" && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px]">
+            <div className="flex items-center gap-2 rounded-md bg-card px-3 py-2 text-sm shadow-sm">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Updating post…
+            </div>
+          </div>
+        )}
         {imageUrl && !compact && (
           <div className="relative aspect-video w-full bg-muted">
             <Image
@@ -276,10 +298,8 @@ export function SongchainPostCard({
           >
             {authorLabel(post)}
           </button>
-          {postText(post) && (
-            <p className="text-sm leading-relaxed whitespace-pre-wrap">
-              {postText(post)}
-            </p>
+          {resolvedPostText && (
+            <SongchainPostContent text={resolvedPostText} compact={compact} />
           )}
           <div className="mt-auto flex flex-wrap items-center gap-1 pt-2 border-t border-border/40">
             <span className="text-xs text-muted-foreground mr-auto">
@@ -378,7 +398,7 @@ export function SongchainPostCard({
                   {comments.map((c) => (
                     <li key={c.id} className="rounded bg-muted/40 p-2">
                       <span className="font-medium">{authorLabel(c)}: </span>
-                      {postText(c)}
+                      <SongchainPostContent text={postText(c)} compact />
                     </li>
                   ))}
                 </ul>
@@ -417,18 +437,35 @@ export function SongchainPostCard({
         onOpenChange={setTimelineOpen}
       />
 
-      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+      <Dialog
+        open={editOpen}
+        onOpenChange={(open) => {
+          if (pending !== "edit") setEditOpen(open);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit post</DialogTitle>
           </DialogHeader>
-          <Textarea
-            value={editText}
-            onChange={(e) => setEditText(e.target.value)}
-            rows={4}
-          />
+          {pending === "edit" ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Updating post…
+            </div>
+          ) : (
+            <Textarea
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              rows={4}
+              disabled={pending === "edit"}
+            />
+          )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setEditOpen(false)}
+              disabled={pending === "edit"}
+            >
               Cancel
             </Button>
             <Button
@@ -436,9 +473,13 @@ export function SongchainPostCard({
               onClick={submitEdit}
             >
               {pending === "edit" ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              ) : null}
-              Save
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Updating…
+                </>
+              ) : (
+                "Save"
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/components/songchain/SongchainPostContent.tsx
+++ b/components/songchain/SongchainPostContent.tsx
@@ -21,31 +21,19 @@ export function SongchainPostContent({
 }: SongchainPostContentProps) {
   const segments = useMemo(() => linkifyPostText(text), [text]);
 
-  const internalUrls = useMemo(
-    () =>
-      segments
-        .filter((segment) => segment.type === "internal")
-        .map((segment) => segment.value),
-    [segments],
-  );
+  const uniqueInternalUrls = useMemo(() => {
+    const urls = segments
+      .filter((segment) => segment.type === "internal")
+      .map((segment) => segment.value);
+    return Array.from(new Set(urls));
+  }, [segments]);
 
-  const uniqueInternalUrls = useMemo(
-    () => Array.from(new Set(internalUrls)),
-    [internalUrls],
-  );
-
-  const externalUrls = useMemo(
-    () =>
-      segments
-        .filter((segment) => segment.type === "external")
-        .map((segment) => segment.value),
-    [segments],
-  );
-
-  const uniqueExternalUrls = useMemo(
-    () => Array.from(new Set(externalUrls)),
-    [externalUrls],
-  );
+  const uniqueExternalUrls = useMemo(() => {
+    const urls = segments
+      .filter((segment) => segment.type === "external")
+      .map((segment) => segment.value);
+    return Array.from(new Set(urls));
+  }, [segments]);
 
   if (!text) return null;
 

--- a/components/songchain/SongchainPostContent.tsx
+++ b/components/songchain/SongchainPostContent.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { ExternalLink } from "lucide-react";
+import { linkifyPostText } from "@/lib/utils/linkify-post-text";
+import { CreativeTVLinkPreview } from "@/components/songchain/CreativeTVLinkPreview";
+import { ExternalLinkPreview } from "@/components/songchain/ExternalLinkPreview";
+import { cn } from "@/lib/utils/utils";
+
+type SongchainPostContentProps = {
+  text: string;
+  compact?: boolean;
+  className?: string;
+};
+
+export function SongchainPostContent({
+  text,
+  compact = false,
+  className,
+}: SongchainPostContentProps) {
+  const segments = useMemo(() => linkifyPostText(text), [text]);
+
+  const internalUrls = useMemo(
+    () =>
+      segments
+        .filter((segment) => segment.type === "internal")
+        .map((segment) => segment.value),
+    [segments],
+  );
+
+  const uniqueInternalUrls = useMemo(
+    () => Array.from(new Set(internalUrls)),
+    [internalUrls],
+  );
+
+  const externalUrls = useMemo(
+    () =>
+      segments
+        .filter((segment) => segment.type === "external")
+        .map((segment) => segment.value),
+    [segments],
+  );
+
+  const uniqueExternalUrls = useMemo(
+    () => Array.from(new Set(externalUrls)),
+    [externalUrls],
+  );
+
+  if (!text) return null;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <p
+        className={cn(
+          "text-sm leading-relaxed whitespace-pre-wrap",
+          compact && "text-xs",
+        )}
+      >
+        {segments.map((segment, index) => {
+          if (segment.type === "text") {
+            return <span key={`text-${index}`}>{segment.value}</span>;
+          }
+
+          if (segment.type === "internal") {
+            return (
+              <Link
+                key={`internal-${index}`}
+                href={segment.href}
+                className="break-all text-violet-400 hover:text-violet-300 hover:underline"
+              >
+                {segment.value}
+              </Link>
+            );
+          }
+
+          return (
+            <a
+              key={`external-${index}`}
+              href={segment.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 break-all text-violet-400 hover:text-violet-300 hover:underline"
+            >
+              {segment.value}
+              <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            </a>
+          );
+        })}
+      </p>
+
+      {!compact &&
+        uniqueInternalUrls.map((url) => (
+          <CreativeTVLinkPreview key={`preview-internal-${url}`} url={url} />
+        ))}
+
+      {!compact &&
+        uniqueExternalUrls.map((url) => (
+          <ExternalLinkPreview
+            key={`preview-external-${url}`}
+            url={url}
+            previewOnly
+          />
+        ))}
+    </div>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -71,14 +71,16 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  overlayClassName?: string;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, overlayClassName, children, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    <SheetOverlay className={overlayClassName} />
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}

--- a/hooks/useIsVideoAdmin.ts
+++ b/hooks/useIsVideoAdmin.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useMemo } from "react";
+import { useUser, useSmartAccountClient } from "@account-kit/react";
+import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
+import { VIDEO_ADMIN_ADDRESS } from "@/lib/constants/admin";
+
+export function useIsVideoAdmin(): boolean {
+  const user = useUser();
+  const { address: scaAddress } = useSmartAccountClient({});
+  const { account } = useModularAccount();
+
+  return useMemo(() => {
+    const admin = VIDEO_ADMIN_ADDRESS.toLowerCase();
+    const candidates = [
+      account?.address,
+      scaAddress,
+      user?.address,
+    ].filter(Boolean) as string[];
+
+    return candidates.some((address) => address.toLowerCase() === admin);
+  }, [account?.address, scaAddress, user?.address]);
+}

--- a/lib/constants/admin.ts
+++ b/lib/constants/admin.ts
@@ -1,0 +1,3 @@
+/** Wallet address allowed to see internal video status badges (ready/published). */
+export const VIDEO_ADMIN_ADDRESS =
+  "0x2953B96F9160955f6256c9D444F8F7950E6647Df";

--- a/lib/sdk/orb/format-auth-error.test.ts
+++ b/lib/sdk/orb/format-auth-error.test.ts
@@ -34,4 +34,12 @@ describe('formatOrbAuthError', () => {
       ),
     ).toMatch(/add-orb-lens-columns/i);
   });
+
+  it('maps duplicate orb_account_id constraint errors', () => {
+    expect(
+      formatOrbAuthError(
+        'duplicate key value violates unique constraint "creator_profiles_orb_account_id_key"',
+      ),
+    ).toMatch(/different wallet profile/i);
+  });
 });

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -44,6 +44,12 @@ export function formatOrbAuthError(error: unknown): string {
   ) {
     return 'Database is missing Orb/Lens profile columns. Run scripts/add-orb-lens-columns-to-creator-profiles.sql in the Supabase SQL Editor, then try again.';
   }
+  if (
+    lower.includes('creator_profiles_orb_account_id_key') ||
+    lower.includes('already linked to another profile')
+  ) {
+    return 'This Orb account is already linked to a different wallet profile. Connect the wallet you used before, or contact support to transfer the link.';
+  }
 
   return msg.length > 160 ? `${msg.slice(0, 157)}…` : msg;
 }

--- a/lib/utils/linkify-post-text.ts
+++ b/lib/utils/linkify-post-text.ts
@@ -1,0 +1,80 @@
+import {
+  parseCreativeTVUrl,
+  type ParsedCreativeTVUrl,
+} from "@/lib/utils/creative-tv-url";
+
+const CREATIVE_TV_HOST = "tv.creativeplatform.xyz";
+
+/** Matches http(s) URLs in plain text. */
+export const URL_IN_TEXT_REGEX = /https?:\/\/[^\s<>"']+/gi;
+
+export type PostTextSegment =
+  | { type: "text"; value: string }
+  | {
+      type: "internal";
+      value: string;
+      href: string;
+      parsed: Extract<ParsedCreativeTVUrl, { kind: "discover" | "watch" }>;
+    }
+  | { type: "external"; value: string; href: string };
+
+export function getInternalHref(
+  parsed: Extract<ParsedCreativeTVUrl, { kind: "discover" | "watch" }>,
+): string {
+  if (parsed.kind === "discover") return `/discover/${parsed.assetId}`;
+  return `/watch/${parsed.playbackId}`;
+}
+
+function classifyUrl(rawUrl: string, origin?: string): PostTextSegment {
+  const trimmed = rawUrl.trim();
+
+  try {
+    const url = new URL(trimmed);
+    const isCreativeTvHost =
+      url.hostname.toLowerCase() === CREATIVE_TV_HOST ||
+      (typeof window !== "undefined" &&
+        url.hostname.toLowerCase() === window.location.hostname.toLowerCase());
+
+    if (isCreativeTvHost) {
+      const parsed = parseCreativeTVUrl(trimmed, { origin });
+      if (parsed.kind === "discover" || parsed.kind === "watch") {
+        return {
+          type: "internal",
+          value: trimmed,
+          href: getInternalHref(parsed),
+          parsed,
+        };
+      }
+    }
+  } catch {
+    // fall through to external
+  }
+
+  return { type: "external", value: trimmed, href: trimmed };
+}
+
+export function linkifyPostText(
+  text: string,
+  opts?: { origin?: string },
+): PostTextSegment[] {
+  if (!text) return [];
+
+  const segments: PostTextSegment[] = [];
+  let lastIndex = 0;
+  const regex = new RegExp(URL_IN_TEXT_REGEX.source, URL_IN_TEXT_REGEX.flags);
+
+  for (const match of text.matchAll(regex)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      segments.push({ type: "text", value: text.slice(lastIndex, matchIndex) });
+    }
+    segments.push(classifyUrl(match[0], opts?.origin));
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", value: text.slice(lastIndex) });
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", value: text }];
+}


### PR DESCRIPTION
## Summary
- Portals the mobile hamburger menu through Radix Sheet with backdrop, scroll lock, and tap-to-close; removes the reset-session menu button.
- Adds Songchain post link previews (internal CRTV embeds + external OG cards), edit processing/optimistic refresh, and feed remount on update.
- Aligns non-hero video players to start muted with matching mute icons; hides ready/published badges unless connected as the admin wallet.
- Transfers stale Orb/Lens links to the current wallet before profile upsert to avoid `creator_profiles_orb_account_id_key` duplicate key errors.

## Test plan
- [ ] Mobile: open/close hamburger menu; backdrop dims page and blocks scroll; nav links close menu
- [ ] Songchain: post with CRTV URL shows embed; external URL shows icon + OG preview; edit post shows "Updating…" and refreshes without manual reload
- [ ] Video: discover/detail/watch players start muted with correct icon; single tap unmutes
- [ ] Admin badges visible only for `0x2953B96F9160955f6256c9D444F8F7950E6647Df`
- [ ] Orb: link Orb from desktop with wallet that previously linked under a different address succeeds
- [ ] `npm test -- app/api/creator-profiles/link-orb/route.test.ts lib/sdk/orb/format-auth-error.test.ts`


Made with [Cursor](https://cursor.com)