### PR TITLE
Fix missing getSongchainConfig import (build)

### DIFF
--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -38,6 +38,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { usePredictionAccess } from "@/lib/hooks/predictions/usePredictionAccess";
 import { ShareDialog } from "@/components/Videos/ShareDialog";
 import { useSongchainPost } from "@/hooks/useSongchainPost";
+import { getSongchainConfig } from "@/lib/songchain/config";
 import { getTemplateIdForQuestionType } from "@/lib/predictions/reality-template";
 
 const PREDICTION_CATEGORIES = [


### PR DESCRIPTION
## Summary
- Restores `getSongchainConfig` import in `CreatePrediction.tsx` that was accidentally dropped when adding `getTemplateIdForQuestionType`.
- Fixes Vercel TypeScript build failure on `main` (commit acf80a5).

## Test plan
- [ ] `yarn build` passes

Made with [Cursor](https://cursor.com)