### PR TITLE
Fix prediction quota, search autocomplete, and answer display

### DIFF
--- a/app/api/predictions/metadata/route.ts
+++ b/app/api/predictions/metadata/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { supabaseService } from "@/lib/sdk/supabase/service";
+
+export async function GET(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.generous(request);
+  if (rl) return rl;
+
+  const questionId = request.nextUrl.searchParams.get("questionId")?.trim();
+  if (!questionId || !/^0x[a-fA-F0-9]{64}$/.test(questionId)) {
+    return NextResponse.json(
+      { error: "Valid questionId query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!supabaseService) {
+    return NextResponse.json({ metadata: null });
+  }
+
+  const { data, error } = await supabaseService
+    .from("prediction_market_creations")
+    .select("title, category, question_type")
+    .eq("question_id", questionId.toLowerCase())
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json({ metadata: null });
+  }
+
+  return NextResponse.json({
+    metadata: {
+      title: data.title ?? null,
+      category: data.category ?? null,
+      questionType: data.question_type ?? null,
+    },
+  });
+}

--- a/app/api/predictions/quota/route.test.ts
+++ b/app/api/predictions/quota/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const ADMIN = "0x2953B96F9160955f6256c9D444F8F7950E6647Df";
+const USER = "0x1111111111111111111111111111111111111111";
+
+const mockGetAllMemberships = vi.fn();
+const mockCountPredictionMarketsThisMonthUtc = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: {
+    generous: vi.fn(async () => null),
+  },
+}));
+
+vi.mock("@/lib/sdk/unlock/services", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/sdk/unlock/services")>();
+  return {
+    ...actual,
+    unlockService: {
+      ...actual.unlockService,
+      getAllMemberships: (...args: unknown[]) => mockGetAllMemberships(...args),
+    },
+  };
+});
+
+vi.mock("@/lib/predictions/prediction-quota", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/predictions/prediction-quota")>();
+  return {
+    ...actual,
+    countPredictionMarketsThisMonthUtc: (...args: unknown[]) =>
+      mockCountPredictionMarketsThisMonthUtc(...args),
+  };
+});
+
+vi.mock("@/lib/sdk/supabase/service", () => ({
+  supabaseService: {},
+}));
+
+describe("GET /api/predictions/quota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllMemberships.mockResolvedValue([]);
+    mockCountPredictionMarketsThisMonthUtc.mockResolvedValue(1);
+  });
+
+  it("returns unlimited quota for platform admin", async () => {
+    const { GET } = await import("./route");
+    const req = new NextRequest(
+      `http://localhost/api/predictions/quota?address=${ADMIN}`
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.unlimited).toBe(true);
+    expect(body.remaining).toBeNull();
+    expect(mockGetAllMemberships).not.toHaveBeenCalled();
+  });
+
+  it("returns monthly quota for non-admin users", async () => {
+    const { GET } = await import("./route");
+    const req = new NextRequest(
+      `http://localhost/api/predictions/quota?address=${USER}`
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.unlimited).toBe(false);
+    expect(body.usedThisMonth).toBe(1);
+    expect(body.remaining).toBe(2);
+    expect(mockGetAllMemberships).toHaveBeenCalled();
+  });
+});

--- a/app/api/predictions/quota/route.ts
+++ b/app/api/predictions/quota/route.ts
@@ -10,6 +10,7 @@ import {
   PREDICTION_MARKETS_MONTHLY_LIMIT,
 } from "@/lib/predictions/prediction-quota";
 import { unlockService } from "@/lib/sdk/unlock/services";
+import { isPlatformAdmin } from "@/lib/access/platform-admin";
 
 export async function GET(request: NextRequest) {
   const verification = await checkBotId();
@@ -36,6 +37,17 @@ export async function GET(request: NextRequest) {
 
   try {
     const normalized = normalizeCreatorAddress(address);
+
+    if (isPlatformAdmin(normalized)) {
+      return NextResponse.json({
+        unlimited: true,
+        premiumTier: null,
+        usedThisMonth: 0,
+        monthlyLimit: PREDICTION_MARKETS_MONTHLY_LIMIT,
+        remaining: null,
+      });
+    }
+
     const memberships = await unlockService.getAllMemberships(normalized);
     const { unlimited, tier } = getPremiumPredictionAccess(memberships);
 

--- a/app/api/predictions/record/route.ts
+++ b/app/api/predictions/record/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
 
     const { unlimited } = getPremiumPredictionAccess(memberships);
 
-    if (unlimited) {
+    if (unlimited || isPlatformAdmin(normalized)) {
       return NextResponse.json({ recorded: false, unlimited: true });
     }
 

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -73,7 +73,6 @@ const AllVideosContent: React.FC = () => {
           onSearchChange={setSearchQuery}
           onCategoryChange={setCategory}
           onSortChange={setSortBy}
-          initialSearch={searchQuery}
           initialCategory={category}
           initialSort={sortBy}
         />

--- a/components/Market/MarketFilters.tsx
+++ b/components/Market/MarketFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -18,6 +19,8 @@ interface MarketFiltersProps {
 }
 
 export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) {
+  const [searchResetKey, setSearchResetKey] = useState(0);
+
   const handleSearchChange = (value: string) => {
     onFiltersChange({ search: value });
   };
@@ -35,6 +38,7 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
   };
 
   const clearFilters = () => {
+    setSearchResetKey((k) => k + 1);
     onFiltersChange({
       type: 'all',
       search: '',
@@ -47,19 +51,16 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
 
   return (
     <div className="space-y-4">
-      {/* Search and Type Filter Row */}
       <div className="flex flex-col sm:flex-row gap-4">
-        {/* Search Input */}
         <div className="relative flex-1">
           <PredictiveSearchInput
             scope="market"
             placeholder="Search tokens, symbols, or creators..."
-            value={filters.search}
+            resetKey={searchResetKey}
             onQueryChange={handleSearchChange}
           />
         </div>
 
-        {/* Type Filter */}
         <Select value={filters.type} onValueChange={handleTypeChange}>
           <SelectTrigger className="w-full sm:w-[180px]">
             <SelectValue placeholder="Token Type" />
@@ -72,7 +73,6 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
         </Select>
       </div>
 
-      {/* Sort Controls Row */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-sm text-muted-foreground">Sort by:</span>
@@ -105,7 +105,6 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
           </Button>
         </div>
 
-        {/* Clear Filters */}
         {hasActiveFilters && (
           <Button
             variant="ghost"
@@ -119,7 +118,6 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
         )}
       </div>
 
-      {/* Active Filters Display */}
       {hasActiveFilters && (
         <div className="flex flex-wrap items-center gap-2 text-sm">
           <span className="text-muted-foreground">Active filters:</span>
@@ -138,4 +136,3 @@ export function MarketFilters({ filters, onFiltersChange }: MarketFiltersProps) 
     </div>
   );
 }
-

--- a/components/Videos/VideoSearch.tsx
+++ b/components/Videos/VideoSearch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -10,14 +10,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { X, SlidersHorizontal } from "lucide-react";
-import { useDebounce } from "@/lib/hooks/useDebounce";
 import { PredictiveSearchInput } from "@/components/search/PredictiveSearchInput";
 
 interface VideoSearchProps {
   onSearchChange: (search: string) => void;
   onCategoryChange: (category: string) => void;
   onSortChange: (sort: 'created_at' | 'views_count' | 'likes_count' | 'updated_at') => void;
-  initialSearch?: string;
   initialCategory?: string;
   initialSort?: 'created_at' | 'views_count' | 'likes_count' | 'updated_at';
 }
@@ -52,22 +50,13 @@ export function VideoSearch({
   onSearchChange,
   onCategoryChange,
   onSortChange,
-  initialSearch = "",
   initialCategory = "all",
   initialSort = "created_at",
 }: VideoSearchProps) {
-  const [searchInput, setSearchInput] = useState(initialSearch);
   const [category, setCategory] = useState(initialCategory);
   const [sort, setSort] = useState(initialSort);
   const [showFilters, setShowFilters] = useState(false);
-
-  // Debounce search input to avoid excessive API calls
-  const debouncedSearch = useDebounce(searchInput, 500);
-
-  // Notify parent of search changes
-  useEffect(() => {
-    onSearchChange(debouncedSearch);
-  }, [debouncedSearch, onSearchChange]);
+  const [searchResetKey, setSearchResetKey] = useState(0);
 
   const handleCategoryChange = useCallback((value: string) => {
     setCategory(value);
@@ -81,7 +70,7 @@ export function VideoSearch({
   }, [onSortChange]);
 
   const clearSearch = useCallback(() => {
-    setSearchInput("");
+    setSearchResetKey((k) => k + 1);
     onSearchChange("");
   }, [onSearchChange]);
 
@@ -91,22 +80,21 @@ export function VideoSearch({
         <PredictiveSearchInput
           scope="videos"
           placeholder="Search videos by title or description..."
-          value={searchInput}
-          onQueryChange={setSearchInput}
+          resetKey={searchResetKey}
+          onQueryChange={onSearchChange}
           showClear={false}
           inputClassName="pr-24"
         />
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 gap-2 z-10">
-          {searchInput && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={clearSearch}
-              className="h-7 px-2"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearSearch}
+            className="h-7 px-2"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </Button>
           <Button
             variant="ghost"
             size="sm"
@@ -118,10 +106,8 @@ export function VideoSearch({
         </div>
       </div>
 
-      {/* Filters (Collapsible) */}
       {showFilters && (
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-          {/* Category Filter */}
           <div className="flex-1">
             <label htmlFor="genre-select" className="mb-2 block text-sm font-medium">Genre</label>
             <Select value={category} onValueChange={handleCategoryChange}>
@@ -138,7 +124,6 @@ export function VideoSearch({
             </Select>
           </div>
 
-          {/* Sort Filter */}
           <div className="flex-1">
             <label htmlFor="sort-select" className="mb-2 block text-sm font-medium">Sort By</label>
             <Select value={sort} onValueChange={handleSortChange}>
@@ -159,4 +144,3 @@ export function VideoSearch({
     </div>
   );
 }
-

--- a/components/Videos/VideoSearch.tsx
+++ b/components/Videos/VideoSearch.tsx
@@ -57,6 +57,7 @@ export function VideoSearch({
   const [sort, setSort] = useState(initialSort);
   const [showFilters, setShowFilters] = useState(false);
   const [searchResetKey, setSearchResetKey] = useState(0);
+  const [hasSearch, setHasSearch] = useState(false);
 
   const handleCategoryChange = useCallback((value: string) => {
     setCategory(value);
@@ -71,6 +72,7 @@ export function VideoSearch({
 
   const clearSearch = useCallback(() => {
     setSearchResetKey((k) => k + 1);
+    setHasSearch(false);
     onSearchChange("");
   }, [onSearchChange]);
 
@@ -81,20 +83,25 @@ export function VideoSearch({
           scope="videos"
           placeholder="Search videos by title or description..."
           resetKey={searchResetKey}
-          onQueryChange={onSearchChange}
+          onQueryChange={(q) => {
+            setHasSearch(!!q);
+            onSearchChange(q);
+          }}
           showClear={false}
           inputClassName="pr-24"
         />
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 gap-2 z-10">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={clearSearch}
-            className="h-7 px-2"
-            aria-label="Clear search"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+          {hasSearch && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearSearch}
+              className="h-7 px-2"
+              aria-label="Clear search"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"

--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -38,7 +38,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { usePredictionAccess } from "@/lib/hooks/predictions/usePredictionAccess";
 import { ShareDialog } from "@/components/Videos/ShareDialog";
 import { useSongchainPost } from "@/hooks/useSongchainPost";
-import { getSongchainConfig } from "@/lib/songchain/config";
+import { getTemplateIdForQuestionType } from "@/lib/predictions/reality-template";
 
 const PREDICTION_CATEGORIES = [
   { value: "creative tv", label: "Creative TV" },
@@ -115,7 +115,7 @@ function CreatePrediction() {
 
   const { openAuthModal } = useAuthModal();
   const { client: accountKitClient } = useSmartAccountClient({});
-  const { canCreatePrediction, blockReason, isCreatorTier } = usePredictionAccess();
+  const { canCreatePrediction, blockReason, isCreatorTier, isAdmin } = usePredictionAccess();
   const { createPost, isPosting: isSongchainPosting } = useSongchainPost();
   const songchainConfig = getSongchainConfig();
   const [shareOpen, setShareOpen] = useState(false);
@@ -150,6 +150,18 @@ function CreatePrediction() {
       setQuota(null);
       return;
     }
+    if (isAdmin) {
+      setQuota({
+        unlimited: true,
+        premiumTier: null,
+        usedThisMonth: 0,
+        monthlyLimit: 3,
+        remaining: null,
+      });
+      setQuotaLoading(false);
+      setQuotaError(null);
+      return;
+    }
     let cancelled = false;
     (async () => {
       setQuotaLoading(true);
@@ -178,7 +190,7 @@ function CreatePrediction() {
     return () => {
       cancelled = true;
     };
-  }, [address]);
+  }, [address, isAdmin]);
 
   // Auto-populate outcomes when type changes to bool
   useEffect(() => {
@@ -345,9 +357,7 @@ function CreatePrediction() {
       // Must match Kleros proxy used for disputes / submitEvidence (see getCanonicalRealityEthArbitratorAddress).
       const arbitrator = getCanonicalRealityEthArbitratorAddress();
 
-      // Template ID 0 is typically used for custom questions
-      // You may need to register a template first for production use
-      const templateId = 0;
+      const templateId = getTemplateIdForQuestionType(questionData.type);
 
       logger.debug("📝 Creating question with params:", {
         templateId,

--- a/components/predictions/PredictionDetails.tsx
+++ b/components/predictions/PredictionDetails.tsx
@@ -16,6 +16,7 @@ import {
   parsePredictionDisplay,
   answerBytesToLabel,
   formatCategoryLabel,
+  applyPredictionMetadataOverride,
   type ParsedPredictionDisplay,
 } from "@/lib/predictions/parse-prediction-display";
 import { BetForm } from "./BetForm";
@@ -83,10 +84,28 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
           throw questionError;
         }
 
-        const parsed = parsePredictionDisplay(
+        let parsed = parsePredictionDisplay(
           questionDataRaw.question ?? "",
           questionDataRaw.template_id
         );
+
+        try {
+          const metaRes = await fetch(
+            `/api/predictions/metadata?questionId=${encodeURIComponent(questionId)}`
+          );
+          if (metaRes.ok) {
+            const metaJson = (await metaRes.json()) as {
+              metadata?: {
+                title?: string | null;
+                questionType?: string | null;
+                category?: string | null;
+              } | null;
+            };
+            parsed = applyPredictionMetadataOverride(parsed, metaJson.metadata);
+          }
+        } catch (metaErr) {
+          logger.debug("Prediction metadata fetch skipped:", metaErr);
+        }
 
         const questionData: QuestionData = {
           ...questionDataRaw,

--- a/components/search/PredictiveSearchInput.tsx
+++ b/components/search/PredictiveSearchInput.tsx
@@ -56,9 +56,8 @@ export function PredictiveSearchInput({
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const lastEmittedRef = useRef("");
+  const isFirstResetRender = useRef(true);
   const debounced = useDebounce(input, 300);
-  const onQueryChangeRef = useRef(onQueryChange);
-
   const onQueryChangeRef = useRef(onQueryChange);
 
   useEffect(() => {
@@ -66,6 +65,10 @@ export function PredictiveSearchInput({
   }, [onQueryChange]);
 
   useEffect(() => {
+    if (isFirstResetRender.current) {
+      isFirstResetRender.current = false;
+      return;
+    }
     setInput("");
     setResults([]);
     setOpen(false);

--- a/components/search/PredictiveSearchInput.tsx
+++ b/components/search/PredictiveSearchInput.tsx
@@ -28,7 +28,8 @@ const SCOPE_ENDPOINT: Record<SearchScope, string> = {
 interface PredictiveSearchInputProps {
   scope: SearchScope;
   placeholder?: string;
-  value?: string;
+  /** External reset key — increment to clear the input from parent (e.g. "Clear filters"). */
+  resetKey?: number;
   onQueryChange: (query: string) => void;
   onSelect?: (result: SuggestResult) => void;
   className?: string;
@@ -39,7 +40,7 @@ interface PredictiveSearchInputProps {
 export function PredictiveSearchInput({
   scope,
   placeholder = "Search…",
-  value,
+  resetKey = 0,
   onQueryChange,
   onSelect,
   className,
@@ -47,27 +48,35 @@ export function PredictiveSearchInput({
   showClear = true,
 }: PredictiveSearchInputProps) {
   const router = useRouter();
-  const [input, setInput] = useState(value ?? "");
+  const [input, setInput] = useState("");
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [results, setResults] = useState<SuggestResult[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const lastEmittedRef = useRef("");
   const debounced = useDebounce(input, 300);
 
   useEffect(() => {
-    if (value !== undefined && value !== input) {
-      setInput(value);
-    }
-  }, [value, input]);
+    setInput("");
+    setResults([]);
+    setOpen(false);
+    setFetchError(null);
+    lastEmittedRef.current = "";
+    onQueryChange("");
+  }, [resetKey]); // eslint-disable-line react-hooks/exhaustive-deps -- reset only when key changes
 
   useEffect(() => {
+    if (debounced === lastEmittedRef.current) return;
+    lastEmittedRef.current = debounced;
     onQueryChange(debounced);
   }, [debounced, onQueryChange]);
 
   useEffect(() => {
     if (debounced.trim().length < 2) {
       setResults([]);
+      setFetchError(null);
       setOpen(false);
       return;
     }
@@ -75,12 +84,23 @@ export function PredictiveSearchInput({
     let cancelled = false;
     (async () => {
       setLoading(true);
+      setFetchError(null);
+      setOpen(true);
       try {
         const res = await fetch(
           `${SCOPE_ENDPOINT[scope]}?q=${encodeURIComponent(debounced.trim())}&limit=8`
         );
         const data = await res.json();
         if (cancelled) return;
+        if (!res.ok) {
+          setResults([]);
+          setFetchError(
+            typeof data.error === "string" ? data.error : "Search unavailable"
+          );
+          setOpen(true);
+          setActiveIndex(-1);
+          return;
+        }
         const mapped: SuggestResult[] = (data.results ?? []).map(
           (r: Record<string, string>) => ({
             id: r.id,
@@ -92,10 +112,15 @@ export function PredictiveSearchInput({
           })
         );
         setResults(mapped);
-        setOpen(mapped.length > 0);
+        setFetchError(null);
+        setOpen(true);
         setActiveIndex(-1);
       } catch {
-        if (!cancelled) setResults([]);
+        if (!cancelled) {
+          setResults([]);
+          setFetchError("Search unavailable");
+          setOpen(true);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -122,11 +147,13 @@ export function PredictiveSearchInput({
   const selectResult = useCallback(
     (result: SuggestResult) => {
       setInput(result.title);
+      lastEmittedRef.current = result.title;
+      onQueryChange(result.title);
       setOpen(false);
       onSelect?.(result);
       router.push(result.href);
     },
-    [onSelect, router]
+    [onSelect, onQueryChange, router]
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -145,6 +172,11 @@ export function PredictiveSearchInput({
     }
   };
 
+  const showDropdown =
+    open &&
+    debounced.trim().length >= 2 &&
+    (loading || fetchError !== null || results.length > 0);
+
   return (
     <div ref={containerRef} className={cn("relative", className)}>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none" />
@@ -153,7 +185,7 @@ export function PredictiveSearchInput({
         placeholder={placeholder}
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        onFocus={() => results.length > 0 && setOpen(true)}
+        onFocus={() => debounced.trim().length >= 2 && setOpen(true)}
         onKeyDown={handleKeyDown}
         className={cn("pl-10 pr-20", inputClassName)}
         autoComplete="off"
@@ -168,7 +200,9 @@ export function PredictiveSearchInput({
             className="h-7 px-2"
             onClick={() => {
               setInput("");
+              lastEmittedRef.current = "";
               setResults([]);
+              setFetchError(null);
               setOpen(false);
               onQueryChange("");
             }}
@@ -177,11 +211,20 @@ export function PredictiveSearchInput({
           </Button>
         )}
       </div>
-      {open && results.length > 0 && (
+      {showDropdown && (
         <ul
           className="absolute z-50 mt-1 w-full rounded-md border bg-popover text-popover-foreground shadow-md max-h-64 overflow-auto"
           role="listbox"
         >
+          {loading && results.length === 0 && (
+            <li className="px-3 py-2 text-sm text-muted-foreground">Searching…</li>
+          )}
+          {!loading && fetchError && (
+            <li className="px-3 py-2 text-sm text-destructive">{fetchError}</li>
+          )}
+          {!loading && !fetchError && results.length === 0 && (
+            <li className="px-3 py-2 text-sm text-muted-foreground">No results</li>
+          )}
           {results.map((result, idx) => (
             <li key={result.href + idx}>
               <button

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -47,6 +47,12 @@ initBotId({
     { path: '/api/coinbase/session-token', method: 'POST' },
     { path: '/api/reality-eth-subgraph', method: 'POST' },
     { path: '/api/metokens/*/transactions', method: 'POST' },
+    { path: '/api/predictions/quota', method: 'GET' },
+    { path: '/api/predictions/record', method: 'POST' },
+    { path: '/api/predictions/metadata', method: 'GET' },
+    { path: '/api/search/videos', method: 'GET' },
+    { path: '/api/search/market', method: 'GET' },
+    { path: '/api/search/predictions', method: 'GET' },
     // Server actions: pages that invoke saveCreatorCollectionAction (Next.js POSTs to page URL)
     { path: '/', method: 'POST' },
     { path: '/studio', method: 'POST' },

--- a/lib/predictions/parse-prediction-display.test.ts
+++ b/lib/predictions/parse-prediction-display.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   parsePredictionDisplay,
   answerBytesToLabel,
+  applyPredictionMetadataOverride,
   isSongchainCategory,
 } from "./parse-prediction-display";
 
@@ -13,6 +14,20 @@ describe("parsePredictionDisplay", () => {
     expect(parsed.title).toBe("Will it rain tomorrow?");
     expect(parsed.outcomes).toContain("Yes");
     expect(parsed.category.toLowerCase()).toContain("creative");
+  });
+
+  it("parses bool template id 0", () => {
+    const raw = 'Will it rain?\u241fgeneral\u241fen_US';
+    const parsed = parsePredictionDisplay(raw, 0);
+    expect(parsed.type).toBe("bool");
+    expect(parsed.title).toBe("Will it rain?");
+  });
+
+  it("parses uint template id 1", () => {
+    const raw = 'How many views?\u241fgeneral\u241fen_US';
+    const parsed = parsePredictionDisplay(raw, 1);
+    expect(parsed.type).toBe("uint");
+    expect(parsed.title).toBe("How many views?");
   });
 
   it("maps bool answers", () => {
@@ -27,6 +42,17 @@ describe("parsePredictionDisplay", () => {
     )).toBe("No");
   });
 
+  it("decodes uint answer even when parsed type was mis-inferred as bool", () => {
+    const parsed = parsePredictionDisplay("Test?\u241f\u241fgeneral\u241fen_US");
+    expect(parsed.type).toBe("bool");
+    expect(
+      answerBytesToLabel(
+        "0x0000000000000000000000000000000000000000000000000000000000000005",
+        parsed
+      )
+    ).toBe("5");
+  });
+
   it("returns null for unresolved non-boolean zero answer", () => {
     const parsed = parsePredictionDisplay(
       'Pick one?\u241f"A","B","C"\u241fgeneral\u241fen_US'
@@ -35,6 +61,26 @@ describe("parsePredictionDisplay", () => {
       "0x0000000000000000000000000000000000000000000000000000000000000000",
       parsed
     )).toBeNull();
+  });
+
+  it("applies metadata override for badly formatted titles", () => {
+    const parsed = parsePredictionDisplay(
+      "[Badly formatted question]: usususus",
+      0
+    );
+    const updated = applyPredictionMetadataOverride(parsed, {
+      title: "How many streams?",
+      questionType: "uint",
+    });
+    expect(updated.title).toBe("How many streams?");
+    expect(updated.type).toBe("uint");
+    expect(
+      answerBytesToLabel(
+        "0x0000000000000000000000000000000000000000000000000000000000000005",
+        updated,
+        updated.type
+      )
+    ).toBe("5");
   });
 
   it("detects songchain category", () => {

--- a/lib/predictions/parse-prediction-display.test.ts
+++ b/lib/predictions/parse-prediction-display.test.ts
@@ -74,6 +74,7 @@ describe("parsePredictionDisplay", () => {
     });
     expect(updated.title).toBe("How many streams?");
     expect(updated.type).toBe("uint");
+    expect(updated.outcomes).toEqual([]);
     expect(
       answerBytesToLabel(
         "0x0000000000000000000000000000000000000000000000000000000000000005",

--- a/lib/predictions/parse-prediction-display.ts
+++ b/lib/predictions/parse-prediction-display.ts
@@ -1,5 +1,7 @@
 import { keccak256, stringToHex } from "viem";
 import { parseQuestionText } from "@/lib/sdk/reality-eth/reality-eth-utils";
+import type { QuestionType } from "@/lib/sdk/reality-eth/reality-eth-utils";
+import { getTemplateTextForId } from "@/lib/predictions/reality-template";
 
 const UNIT_SEP = "\u241F";
 
@@ -17,11 +19,11 @@ const ZERO_ANSWER =
 const ONE_ANSWER =
   "0x0000000000000000000000000000000000000000000000000000000000000001" as const;
 
-/** Reality.eth standard template strings by template id */
-const TEMPLATE_BY_ID: Record<number, string> = {
-  0: `␟␟␟␟`,
-  1: `␟␟␟`,
-  2: `␟␟␟␟`,
+const TEMPLATE_ID_TO_TYPE: Record<number, ParsedPredictionDisplay["type"]> = {
+  0: "bool",
+  1: "uint",
+  2: "single-select",
+  3: "multiple-select",
 };
 
 function parseOutcomesSegment(segment: string): string[] {
@@ -63,6 +65,47 @@ function inferTypeFromOutcomes(outcomes: string[]): ParsedPredictionDisplay["typ
   return "bool";
 }
 
+function isValidQuestionType(value: string): value is ParsedPredictionDisplay["type"] {
+  return (
+    value === "bool" ||
+    value === "uint" ||
+    value === "single-select" ||
+    value === "multiple-select"
+  );
+}
+
+/** Prefer Supabase-stored title when on-chain parse failed. */
+export function applyPredictionMetadataOverride(
+  parsed: ParsedPredictionDisplay,
+  metadata?: {
+    title?: string | null;
+    questionType?: string | null;
+    category?: string | null;
+  } | null
+): ParsedPredictionDisplay {
+  if (!metadata) return parsed;
+
+  let next = { ...parsed };
+
+  if (
+    metadata.title?.trim() &&
+    (parsed.title.startsWith("[Badly formatted question]") ||
+      parsed.title === "Untitled Prediction")
+  ) {
+    next = { ...next, title: metadata.title.trim() };
+  }
+
+  if (metadata.questionType && isValidQuestionType(metadata.questionType)) {
+    next = { ...next, type: metadata.questionType };
+  }
+
+  if (metadata.category?.trim()) {
+    next = { ...next, category: metadata.category.trim() };
+  }
+
+  return next;
+}
+
 /**
  * Parse encoded Reality.eth question text for display.
  */
@@ -82,23 +125,30 @@ export function parsePredictionDisplay(
   }
 
   const tid = templateId != null ? Number(templateId) : NaN;
-  if (!Number.isNaN(tid) && TEMPLATE_BY_ID[tid] !== undefined) {
-    try {
-      const parsed = parseQuestionText(TEMPLATE_BY_ID[tid], raw);
-      const outcomes = Array.isArray(parsed.outcomes)
-        ? parsed.outcomes.map(String)
-        : parseOutcomesSegment(String(parsed.outcomes ?? ""));
-      const type = (parsed.type as ParsedPredictionDisplay["type"]) ?? inferTypeFromOutcomes(outcomes);
-      return {
-        title: String(parsed.title ?? raw.split(UNIT_SEP)[0] ?? raw),
-        type,
-        outcomes: outcomes.length ? outcomes : type === "bool" ? ["Yes", "No"] : [],
-        category: String(parsed.category ?? "general"),
-        language: String(parsed.language ?? "en_US"),
-        description: parsed.description ? String(parsed.description) : undefined,
-      };
-    } catch {
-      // fall through to manual split
+  if (!Number.isNaN(tid)) {
+    const templateText = getTemplateTextForId(tid);
+    if (templateText) {
+      try {
+        const parsed = parseQuestionText(templateText, raw);
+        const outcomes = Array.isArray(parsed.outcomes)
+          ? parsed.outcomes.map(String)
+          : parseOutcomesSegment(String(parsed.outcomes ?? ""));
+        const typeFromTemplate = TEMPLATE_ID_TO_TYPE[tid];
+        const type =
+          (parsed.type as ParsedPredictionDisplay["type"]) ??
+          typeFromTemplate ??
+          inferTypeFromOutcomes(outcomes);
+        return {
+          title: String(parsed.title ?? raw.split(UNIT_SEP)[0] ?? raw),
+          type,
+          outcomes: outcomes.length ? outcomes : type === "bool" ? ["Yes", "No"] : [],
+          category: String(parsed.category ?? "general"),
+          language: String(parsed.language ?? parsed.lang ?? "en_US"),
+          description: parsed.description ? String(parsed.description) : undefined,
+        };
+      } catch {
+        // fall through to manual split
+      }
     }
   }
 
@@ -127,30 +177,50 @@ export function parsePredictionDisplay(
   };
 }
 
+function looksLikeUintAnswer(normalized: string): boolean {
+  if (normalized === ZERO_ANSWER.toLowerCase() || normalized === ONE_ANSWER.toLowerCase()) {
+    return false;
+  }
+  try {
+    const value = BigInt(normalized);
+    return value >= 0n && value < 2n ** 128n;
+  } catch {
+    return false;
+  }
+}
+
+function decodeUintAnswer(answerHex: string): string | null {
+  try {
+    const value = BigInt(answerHex);
+    if (value < 0n || value >= 2n ** 128n) return null;
+    return value.toString();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Map bytes32 answer to human-readable label.
  */
 export function answerBytesToLabel(
   answerHex: string | null | undefined,
-  parsed: ParsedPredictionDisplay
+  parsed: ParsedPredictionDisplay,
+  typeOverride?: QuestionType | null
 ): string | null {
   if (!answerHex || (answerHex === ZERO_ANSWER && parsed.type !== "bool")) {
     return null;
   }
 
+  const effectiveType = typeOverride ?? parsed.type;
   const normalized = answerHex.toLowerCase();
 
-  if (parsed.type === "bool") {
+  if (effectiveType === "bool") {
     if (normalized === ONE_ANSWER.toLowerCase()) return "Yes";
     if (normalized === ZERO_ANSWER.toLowerCase()) return "No";
   }
 
-  if (parsed.type === "uint") {
-    try {
-      return BigInt(answerHex).toString();
-    } catch {
-      return answerHex;
-    }
+  if (effectiveType === "uint") {
+    return decodeUintAnswer(answerHex) ?? answerHex;
   }
 
   for (const outcome of parsed.outcomes) {
@@ -164,6 +234,10 @@ export function answerBytesToLabel(
 
   if (normalized === ONE_ANSWER.toLowerCase()) return "Yes";
   if (normalized === ZERO_ANSWER.toLowerCase()) return "No";
+
+  if (looksLikeUintAnswer(normalized)) {
+    return decodeUintAnswer(answerHex);
+  }
 
   return answerHex.length > 18
     ? `${answerHex.slice(0, 10)}…${answerHex.slice(-6)}`

--- a/lib/predictions/parse-prediction-display.ts
+++ b/lib/predictions/parse-prediction-display.ts
@@ -122,6 +122,11 @@ export function applyPredictionMetadataOverride(
 
   if (metadata.questionType && isValidQuestionType(metadata.questionType)) {
     next = { ...next, type: metadata.questionType };
+    if (metadata.questionType === "uint") {
+      next.outcomes = [];
+    } else if (metadata.questionType === "bool" && next.outcomes.length === 0) {
+      next.outcomes = ["Yes", "No"];
+    }
   }
 
   if (metadata.category?.trim()) {

--- a/lib/predictions/reality-template.test.ts
+++ b/lib/predictions/reality-template.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { getTemplateIdForQuestionType } from "./reality-template";
+
+describe("reality-template", () => {
+  it("maps question types to standard Reality.eth template ids", () => {
+    expect(getTemplateIdForQuestionType("bool")).toBe(0);
+    expect(getTemplateIdForQuestionType("uint")).toBe(1);
+    expect(getTemplateIdForQuestionType("single-select")).toBe(2);
+    expect(getTemplateIdForQuestionType("multiple-select")).toBe(3);
+  });
+});

--- a/lib/predictions/reality-template.ts
+++ b/lib/predictions/reality-template.ts
@@ -1,0 +1,23 @@
+import { template as realityTemplate } from "@reality.eth/reality-eth-lib";
+import type { QuestionType } from "@/lib/sdk/reality-eth/reality-eth-utils";
+
+/** Standard Reality.eth template IDs (see @reality.eth/contracts/config/templates.json). */
+export function getTemplateIdForQuestionType(type: QuestionType): number {
+  const id = realityTemplate.defaultTemplateIDForType(type);
+  if (typeof id !== "number" || Number.isNaN(id)) {
+    throw new Error(`No Reality.eth template for question type: ${type}`);
+  }
+  return id;
+}
+
+export function getTemplateTextForId(templateId: number): string | undefined {
+  const contents = realityTemplate.preloadedTemplateContents() as Record<
+    string,
+    string
+  >;
+  return contents[String(templateId)];
+}
+
+export function getTemplateTextForQuestionType(type: QuestionType): string {
+  return realityTemplate.defaultTemplateForType(type);
+}


### PR DESCRIPTION
## Summary
- Register BotID-protected routes for prediction quota/record/metadata and search autocomplete APIs to fix production 403 errors.
- Fix search input flashing by removing the controlled-value race and double debounce; improve autocomplete empty/loading/error states.
- Decode resolved uint answers readably, fetch Supabase metadata for mis-parsed markets, and use correct Reality.eth template IDs on create.

## Test plan
- [ ] Deploy preview and confirm `/api/predictions/quota` and `/api/search/*` return 200 (not 403)
- [ ] Type in Discover, Market, and Predict search — no letter flashing; dropdown shows results after 2+ chars
- [ ] Admin create page shows unlimited allowance without "Access denied"
- [ ] Resolved uint market displays `5` instead of `0x…000005`
- [ ] New uint/select predictions parse title correctly (no "Badly formatted question")
- [ ] `npx vitest run lib/predictions/parse-prediction-display.test.ts lib/predictions/reality-template.test.ts app/api/predictions/quota/route.test.ts`


Made with [Cursor](https://cursor.com)