### PR TITLE
Fix predictions parsing, market crash, and Songchain feed UX

### DIFF
--- a/components/Market/MarketFilters.tsx
+++ b/components/Market/MarketFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -18,9 +19,12 @@ interface MarketFiltersProps {
 }
 
 export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) {
-  const handleSearchChange = (value: string) => {
-    onFiltersChange({ search: value });
-  };
+  const handleSearchChange = useCallback(
+    (searchValue: string) => {
+      onFiltersChange({ search: searchValue });
+    },
+    [onFiltersChange]
+  );
 
   const handleTypeChange = (value: string) => {
     onFiltersChange({ type: value as MarketFiltersType['type'] });

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -37,8 +37,9 @@ export function Player(props: {
   assetId?: string;
   jwt?: string;
   onPlay?: () => void;
+  autoPlay?: boolean;
 }) {
-  const { src, title, playbackId, assetId, jwt, onPlay } = props;
+  const { src, title, playbackId, assetId, jwt, onPlay, autoPlay = true } = props;
 
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
@@ -132,7 +133,7 @@ export function Player(props: {
       src={src}
       playbackId={playbackId}
       jwt={jwt}
-      autoPlay={true}
+      autoPlay={autoPlay}
       volume={0}
       aspectRatio={16 / 9}
       lowLatency={true} // Force low latency for livestream

--- a/components/search/PredictiveSearchInput.tsx
+++ b/components/search/PredictiveSearchInput.tsx
@@ -54,16 +54,26 @@ export function PredictiveSearchInput({
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounced = useDebounce(input, 300);
+  const onQueryChangeRef = useRef(onQueryChange);
+  const prevValueRef = useRef(value);
 
   useEffect(() => {
-    if (value !== undefined && value !== input) {
+    onQueryChangeRef.current = onQueryChange;
+  }, [onQueryChange]);
+
+  // Sync external value changes only (not while user is typing ahead of debounce)
+  useEffect(() => {
+    if (value === undefined) return;
+    if (prevValueRef.current !== value) {
+      prevValueRef.current = value;
       setInput(value);
     }
-  }, [value, input]);
+  }, [value]);
 
   useEffect(() => {
-    onQueryChange(debounced);
-  }, [debounced, onQueryChange]);
+    if (value !== undefined && debounced === value) return;
+    onQueryChangeRef.current(debounced);
+  }, [debounced, value]);
 
   useEffect(() => {
     if (debounced.trim().length < 2) {

--- a/components/search/PredictiveSearchInput.tsx
+++ b/components/search/PredictiveSearchInput.tsx
@@ -55,7 +55,6 @@ export function PredictiveSearchInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const debounced = useDebounce(input, 300);
   const onQueryChangeRef = useRef(onQueryChange);
-  const prevValueRef = useRef(value);
 
   useEffect(() => {
     onQueryChangeRef.current = onQueryChange;
@@ -64,11 +63,10 @@ export function PredictiveSearchInput({
   // Sync external value changes only (not while user is typing ahead of debounce)
   useEffect(() => {
     if (value === undefined) return;
-    if (prevValueRef.current !== value) {
-      prevValueRef.current = value;
+    if (value !== input && value !== debounced) {
       setInput(value);
     }
-  }, [value]);
+  }, [value, input, debounced]);
 
   useEffect(() => {
     if (value !== undefined && debounced === value) return;

--- a/components/songchain/CreativeTVLinkPreview.tsx
+++ b/components/songchain/CreativeTVLinkPreview.tsx
@@ -108,6 +108,7 @@ export function CreativeTVLinkPreview({
             src={playbackSources}
             title={resolvedTitle}
             playbackId={state.result.playbackId}
+            autoPlay={false}
           />
         ) : (
           <div className="flex items-center justify-center py-6 text-muted-foreground">

--- a/components/songchain/SongchainBookmarksSection.tsx
+++ b/components/songchain/SongchainBookmarksSection.tsx
@@ -4,6 +4,10 @@ import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSongchainBookmarks } from "@/hooks/useSongchainBookmarks";
 import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
+import {
+  SongchainPostMasonryGrid,
+  SongchainPostMasonryItem,
+} from "@/components/songchain/SongchainPostMasonryGrid";
 
 import type { SongchainConfig } from "@/lib/songchain/config";
 
@@ -55,16 +59,17 @@ export function SongchainBookmarksSection({
       ) : posts.length === 0 ? (
         <p className="text-center text-muted-foreground py-12">No bookmarks yet.</p>
       ) : (
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <SongchainPostMasonryGrid>
           {posts.map((post) => (
-            <SongchainPostCard
-              key={post.id}
-              post={post}
-              graphId={graphId}
-              onReactionChange={reload}
-            />
+            <SongchainPostMasonryItem key={post.id}>
+              <SongchainPostCard
+                post={post}
+                graphId={graphId}
+                onReactionChange={reload}
+              />
+            </SongchainPostMasonryItem>
           ))}
-        </div>
+        </SongchainPostMasonryGrid>
       )}
     </section>
   );

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -6,6 +6,10 @@ import { Button } from "@/components/ui/button";
 import { useSongchainFeed } from "@/hooks/useSongchainFeed";
 import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
 import { SongchainPendingPostCard } from "@/components/songchain/SongchainPendingPostCard";
+import {
+  SongchainPostMasonryGrid,
+  SongchainPostMasonryItem,
+} from "@/components/songchain/SongchainPostMasonryGrid";
 import { getFeedDiagnosticInfo } from "@/lib/songchain/feed-diagnostics";
 import type { SongchainCreatedPost } from "@/lib/songchain/feed-types";
 
@@ -134,25 +138,27 @@ export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFee
             <p className="mt-2 text-sm text-muted-foreground">{emptyDescription}</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <SongchainPostMasonryGrid>
             {pendingPosts.map((pending) => (
-              <SongchainPendingPostCard
-                key={pending.localId}
-                pending={pending}
-                onRefresh={() => reload()}
-              />
+              <SongchainPostMasonryItem key={pending.localId}>
+                <SongchainPendingPostCard
+                  pending={pending}
+                  onRefresh={() => reload()}
+                />
+              </SongchainPostMasonryItem>
             ))}
             {posts.map((post) => (
-              <SongchainPostCard
-                key={post.id}
-                post={post}
-                feedId={feedId}
-                graphId={graphId}
-                onReactionChange={reload}
-                onPostUpdated={onPostUpdated}
-              />
+              <SongchainPostMasonryItem key={post.id}>
+                <SongchainPostCard
+                  post={post}
+                  feedId={feedId}
+                  graphId={graphId}
+                  onReactionChange={reload}
+                  onPostUpdated={onPostUpdated}
+                />
+              </SongchainPostMasonryItem>
             ))}
-          </div>
+          </SongchainPostMasonryGrid>
         )}
 
         {hasMore && (

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -289,7 +289,7 @@ export function SongchainPostCard({
             <SongchainPostMedia media={media} compact={compact} />
           </div>
         )}
-        <div className="flex flex-1 flex-col gap-3 p-4">
+        <div className="flex flex-col gap-3 p-4">
           <div className="flex items-center justify-between gap-2">
             <button
               type="button"

--- a/components/songchain/SongchainPostMasonryGrid.tsx
+++ b/components/songchain/SongchainPostMasonryGrid.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils/utils";
+
+type SongchainPostMasonryGridProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+/**
+ * Masonry-style post grid using CSS columns so cards keep natural height.
+ */
+export function SongchainPostMasonryGrid({
+  children,
+  className,
+}: SongchainPostMasonryGridProps) {
+  return (
+    <div
+      className={cn(
+        "columns-1 gap-6 sm:columns-2 lg:columns-3",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type SongchainPostMasonryItemProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function SongchainPostMasonryItem({
+  children,
+  className,
+}: SongchainPostMasonryItemProps) {
+  return (
+    <div className={cn("mb-6 break-inside-avoid", className)}>{children}</div>
+  );
+}

--- a/lib/predictions/parse-prediction-display.test.ts
+++ b/lib/predictions/parse-prediction-display.test.ts
@@ -41,4 +41,30 @@ describe("parsePredictionDisplay", () => {
     expect(isSongchainCategory("songchain")).toBe(true);
     expect(isSongchainCategory("creative tv")).toBe(false);
   });
+
+  it("parses bool question with template_id 0", () => {
+    const raw =
+      "Will the album drop this week?\u241fcreative tv\u241fen_US";
+    const parsed = parsePredictionDisplay(raw, 0);
+    expect(parsed.title).toBe("Will the album drop this week?");
+    expect(parsed.category).toBe("creative tv");
+    expect(parsed.type).toBe("bool");
+    expect(parsed.title).not.toContain("[Badly formatted question]");
+  });
+
+  it("parses single-select question with template_id 2", () => {
+    const raw = 'Who wins?\u241f"Alice","Bob"\u241fgeneral\u241fen_US';
+    const parsed = parsePredictionDisplay(raw, 2);
+    expect(parsed.title).toBe("Who wins?");
+    expect(parsed.outcomes).toEqual(["Alice", "Bob"]);
+    expect(parsed.type).toBe("single-select");
+    expect(parsed.title).not.toContain("[Badly formatted question]");
+  });
+
+  it("parses bool question with template_id as bigint", () => {
+    const raw = "Test question?\u241fgeneral\u241fen_US";
+    const parsed = parsePredictionDisplay(raw, BigInt(0));
+    expect(parsed.title).toBe("Test question?");
+    expect(parsed.title).not.toContain("[Badly formatted question]");
+  });
 });

--- a/lib/predictions/parse-prediction-display.ts
+++ b/lib/predictions/parse-prediction-display.ts
@@ -17,12 +17,46 @@ const ZERO_ANSWER =
 const ONE_ANSWER =
   "0x0000000000000000000000000000000000000000000000000000000000000001" as const;
 
-/** Reality.eth standard template strings by template id */
+/** Reality.eth built-in template JSON strings by template id */
 const TEMPLATE_BY_ID: Record<number, string> = {
-  0: `␟␟␟␟`,
-  1: `␟␟␟`,
-  2: `␟␟␟␟`,
+  0: `{"title": "%s", "type": "bool", "category": "%s", "lang": "%s"}`,
+  1: `{"title": "%s", "type": "uint", "decimals": 18, "category": "%s", "lang": "%s"}`,
+  2: `{"title": "%s", "type": "single-select", "outcomes": [%s], "category": "%s", "lang": "%s"}`,
+  3: `{"title": "%s", "type": "multiple-select", "outcomes": [%s], "category": "%s", "lang": "%s"}`,
+  4: `{"title": "%s", "type": "datetime", "category": "%s", "lang": "%s"}`,
 };
+
+function isBadParsedTitle(title: string): boolean {
+  const t = title.trim();
+  if (!t) return true;
+  if (t.startsWith("[Badly formatted question]")) return true;
+  if (/^␟+$/.test(t) || /^[\u241F]+$/.test(t)) return true;
+  return false;
+}
+
+function buildDisplayFromParsed(
+  parsed: Record<string, unknown>,
+  raw: string
+): ParsedPredictionDisplay | null {
+  const title = String(parsed.title ?? "").trim();
+  if (isBadParsedTitle(title)) return null;
+
+  const outcomes = Array.isArray(parsed.outcomes)
+    ? parsed.outcomes.map(String)
+    : parseOutcomesSegment(String(parsed.outcomes ?? ""));
+  const type =
+    (parsed.type as ParsedPredictionDisplay["type"]) ??
+    inferTypeFromOutcomes(outcomes);
+
+  return {
+    title,
+    type,
+    outcomes: outcomes.length ? outcomes : type === "bool" ? ["Yes", "No"] : [],
+    category: String(parsed.category ?? "general"),
+    language: String(parsed.lang ?? parsed.language ?? "en_US"),
+    description: parsed.description ? String(parsed.description) : undefined,
+  };
+}
 
 function parseOutcomesSegment(segment: string): string[] {
   const trimmed = segment.trim();
@@ -85,18 +119,8 @@ export function parsePredictionDisplay(
   if (!Number.isNaN(tid) && TEMPLATE_BY_ID[tid] !== undefined) {
     try {
       const parsed = parseQuestionText(TEMPLATE_BY_ID[tid], raw);
-      const outcomes = Array.isArray(parsed.outcomes)
-        ? parsed.outcomes.map(String)
-        : parseOutcomesSegment(String(parsed.outcomes ?? ""));
-      const type = (parsed.type as ParsedPredictionDisplay["type"]) ?? inferTypeFromOutcomes(outcomes);
-      return {
-        title: String(parsed.title ?? raw.split(UNIT_SEP)[0] ?? raw),
-        type,
-        outcomes: outcomes.length ? outcomes : type === "bool" ? ["Yes", "No"] : [],
-        category: String(parsed.category ?? "general"),
-        language: String(parsed.language ?? "en_US"),
-        description: parsed.description ? String(parsed.description) : undefined,
-      };
+      const display = buildDisplayFromParsed(parsed, raw);
+      if (display) return display;
     } catch {
       // fall through to manual split
     }


### PR DESCRIPTION
## Summary
- Restore legible Reality.eth prediction titles by fixing built-in template JSON and adding bad-title fallback parsing.
- Fix market page React #185 by stabilizing `PredictiveSearchInput` controlled-mode updates and memoizing the market search handler.
- Improve Songchain feeds: disable Creative TV inline preview autoplay and switch Feed, Exclusive, and Bookmarks to masonry card layout.

## Test plan
- [ ] Run `pnpm test lib/predictions/parse-prediction-display.test.ts`
- [ ] Open `/predict` and confirm prediction titles/categories render correctly
- [ ] Open `/market` and confirm the page loads without React error #185
- [ ] Type in market search and confirm input does not reset while typing
- [ ] Open `/songchain` and confirm Creative TV previews stay paused until play is clicked
- [ ] Verify Feed, Exclusive, and Bookmarks tabs use dynamic card heights (no row stretching)


Made with [Cursor](https://cursor.com)