### PR TITLE
Improve predictions UX with enriched display, search, and claim detection

### DIFF
--- a/app/api/predictions/claim-status/route.ts
+++ b/app/api/predictions/claim-status/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { isAddress, createPublicClient, http, fallback } from "viem";
+import { base } from "@account-kit/infra";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import {
+  getFinalAnswer,
+  getQuestion,
+} from "@/lib/sdk/reality-eth/reality-eth-question-wrapper";
+import { enrichPredictionDisplaySync } from "@/lib/predictions/enrich-prediction-display";
+import { getUserClaimStatus } from "@/lib/predictions/claim-status";
+
+export async function GET(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.generous(request);
+  if (rl) return rl;
+
+  const questionId = request.nextUrl.searchParams.get("questionId")?.trim();
+  const address = request.nextUrl.searchParams.get("address")?.trim();
+  const smartAccount = request.nextUrl.searchParams
+    .get("smartAccount")
+    ?.trim();
+
+  if (!questionId || !/^0x[a-fA-F0-9]{64}$/.test(questionId)) {
+    return NextResponse.json(
+      { error: "Valid questionId is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!address || !isAddress(address)) {
+    return NextResponse.json(
+      { error: "Valid address is required" },
+      { status: 400 }
+    );
+  }
+
+  const publicClient = createPublicClient({
+    chain: base,
+    transport: fallback([
+      http(
+        process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+          ? `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
+          : undefined
+      ),
+      http("https://mainnet.base.org"),
+    ]),
+  });
+
+  try {
+    const [questionData, finalAnswer] = await Promise.all([
+      getQuestion(publicClient, questionId),
+      getFinalAnswer(publicClient, questionId).catch(() => null),
+    ]);
+
+    const { parsed } = enrichPredictionDisplaySync(
+      questionData.question ?? "",
+      questionData.template_id
+    );
+
+    const result = await getUserClaimStatus({
+      publicClient,
+      questionId,
+      addresses: [address, smartAccount],
+      finalAnswer,
+      parsed,
+    });
+
+    return NextResponse.json({
+      status: result.status,
+      winningAnswerLabel: result.winningAnswerLabel,
+      winningBondTotal: result.winningBondTotal.toString(),
+      contractBalance: result.contractBalance.toString(),
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to check claim status" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/predictions/metadata/route.ts
+++ b/app/api/predictions/metadata/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await supabaseService
     .from("prediction_market_creations")
-    .select("title, category, question_type")
+    .select("title, category, question_type, outcomes")
     .eq("question_id", questionId.toLowerCase())
     .maybeSingle();
 
@@ -45,6 +45,9 @@ export async function GET(request: NextRequest) {
       title: data.title ?? null,
       category: data.category ?? null,
       questionType: data.question_type ?? null,
+      outcomes: Array.isArray(data.outcomes)
+        ? (data.outcomes as string[])
+        : null,
     },
   });
 }

--- a/app/api/predictions/precog/route.ts
+++ b/app/api/predictions/precog/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { fetchPrecogMarket } from "@/lib/predictions/precog-markets";
+
+export async function GET(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.generous(request);
+  if (rl) return rl;
+
+  const chainId = parseInt(
+    request.nextUrl.searchParams.get("chainId") ?? "",
+    10
+  );
+  const marketId = parseInt(
+    request.nextUrl.searchParams.get("marketId") ?? "",
+    10
+  );
+
+  if (!Number.isFinite(chainId) || !Number.isFinite(marketId)) {
+    return NextResponse.json(
+      { error: "chainId and marketId are required" },
+      { status: 400 }
+    );
+  }
+
+  const data = await fetchPrecogMarket(chainId, marketId);
+  if (!data) {
+    return NextResponse.json({ market: null });
+  }
+
+  return NextResponse.json({ market: data });
+}

--- a/app/api/predictions/precog/route.ts
+++ b/app/api/predictions/precog/route.ts
@@ -11,18 +11,20 @@ export async function GET(request: NextRequest) {
   const rl = await rateLimiters.generous(request);
   if (rl) return rl;
 
-  const chainId = parseInt(
-    request.nextUrl.searchParams.get("chainId") ?? "",
-    10
-  );
-  const marketId = parseInt(
-    request.nextUrl.searchParams.get("marketId") ?? "",
-    10
-  );
+  const chainIdStr = request.nextUrl.searchParams.get("chainId");
+  const marketIdStr = request.nextUrl.searchParams.get("marketId");
 
-  if (!Number.isFinite(chainId) || !Number.isFinite(marketId)) {
+  const chainId = chainIdStr ? parseInt(chainIdStr, 10) : NaN;
+  const marketId = marketIdStr ? parseInt(marketIdStr, 10) : NaN;
+
+  if (
+    !Number.isInteger(chainId) ||
+    chainId <= 0 ||
+    !Number.isInteger(marketId) ||
+    marketId <= 0
+  ) {
     return NextResponse.json(
-      { error: "chainId and marketId are required" },
+      { error: "Valid positive integer chainId and marketId are required" },
       { status: 400 }
     );
   }

--- a/app/api/predictions/record/route.ts
+++ b/app/api/predictions/record/route.ts
@@ -23,6 +23,7 @@ const bodySchema = z.object({
   title: z.string().optional(),
   category: z.string().optional(),
   questionType: z.string().optional(),
+  outcomes: z.array(z.string()).optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -55,7 +56,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { address, transactionHash, questionId, title, category, questionType } =
+  const { address, transactionHash, questionId, title, category, questionType, outcomes } =
     parsed.data;
 
   try {
@@ -100,6 +101,7 @@ export async function POST(request: NextRequest) {
         title: title ?? null,
         category: category ?? null,
         question_type: questionType ?? null,
+        outcomes: outcomes?.length ? outcomes : null,
       });
 
     if (insertError) {

--- a/app/predict/[id]/page.tsx
+++ b/app/predict/[id]/page.tsx
@@ -17,12 +17,21 @@ import { getRealityEthContractAddress } from "@/lib/sdk/reality-eth/reality-eth-
 import { createPublicClient, http, fallback, formatEther } from "viem";
 import { baseMainnet } from "@/lib/utils/chains/base";
 import { getQuestion } from "@/lib/sdk/reality-eth/reality-eth-question-wrapper";
+import { enrichPredictionDisplaySync } from "@/lib/predictions/enrich-prediction-display";
 import { logger } from "@/lib/utils/logger";
 
 
 interface PredictionDetailsPageProps {
   params: Promise<{ id: string }>;
 }
+
+const PREDICTION_OG_IMAGE = {
+  url: "/images/prediction_banner.png",
+  width: 800,
+  height: 300,
+  alt: "The best way to predict the future is to create it.",
+  type: "image/png",
+} as const;
 
 export async function generateMetadata(
   { params }: PredictionDetailsPageProps,
@@ -50,11 +59,11 @@ export async function generateMetadata(
     let description = defaultDescription;
 
     if (questionData) {
-      if (questionData.question) {
-        // Try to parse the question if it's a template
-        // For standard reality.eth questions, the question text is often the title
-        title = questionData.question;
-      }
+      const { parsed } = enrichPredictionDisplaySync(
+        questionData.question ?? "",
+        questionData.template_id
+      );
+      title = parsed.title || defaultTitle;
 
       // Add bounty to description if it exists
       if (questionData.bounty && questionData.bounty > 0n) {
@@ -70,18 +79,32 @@ export async function generateMetadata(
         title: `Prediction: ${title}`,
         description: description,
         type: "website",
+        images: [PREDICTION_OG_IMAGE],
       },
       twitter: {
         card: "summary_large_image",
         title: `Prediction: ${title}`,
         description: description,
-      }
+        images: [PREDICTION_OG_IMAGE.url],
+      },
     };
   } catch (error) {
     logger.error("Error generating metadata:", error);
     return {
       title: defaultTitle,
       description: defaultDescription,
+      openGraph: {
+        title: defaultTitle,
+        description: defaultDescription,
+        type: "website",
+        images: [PREDICTION_OG_IMAGE],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: defaultTitle,
+        description: defaultDescription,
+        images: [PREDICTION_OG_IMAGE.url],
+      },
     };
   }
 }
@@ -127,20 +150,21 @@ export default async function PredictionDetailsPage({
           </Breadcrumb>
         </div>
 
-        <Card className="p-6 mb-6">
-          <div className="mb-4">
-            <Link
-              href={realityEthUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-blue-500 hover:text-blue-700 underline font-mono text-sm"
-            >
-              View on Reality.eth
-              <ExternalLink className="h-3 w-3" />
-            </Link>
-          </div>
+        <Card className="p-6 mb-4">
           <PredictionDetails questionId={id} />
         </Card>
+
+        <p className="text-center text-xs text-muted-foreground">
+          <Link
+            href={realityEthUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Verify on Reality.eth
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/app/predict/page.tsx
+++ b/app/predict/page.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from "react";
+import type { Metadata } from "next";
 import Image from "next/image";
 import {
   Breadcrumb,
@@ -12,6 +13,31 @@ import Link from "next/link";
 import { Slash } from "lucide-react";
 import { PredictionList } from "@/components/predictions/PredictionList";
 import { PredictionListSkeleton } from "@/components/predictions/PredictionListSkeleton";
+
+export const metadata: Metadata = {
+  title: "Predictions",
+  description: "Make predictions and bet on outcomes using Reality.eth.",
+  openGraph: {
+    title: "Predictions",
+    description: "Make predictions and bet on outcomes using Reality.eth.",
+    type: "website",
+    images: [
+      {
+        url: "/images/prediction_banner.png",
+        width: 800,
+        height: 300,
+        alt: "The best way to predict the future is to create it.",
+        type: "image/png",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Predictions",
+    description: "Make predictions and bet on outcomes using Reality.eth.",
+    images: ["/images/prediction_banner.png"],
+  },
+};
 
 export default function PredictPage() {
   return (

--- a/components/predictions/ClaimWinningsCard.tsx
+++ b/components/predictions/ClaimWinningsCard.tsx
@@ -11,26 +11,40 @@ import {
   buildClaimWinningsParams,
   claimWinnings as claimWinningsTx,
   withdraw,
-  getBalanceOf,
 } from "@/lib/sdk/reality-eth/reality-eth-question-wrapper";
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
 import { Loader2, Wallet, Gift } from "lucide-react";
 import { toast } from "sonner";
 import { logger } from "@/lib/utils/logger";
+import {
+  getUserClaimStatus,
+  type UserClaimStatus,
+} from "@/lib/predictions/claim-status";
+import type { ParsedPredictionDisplay } from "@/lib/predictions/parse-prediction-display";
 
 interface ClaimWinningsCardProps {
   questionId: string;
+  finalAnswer: string | null;
+  parsed: ParsedPredictionDisplay;
 }
 
 type ClaimStep = "idle" | "fetching" | "claiming" | "withdrawing" | "done" | "error";
 
-export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
-  const [balance, setBalance] = useState<bigint | null>(null);
+export function ClaimWinningsCard({
+  questionId,
+  finalAnswer,
+  parsed,
+}: ClaimWinningsCardProps) {
+  const [claimStatus, setClaimStatus] = useState<UserClaimStatus | null>(null);
+  const [winningBondTotal, setWinningBondTotal] = useState<bigint>(0n);
+  const [contractBalance, setContractBalance] = useState<bigint | null>(null);
   const [step, setStep] = useState<ClaimStep>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [canClaim, setCanClaim] = useState<boolean | null>(null);
+  const [winningAnswerLabel, setWinningAnswerLabel] = useState<string | null>(
+    null
+  );
 
-  const { isConnected, walletAddress } = useWalletStatus();
+  const { isConnected, walletAddress, smartAccountAddress } = useWalletStatus();
   const { client: accountKitClient } = useSmartAccountClient({});
 
   const publicClient = useMemo(
@@ -49,25 +63,41 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
     []
   );
 
-  const fetchBalanceAndClaimability = useCallback(async () => {
-    if (!walletAddress) return;
+  const refreshStatus = useCallback(async () => {
+    if (!walletAddress || !finalAnswer) return;
     setError(null);
     try {
-      const bal = await getBalanceOf(publicClient, walletAddress as `0x${string}`);
-      setBalance(bal);
-      const history = await getAnswerHistory(publicClient, questionId);
-      setCanClaim(history.length > 0);
+      const result = await getUserClaimStatus({
+        publicClient,
+        questionId,
+        addresses: [walletAddress, smartAccountAddress],
+        finalAnswer,
+        parsed,
+      });
+      setClaimStatus(result.status);
+      setWinningBondTotal(result.winningBondTotal);
+      setContractBalance(result.contractBalance);
+      setWinningAnswerLabel(result.winningAnswerLabel);
     } catch (e: unknown) {
-      const err = e as { message?: string };
-      logger.error("Error fetching balance / history:", e);
-      setError(err?.message ?? "Failed to fetch");
-      setCanClaim(false);
+      logger.error("Error fetching claim status:", e);
+      setError((e as { message?: string })?.message ?? "Failed to check status");
     }
-  }, [questionId, walletAddress, publicClient]);
+  }, [
+    walletAddress,
+    smartAccountAddress,
+    finalAnswer,
+    publicClient,
+    questionId,
+    parsed,
+  ]);
 
   useEffect(() => {
-    if (isConnected && walletAddress) void fetchBalanceAndClaimability();
-  }, [isConnected, walletAddress, questionId, fetchBalanceAndClaimability]);
+    if (isConnected && walletAddress && finalAnswer) {
+      void refreshStatus();
+    } else {
+      setClaimStatus(null);
+    }
+  }, [isConnected, walletAddress, finalAnswer, refreshStatus]);
 
   const handleClaimAndWithdraw = async () => {
     if (!isConnected || !walletAddress || !accountKitClient) {
@@ -86,7 +116,8 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
         return;
       }
 
-      const { history_hashes, addrs, bonds, answers } = buildClaimWinningsParams(history);
+      const { history_hashes, addrs, bonds, answers } =
+        buildClaimWinningsParams(history);
 
       setStep("claiming");
       try {
@@ -98,32 +129,39 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
           answers,
         });
         toast.success("Winnings distributed.");
-      } catch (claimError: any) {
-        // If claim fails, we check if it was because it's already claimed or similar
-        const msg = claimError?.message || "";
+      } catch (claimError: unknown) {
+        const msg =
+          claimError instanceof Error ? claimError.message : "";
         logger.warn("Claim warning (might be already claimed):", claimError);
 
-        if (msg.toLowerCase().includes("already") || msg.toLowerCase().includes("revert")) {
+        if (
+          msg.toLowerCase().includes("already") ||
+          msg.toLowerCase().includes("revert")
+        ) {
           toast.info("Winnings might already be distributed. Checking balance...");
         } else {
-          // If it's a real unknown error, we stop here? 
-          // Or we continues to check balance just in case.
           toast.error("Distribution step failed, but checking for withdrawable funds...");
         }
       }
 
-      // Always check balance after claim attempt
-      const bal = await getBalanceOf(publicClient, walletAddress as `0x${string}`);
-      if (bal > 0n) {
-        setStep("withdrawing");
+      setStep("withdrawing");
+      const result = await getUserClaimStatus({
+        publicClient,
+        questionId,
+        addresses: [walletAddress, smartAccountAddress],
+        finalAnswer,
+        parsed,
+      });
+
+      if (result.contractBalance > 0n) {
         await withdraw(publicClient, accountKitClient as any);
         toast.success("Withdrawal successful!");
       } else {
-        toast.info("No funds to withdraw.");
+        toast.info("No funds to withdraw yet.");
       }
 
       setStep("done");
-      await fetchBalanceAndClaimability();
+      await refreshStatus();
     } catch (e: unknown) {
       logger.error("Claim/withdraw process error:", e);
       const msg = (e as { message?: string })?.message ?? "Process failed.";
@@ -144,7 +182,7 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
       await withdraw(publicClient, accountKitClient as any);
       toast.success("Withdrawal successful!");
       setStep("done");
-      await fetchBalanceAndClaimability();
+      await refreshStatus();
     } catch (e: unknown) {
       logger.error("Withdraw error:", e);
       setError((e as { message?: string })?.message ?? "Withdrawal failed.");
@@ -153,8 +191,35 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
     }
   };
 
-  const isLoading = step === "fetching" || step === "claiming" || step === "withdrawing";
-  const hasBalance = balance !== null && balance > 0n;
+  if (claimStatus === "not_participant" && isConnected) {
+    return null;
+  }
+
+  if (claimStatus === "bonded_lost" && isConnected) {
+    return (
+      <Card className="p-4 bg-muted/40 border-muted">
+        <p className="text-sm text-muted-foreground">
+          This prediction is resolved. Your bond was on a losing answer.
+        </p>
+      </Card>
+    );
+  }
+
+  if (claimStatus === "already_settled" && isConnected) {
+    return (
+      <Card className="p-4 bg-muted/40 border-muted">
+        <p className="text-sm text-muted-foreground">
+          Winnings for this market have already been claimed and withdrawn.
+        </p>
+      </Card>
+    );
+  }
+
+  const isLoading =
+    step === "fetching" || step === "claiming" || step === "withdrawing";
+  const hasBalance = contractBalance !== null && contractBalance > 0n;
+  const showClaimCta =
+    claimStatus === "won_pending_claim" || claimStatus === "won_withdrawable";
 
   return (
     <Card className="p-6 bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800">
@@ -164,32 +229,55 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
           Claim your winnings
         </h2>
       </div>
-      <p className="text-sm text-emerald-700 dark:text-emerald-300 mb-4">
-        This prediction is resolved. If you bonded on the winning answer, claim to distribute
-        winnings to your balance, then withdraw to your wallet.
-      </p>
 
       {!isConnected ? (
         <p className="text-sm text-amber-700 dark:text-amber-300">
           Connect your wallet to claim or withdraw.
         </p>
-      ) : (
+      ) : showClaimCta ? (
         <>
+          <p className="text-sm text-emerald-700 dark:text-emerald-300 mb-4">
+            {claimStatus === "won_pending_claim" ? (
+              <>
+                You bonded{" "}
+                <strong>
+                  {Number(formatEther(winningBondTotal)).toFixed(4)} ETH
+                </strong>{" "}
+                on{" "}
+                <strong>{winningAnswerLabel ?? "the winning answer"}</strong>.
+                Claim to distribute winnings, then withdraw to your wallet.
+              </>
+            ) : (
+              <>
+                You have{" "}
+                <strong>
+                  {Number(formatEther(contractBalance ?? 0n)).toFixed(4)} ETH
+                </strong>{" "}
+                ready to withdraw from Reality.eth
+                {contractBalance && contractBalance > winningBondTotal
+                  ? " (may include other markets)"
+                  : ""}
+                .
+              </>
+            )}
+          </p>
+
           <div className="flex flex-wrap items-center gap-3 mb-4">
             <Button
               type="button"
-              onClick={fetchBalanceAndClaimability}
+              onClick={refreshStatus}
               disabled={isLoading}
               variant="outline"
               size="sm"
               className="border-emerald-300 dark:border-emerald-700"
             >
-              {balance === null ? "Check balance" : "Refresh"}
+              Refresh
             </Button>
-            {balance !== null && (
+            {contractBalance !== null && (
               <span className="inline-flex items-center gap-1 text-sm text-emerald-800 dark:text-emerald-200">
                 <Wallet className="h-4 w-4" aria-hidden />
-                Withdrawable Balance: {Number(formatEther(balance)).toFixed(3)} ETH
+                Withdrawable balance:{" "}
+                {Number(formatEther(contractBalance)).toFixed(4)} ETH
               </span>
             )}
           </div>
@@ -201,42 +289,39 @@ export function ClaimWinningsCard({ questionId }: ClaimWinningsCardProps) {
           )}
 
           <div className="flex flex-wrap gap-2">
-            {canClaim !== false && (
+            {claimStatus === "won_pending_claim" && (
               <Button
                 type="button"
                 onClick={handleClaimAndWithdraw}
                 disabled={isLoading}
                 className="bg-emerald-600 hover:bg-emerald-700 text-white"
-                aria-label="Claim winnings and withdraw to wallet"
               >
                 {isLoading ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-                    {step === "claiming"
-                      ? "Distributing…"
-                      : step === "withdrawing"
-                        ? "Withdrawing…"
-                        : "Processing…"}
+                    Processing…
                   </>
                 ) : (
                   "Claim & withdraw"
                 )}
               </Button>
             )}
-            {hasBalance && (
+            {hasBalance && claimStatus === "won_withdrawable" && (
               <Button
                 type="button"
-                variant="outline"
                 onClick={handleWithdrawOnly}
                 disabled={isLoading}
-                className="border-emerald-400 dark:border-emerald-600"
-                aria-label="Withdraw balance only"
+                className="bg-emerald-600 hover:bg-emerald-700 text-white"
               >
-                Withdraw only
+                Withdraw
               </Button>
             )}
           </div>
         </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Checking claim eligibility…
+        </p>
       )}
     </Card>
   );

--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -40,15 +40,11 @@ import { ShareDialog } from "@/components/Videos/ShareDialog";
 import { useSongchainPost } from "@/hooks/useSongchainPost";
 import { getSongchainConfig } from "@/lib/songchain/config";
 import { getTemplateIdForQuestionType } from "@/lib/predictions/reality-template";
-
-const PREDICTION_CATEGORIES = [
-  { value: "creative tv", label: "Creative TV" },
-  { value: "songchain", label: "Songchain" },
-  { value: "general", label: "General" },
-  { value: "technology", label: "Technology" },
-  { value: "sports", label: "Sports" },
-  { value: "entertainment", label: "Entertainment" },
-] as const;
+import { PREDICTION_CATEGORIES } from "@/lib/predictions/categories";
+import {
+  REALITY_QUESTION_TYPES,
+  getRealityQuestionTypeOption,
+} from "@/lib/predictions/reality-question-types";
 
 const predictionSchema = z.object({
   title: z.string().min(3, "Title is required"),
@@ -401,6 +397,7 @@ function CreatePrediction() {
             title: values.title,
             category: values.category || "creative tv",
             questionType: values.type,
+            outcomes: finalOutcomes,
           }),
         });
         const recData = await rec.json();
@@ -562,31 +559,35 @@ function CreatePrediction() {
           <FormField
             name="type"
             control={form.control}
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Question type</FormLabel>
-                <div className="flex flex-wrap gap-2">
-                  {(
-                    [
-                      ["bool", "Yes / No"],
-                      ["single-select", "Pick one"],
-                      ["uint", "Number"],
-                    ] as const
-                  ).map(([value, label]) => (
-                    <Button
-                      key={value}
-                      type="button"
-                      variant={field.value === value ? "default" : "outline"}
-                      size="sm"
-                      onClick={() => field.onChange(value)}
-                    >
-                      {label}
-                    </Button>
-                  ))}
-                </div>
-                <FormMessage />
-              </FormItem>
-            )}
+            render={({ field }) => {
+              const selected = getRealityQuestionTypeOption(field.value);
+              return (
+                <FormItem>
+                  <FormLabel>Question type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select question type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {REALITY_QUESTION_TYPES.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {selected && (
+                    <p className="text-xs text-muted-foreground mt-1.5">
+                      {selected.description} (Reality.eth template{" "}
+                      {selected.templateId})
+                    </p>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
           />
 
           {(questionType === "single-select" || questionType === "multiple-select") && (

--- a/components/predictions/PredictionDetails.tsx
+++ b/components/predictions/PredictionDetails.tsx
@@ -1,24 +1,25 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { base } from "@account-kit/infra";
 import { createPublicClient, http, fallback, formatEther } from "viem";
+import { request } from "graphql-request";
 import {
   getQuestion,
   getFinalAnswer,
   type RealityEthQuestion,
 } from "@/lib/sdk/reality-eth/reality-eth-question-wrapper";
+import { GET_QUESTION } from "@/lib/sdk/reality-eth/reality-eth-subgraph";
 import {
-  parsePredictionDisplay,
   answerBytesToLabel,
   formatCategoryLabel,
-  applyPredictionMetadataOverride,
   type ParsedPredictionDisplay,
 } from "@/lib/predictions/parse-prediction-display";
+import { enrichPredictionDisplay } from "@/lib/predictions/enrich-prediction-display";
 import { BetForm } from "./BetForm";
 import { ClaimWinningsCard } from "./ClaimWinningsCard";
 import { Clock, Share2 } from "lucide-react";
@@ -31,6 +32,14 @@ interface PredictionDetailsProps {
 }
 
 type QuestionType = ParsedPredictionDisplay["type"];
+
+type AnswerTimelineEntry = {
+  answer: string;
+  bond: string;
+  answerer: string;
+  created: string;
+  label: string | null;
+};
 
 interface QuestionData extends Omit<
   RealityEthQuestion,
@@ -48,23 +57,30 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
   const [error, setError] = useState<string | null>(null);
   const [finalAnswer, setFinalAnswer] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
+  const [answerTimeline, setAnswerTimeline] = useState<AnswerTimelineEntry[]>(
+    []
+  );
+
+  const publicClient = useMemo(
+    () =>
+      createPublicClient({
+        chain: base,
+        transport: fallback([
+          http(
+            process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+              ? `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
+              : undefined
+          ),
+          http("https://mainnet.base.org"),
+        ]),
+      }),
+    []
+  );
 
   useEffect(() => {
     async function fetchQuestion() {
       try {
         setIsLoading(true);
-
-        const publicClient = createPublicClient({
-          chain: base,
-          transport: fallback([
-            http(
-              process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
-                ? `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
-                : undefined
-            ),
-            http("https://mainnet.base.org"),
-          ]),
-        });
 
         let questionDataRaw;
         try {
@@ -84,10 +100,12 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
           throw questionError;
         }
 
-        let parsed = parsePredictionDisplay(
-          questionDataRaw.question ?? "",
-          questionDataRaw.template_id
-        );
+        let metadata: {
+          title?: string | null;
+          questionType?: string | null;
+          category?: string | null;
+          outcomes?: string[] | null;
+        } | null = null;
 
         try {
           const metaRes = await fetch(
@@ -95,17 +113,66 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
           );
           if (metaRes.ok) {
             const metaJson = (await metaRes.json()) as {
-              metadata?: {
-                title?: string | null;
-                questionType?: string | null;
-                category?: string | null;
-              } | null;
+              metadata?: typeof metadata;
             };
-            parsed = applyPredictionMetadataOverride(parsed, metaJson.metadata);
+            metadata = metaJson.metadata ?? null;
           }
         } catch (metaErr) {
           logger.debug("Prediction metadata fetch skipped:", metaErr);
         }
+
+        let subgraphOutcomes: unknown;
+        let subgraphCategory: string | null = null;
+        let timeline: AnswerTimelineEntry[] = [];
+
+        if (typeof window !== "undefined") {
+          try {
+            const endpoint = `${window.location.origin}/api/reality-eth-subgraph`;
+            const subgraphData = (await request(endpoint, GET_QUESTION, {
+              id: questionId,
+            })) as {
+              question?: {
+                outcomes?: string;
+                category?: string;
+                answers?: Array<{
+                  answer: string;
+                  bond: string;
+                  answerer: string;
+                  created: string;
+                }>;
+              };
+            };
+
+            subgraphOutcomes = subgraphData?.question?.outcomes;
+            subgraphCategory = subgraphData?.question?.category ?? null;
+
+            const { parsed: previewParsed } = await enrichPredictionDisplay(
+              questionDataRaw.question ?? "",
+              questionDataRaw.template_id,
+              { subgraphOutcomes, subgraphCategory, metadata }
+            );
+
+            timeline = (subgraphData?.question?.answers ?? [])
+              .slice()
+              .reverse()
+              .slice(0, 8)
+              .map((a) => ({
+                answer: a.answer,
+                bond: a.bond,
+                answerer: a.answerer,
+                created: a.created,
+                label: answerBytesToLabel(a.answer, previewParsed),
+              }));
+          } catch (subErr) {
+            logger.debug("Subgraph enrichment skipped:", subErr);
+          }
+        }
+
+        const { parsed } = await enrichPredictionDisplay(
+          questionDataRaw.question ?? "",
+          questionDataRaw.template_id,
+          { subgraphOutcomes, subgraphCategory, metadata }
+        );
 
         const questionData: QuestionData = {
           ...questionDataRaw,
@@ -118,6 +185,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
         };
 
         setQuestion(questionData);
+        setAnswerTimeline(timeline);
 
         try {
           const answer = await getFinalAnswer(publicClient, questionId);
@@ -144,7 +212,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
     if (questionId) {
       fetchQuestion();
     }
-  }, [questionId]);
+  }, [questionId, publicClient]);
 
   if (isLoading) {
     return (
@@ -194,34 +262,32 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
   return (
     <div className="space-y-6">
       <div>
-        <div className="flex items-start gap-2 mb-2 flex-wrap">
-          <h1 className="text-2xl font-bold flex-1 min-w-0">{parsed.title}</h1>
-          <div className="flex gap-2 items-center flex-wrap">
-            <Badge variant="outline">{formatCategoryLabel(parsed.category)}</Badge>
-            <Badge variant="secondary">{parsed.language}</Badge>
-            {isResolved ? (
-              <Badge variant="secondary">Resolved</Badge>
-            ) : isPendingArbitration ? (
-              <Badge variant="destructive">Arbitration Pending</Badge>
-            ) : isFinalizing ? (
-              <Badge className="bg-yellow-500 hover:bg-yellow-600">Finalizing</Badge>
-            ) : isActive ? (
-              <Badge className="bg-green-600 hover:bg-green-700">Active</Badge>
-            ) : (
-              <Badge variant="secondary">Closed</Badge>
-            )}
-            {!isResolved && (
-              <EvidenceSubmissionModal questionId={questionId} />
-            )}
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => setShareOpen(true)}
-              title="Share Prediction"
-            >
-              <Share2 className="h-4 w-4" />
-            </Button>
-          </div>
+        <h1 className="text-2xl font-bold mb-3">{parsed.title}</h1>
+        <div className="flex gap-2 items-center flex-wrap mb-4">
+          <Badge variant="outline">{formatCategoryLabel(parsed.category)}</Badge>
+          <Badge variant="secondary">{parsed.language}</Badge>
+          {isResolved ? (
+            <Badge variant="secondary">Resolved</Badge>
+          ) : isPendingArbitration ? (
+            <Badge variant="destructive">Arbitration Pending</Badge>
+          ) : isFinalizing ? (
+            <Badge className="bg-yellow-500 hover:bg-yellow-600">Finalizing</Badge>
+          ) : isActive ? (
+            <Badge className="bg-green-600 hover:bg-green-700">Active</Badge>
+          ) : (
+            <Badge variant="secondary">Closed</Badge>
+          )}
+          {!isResolved && (
+            <EvidenceSubmissionModal questionId={questionId} />
+          )}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setShareOpen(true)}
+            title="Share Prediction"
+          >
+            <Share2 className="h-4 w-4" />
+          </Button>
         </div>
 
         <div className="text-sm text-muted-foreground space-y-1 mb-4">
@@ -262,21 +328,25 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
         <div className="text-foreground/90">{parsed.description}</div>
       )}
 
-      {parsed.outcomes.length > 1 && !isResolved && (
+      {parsed.outcomes.length > 0 && (
         <Card className="p-4">
           <h3 className="text-sm font-medium text-muted-foreground mb-2">
             Outcomes
           </h3>
           <div className="flex flex-wrap gap-2">
-            {parsed.outcomes.map((o) => (
-              <Badge
-                key={o}
-                variant={leadingLabel === o ? "default" : "outline"}
-              >
-                {o}
-                {leadingLabel === o ? " · leading" : ""}
-              </Badge>
-            ))}
+            {parsed.outcomes.map((o) => {
+              const isFinal = isResolved && finalLabel === o;
+              const isLeading = !isResolved && leadingLabel === o;
+              return (
+                <Badge
+                  key={o}
+                  variant={isFinal || isLeading ? "default" : "outline"}
+                >
+                  {o}
+                  {isFinal ? " · final" : isLeading ? " · leading" : ""}
+                </Badge>
+              );
+            })}
           </div>
         </Card>
       )}
@@ -291,7 +361,11 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
               {finalLabel}
             </div>
           </Card>
-          <ClaimWinningsCard questionId={questionId} />
+          <ClaimWinningsCard
+            questionId={questionId}
+            finalAnswer={finalAnswer}
+            parsed={parsed}
+          />
         </>
       ) : (
         leadingLabel &&
@@ -317,6 +391,29 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
             )}
           </Card>
         )
+      )}
+
+      {answerTimeline.length > 0 && (
+        <Card className="p-4">
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">
+            Recent answers
+          </h3>
+          <ul className="space-y-2 text-sm">
+            {answerTimeline.map((entry, idx) => (
+              <li
+                key={`${entry.answerer}-${entry.created}-${idx}`}
+                className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 pb-2 last:border-0 last:pb-0"
+              >
+                <span className="font-medium">
+                  {entry.label ?? "Unknown answer"}
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  {Number(formatEther(BigInt(entry.bond || "0"))).toFixed(4)} ETH
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Card>
       )}
 
       {isActive && !isResolved && (

--- a/components/predictions/PredictionDetails.tsx
+++ b/components/predictions/PredictionDetails.tsx
@@ -124,6 +124,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
         let subgraphOutcomes: unknown;
         let subgraphCategory: string | null = null;
         let timeline: AnswerTimelineEntry[] = [];
+        let parsedDisplay: ParsedPredictionDisplay | null = null;
 
         if (typeof window !== "undefined") {
           try {
@@ -151,6 +152,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
               questionDataRaw.template_id,
               { subgraphOutcomes, subgraphCategory, metadata }
             );
+            parsedDisplay = previewParsed;
 
             timeline = (subgraphData?.question?.answers ?? [])
               .slice()
@@ -168,11 +170,15 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
           }
         }
 
-        const { parsed } = await enrichPredictionDisplay(
-          questionDataRaw.question ?? "",
-          questionDataRaw.template_id,
-          { subgraphOutcomes, subgraphCategory, metadata }
-        );
+        const parsed =
+          parsedDisplay ??
+          (
+            await enrichPredictionDisplay(
+              questionDataRaw.question ?? "",
+              questionDataRaw.template_id,
+              { subgraphOutcomes, subgraphCategory, metadata }
+            )
+          ).parsed;
 
         const questionData: QuestionData = {
           ...questionDataRaw,

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -122,8 +122,14 @@ export function PredictionList() {
   const [claimStatusMap, setClaimStatusMap] = useState<
     Record<string, UserClaimStatus>
   >({});
+  const fetchedClaimStatusRef = useRef<Set<string>>(new Set());
 
   const { isConnected, walletAddress, smartAccountAddress } = useWalletStatus();
+
+  useEffect(() => {
+    fetchedClaimStatusRef.current.clear();
+    setClaimStatusMap({});
+  }, [walletAddress, smartAccountAddress]);
 
   useEffect(() => {
     async function fetchQuestions() {
@@ -419,7 +425,6 @@ export function PredictionList() {
 
   useEffect(() => {
     if (!isConnected || !walletAddress) {
-      setClaimStatusMap({});
       return;
     }
 
@@ -427,10 +432,13 @@ export function PredictionList() {
       (q) =>
         q.best_answer &&
         q.best_answer !==
-          "0x0000000000000000000000000000000000000000000000000000000000000000"
+          "0x0000000000000000000000000000000000000000000000000000000000000000" &&
+        !fetchedClaimStatusRef.current.has(q.id)
     );
 
     if (resolvedCandidates.length === 0) return;
+
+    resolvedCandidates.forEach((q) => fetchedClaimStatusRef.current.add(q.id));
 
     let cancelled = false;
     (async () => {
@@ -447,25 +455,31 @@ export function PredictionList() {
             const res = await fetch(
               `/api/predictions/claim-status?${params.toString()}`
             );
-            if (!res.ok) return [q.id, null] as const;
+            if (!res.ok) {
+              fetchedClaimStatusRef.current.delete(q.id);
+              return [q.id, null] as const;
+            }
             const data = (await res.json()) as { status: UserClaimStatus };
             return [q.id, data.status] as const;
           } catch {
+            fetchedClaimStatusRef.current.delete(q.id);
             return [q.id, null] as const;
           }
         })
       );
       if (cancelled) return;
-      const next: Record<string, UserClaimStatus> = {};
-      for (const [id, status] of entries) {
-        if (
-          status === "won_pending_claim" ||
-          status === "won_withdrawable"
-        ) {
-          next[id] = status;
+      setClaimStatusMap((prev) => {
+        const next = { ...prev };
+        for (const [id, status] of entries) {
+          if (
+            status === "won_pending_claim" ||
+            status === "won_withdrawable"
+          ) {
+            next[id] = status;
+          }
         }
-      }
-      setClaimStatusMap(next);
+        return next;
+      });
     })();
 
     return () => {

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
-import { Clock } from "lucide-react";
+import { Clock, Gift } from "lucide-react";
 import { request, gql } from "graphql-request";
 import { getAddress, isAddress } from "viem";
 import { logger } from "@/lib/utils/logger";
@@ -17,12 +17,26 @@ import {
   GET_QUESTIONS_LIST_MINIMAL,
 } from "@/lib/sdk/reality-eth/reality-eth-subgraph";
 import {
-  parsePredictionDisplay,
   answerBytesToLabel,
   formatCategoryLabel,
   isSongchainCategory,
+  normalizeCategoryKey,
 } from "@/lib/predictions/parse-prediction-display";
+import { enrichPredictionDisplaySync } from "@/lib/predictions/enrich-prediction-display";
+import {
+  PREDICTION_CATEGORIES,
+  ALL_CATEGORIES_VALUE,
+} from "@/lib/predictions/categories";
 import { PredictiveSearchInput } from "@/components/search/PredictiveSearchInput";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
+import type { UserClaimStatus } from "@/lib/predictions/claim-status";
 
 const APP_ARBITRATOR = "0x0000000000000000000000000000000000000000";
 
@@ -71,6 +85,22 @@ interface Question {
   description?: string;
   parsedCategory?: string;
   leadingLabel?: string | null;
+  claimStatus?: UserClaimStatus | null;
+}
+
+function matchesSearchQuery(q: Question, sq: string): boolean {
+  const haystack = [
+    q.title,
+    q.parsedCategory,
+    q.category,
+    q.description,
+    q.question,
+    ...(q.outcomes ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(sq);
 }
 
 /**
@@ -82,13 +112,18 @@ interface Question {
 const ITEMS_PER_PAGE = 20;
 
 export function PredictionList() {
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [allQuestions, setAllQuestions] = useState<Question[]>([]);
+  const [rawQuestions, setRawQuestions] = useState<Question[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("creative_tv");
+  const [categoryFilter, setCategoryFilter] = useState<string>(ALL_CATEGORIES_VALUE);
   const [searchQuery, setSearchQuery] = useState("");
+  const [claimStatusMap, setClaimStatusMap] = useState<
+    Record<string, UserClaimStatus>
+  >({});
+
+  const { isConnected, walletAddress, smartAccountAddress } = useWalletStatus();
 
   useEffect(() => {
     async function fetchQuestions() {
@@ -183,29 +218,31 @@ export function PredictionList() {
 
         const parsedQuestions: Question[] = (fetchedQuestions || []).map((q) => {
           const rawQuestion = q.question || "";
-          const display = parsePredictionDisplay(rawQuestion, q.template_id);
-          let title = display.title;
-          let description: string | undefined = display.description;
+          const subgraphOutcomes =
+            usedField === "questions" && typeof q.outcomes === "string"
+              ? q.outcomes
+              : q.outcomes;
+          const { parsed: display } = enrichPredictionDisplaySync(
+            rawQuestion,
+            q.template_id,
+            {
+              subgraphOutcomes,
+              subgraphCategory: q.category ?? null,
+            }
+          );
+          const title = display.title;
+          const description = display.description;
           const parsedCategory = display.category;
+          const outcomes =
+            usedField === "questions" && typeof q.outcomes === "string"
+              ? q.outcomes.split("\n").filter(Boolean)
+              : display.outcomes;
+          const enrichedDisplay = { ...display, outcomes };
           const leadingLabel = q.best_answer
-            ? answerBytesToLabel(q.best_answer, display)
+            ? answerBytesToLabel(q.best_answer, enrichedDisplay)
             : null;
 
-          try {
-            if (rawQuestion.length > 0) {
-              title = display.title;
-            }
-          } catch (e) {
-            logger.warn('Could not parse question text for question', q.id, e);
-          }
-
           if (usedField === "questions") {
-            const outcomesRaw = q.outcomes;
-            const outcomes =
-              typeof outcomesRaw === "string" && outcomesRaw.length > 0
-                ? outcomesRaw.split("\n").filter(Boolean)
-                : undefined;
-
             return {
               id: q.id,
               template_id: q.template_id?.toString() ?? "0",
@@ -224,7 +261,7 @@ export function PredictionList() {
               last_bond_ts: q.last_bond_ts != null ? String(q.last_bond_ts) : undefined,
               category: q.category ?? parsedCategory,
               language: q.language ?? display.language,
-              outcomes: outcomes ?? display.outcomes,
+              outcomes,
               title,
               description,
               parsedCategory,
@@ -242,7 +279,7 @@ export function PredictionList() {
             finalize_ts: undefined,
             is_pending_arbitration: false,
             bounty: "0",
-            best_answer: undefined,
+            best_answer: q.best_answer,
             history_hash: "",
             arbitrator: q.arbitrator || "",
             min_bond: "0",
@@ -250,7 +287,7 @@ export function PredictionList() {
             last_bond_ts: undefined,
             category: parsedCategory,
             language: display.language,
-            outcomes: display.outcomes,
+            outcomes,
             title,
             description,
             parsedCategory,
@@ -304,37 +341,7 @@ export function PredictionList() {
           }
         }
 
-        const appArbNorm = normalizeArbitrator(APP_ARBITRATOR);
-        let filteredQuestions = parsedQuestions;
-
-        if (sourceFilter === "creative_tv") {
-          filteredQuestions = parsedQuestions.filter(
-            (q) => normalizeArbitrator(q.arbitrator) === appArbNorm
-          );
-        } else if (sourceFilter === "songchain") {
-          filteredQuestions = parsedQuestions.filter(
-            (q) =>
-              normalizeArbitrator(q.arbitrator) === appArbNorm &&
-              isSongchainCategory(q.parsedCategory ?? q.category ?? "")
-          );
-        }
-
-        if (searchQuery.trim()) {
-          const sq = searchQuery.trim().toLowerCase();
-          filteredQuestions = filteredQuestions.filter(
-            (q) =>
-              (q.title ?? "").toLowerCase().includes(sq) ||
-              (q.parsedCategory ?? "").toLowerCase().includes(sq)
-          );
-        }
-
-        setAllQuestions(filteredQuestions);
-
-        // Apply pagination
-        const safeFilteredQuestions = filteredQuestions || [];
-        const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-        const endIndex = startIndex + ITEMS_PER_PAGE;
-        setQuestions(safeFilteredQuestions.slice(startIndex, endIndex));
+        setRawQuestions(parsedQuestions);
       } catch (err: any) {
         logger.error('Failed to fetch questions from Reality.eth subgraph:', err);
 
@@ -361,16 +368,129 @@ export function PredictionList() {
         }
 
         setError(errorMessage);
-        // Set empty arrays on error to prevent undefined errors
-        setAllQuestions([]);
-        setQuestions([]);
+        setRawQuestions([]);
       } finally {
         setIsLoading(false);
       }
     }
 
     fetchQuestions();
-  }, [currentPage, sourceFilter, searchQuery])
+  }, []);
+
+  const filteredQuestions = useMemo(() => {
+    const appArbNorm = normalizeArbitrator(APP_ARBITRATOR);
+    let list = rawQuestions;
+
+    if (sourceFilter === "creative_tv") {
+      list = list.filter(
+        (q) => normalizeArbitrator(q.arbitrator) === appArbNorm
+      );
+    } else if (sourceFilter === "songchain") {
+      list = list.filter(
+        (q) =>
+          normalizeArbitrator(q.arbitrator) === appArbNorm &&
+          isSongchainCategory(q.parsedCategory ?? q.category ?? "")
+      );
+    }
+
+    if (categoryFilter !== ALL_CATEGORIES_VALUE) {
+      const key = normalizeCategoryKey(categoryFilter);
+      list = list.filter(
+        (q) => normalizeCategoryKey(q.parsedCategory ?? q.category ?? "") === key
+      );
+    }
+
+    if (searchQuery.trim()) {
+      const sq = searchQuery.trim().toLowerCase();
+      list = list.filter((q) => matchesSearchQuery(q, sq));
+    }
+
+    return list;
+  }, [rawQuestions, sourceFilter, categoryFilter, searchQuery]);
+
+  const totalQuestions = filteredQuestions.length;
+  const totalPages =
+    totalQuestions > 0 ? Math.ceil(totalQuestions / ITEMS_PER_PAGE) : 1;
+
+  const questions = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filteredQuestions.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  }, [filteredQuestions, currentPage]);
+
+  useEffect(() => {
+    if (!isConnected || !walletAddress) {
+      setClaimStatusMap({});
+      return;
+    }
+
+    const resolvedCandidates = questions.filter(
+      (q) =>
+        q.best_answer &&
+        q.best_answer !==
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+    );
+
+    if (resolvedCandidates.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        resolvedCandidates.map(async (q) => {
+          try {
+            const params = new URLSearchParams({
+              questionId: q.id,
+              address: walletAddress,
+            });
+            if (smartAccountAddress) {
+              params.set("smartAccount", smartAccountAddress);
+            }
+            const res = await fetch(
+              `/api/predictions/claim-status?${params.toString()}`
+            );
+            if (!res.ok) return [q.id, null] as const;
+            const data = (await res.json()) as { status: UserClaimStatus };
+            return [q.id, data.status] as const;
+          } catch {
+            return [q.id, null] as const;
+          }
+        })
+      );
+      if (cancelled) return;
+      const next: Record<string, UserClaimStatus> = {};
+      for (const [id, status] of entries) {
+        if (
+          status === "won_pending_claim" ||
+          status === "won_withdrawable"
+        ) {
+          next[id] = status;
+        }
+      }
+      setClaimStatusMap(next);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isConnected, walletAddress, smartAccountAddress, questions]);
+
+  const localSuggest = useCallback(
+    (query: string) => {
+      const sq = query.trim().toLowerCase();
+      if (sq.length < 2) return [];
+      return filteredQuestions
+        .filter((q) => matchesSearchQuery(q, sq))
+        .slice(0, 8)
+        .map((q) => ({
+          questionId: q.id,
+          title: q.title || "Prediction",
+          subtitle: q.parsedCategory
+            ? formatCategoryLabel(q.parsedCategory)
+            : undefined,
+          href: `/predict/${q.id}`,
+        }));
+    },
+    [filteredQuestions]
+  );
 
   if (isLoading) {
     return (
@@ -395,9 +515,8 @@ export function PredictionList() {
     );
   }
 
-  const totalQuestions = allQuestions?.length || 0;
-  const totalPages = totalQuestions > 0 ? Math.ceil(totalQuestions / ITEMS_PER_PAGE) : 1;
-  const hasNextPage = totalQuestions > 0 && currentPage < totalPages;
+  const totalQuestionsDisplay = filteredQuestions?.length || 0;
+  const hasNextPage = totalQuestionsDisplay > 0 && currentPage < totalPages;
   const hasPrevPage = currentPage > 1;
 
   const handleNextPage = () => {
@@ -419,20 +538,30 @@ export function PredictionList() {
     setCurrentPage(1);
   };
 
+  const setCategory = (value: string) => {
+    setCategoryFilter(value);
+    setCurrentPage(1);
+  };
+
   return (
     <div className="space-y-4">
       <PredictiveSearchInput
         scope="predictions"
-        placeholder="Search predictions by title or category…"
-        onQueryChange={setSearchQuery}
+        placeholder="Search predictions by title, category, or outcomes…"
+        onQueryChange={(q) => {
+          setSearchQuery(q);
+          setCurrentPage(1);
+        }}
+        localSuggest={localSuggest}
         className="max-w-xl"
       />
 
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-        <div className="flex flex-col gap-1.5">
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Source
-          </span>
+      <div className="flex flex-col lg:flex-row items-start lg:items-end justify-between gap-4">
+        <div className="flex flex-col sm:flex-row gap-6 flex-wrap">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Source
+            </span>
           <div
             className="inline-flex rounded-lg border bg-muted/40 p-1 flex-wrap"
             role="group"
@@ -482,10 +611,30 @@ export function PredictionList() {
               <strong>songchain</strong>.
             </p>
           )}
+          </div>
+
+          <div className="flex flex-col gap-1.5 min-w-[160px]">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Category
+            </span>
+            <Select value={categoryFilter} onValueChange={setCategory}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="All categories" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_CATEGORIES_VALUE}>All categories</SelectItem>
+                {PREDICTION_CATEGORIES.map((cat) => (
+                  <SelectItem key={cat.value} value={cat.value}>
+                    {cat.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
         <div className="text-sm text-muted-foreground">
-          {totalQuestions > 0
-            ? `Showing ${questions?.length || 0} of ${totalQuestions} question${totalQuestions === 1 ? "" : "s"}`
+          {totalQuestionsDisplay > 0
+            ? `Showing ${questions?.length || 0} of ${totalQuestionsDisplay} question${totalQuestionsDisplay === 1 ? "" : "s"}`
             : sourceFilter === "songchain"
               ? "No Songchain predictions in this view"
               : sourceFilter === "creative_tv"
@@ -494,7 +643,7 @@ export function PredictionList() {
         </div>
       </div>
 
-      {totalQuestions === 0 ? (
+      {totalQuestionsDisplay === 0 ? (
         <div className="rounded-lg border border-dashed p-8 text-center">
           <p className="font-medium text-foreground">No predictions found</p>
           <p className="mt-2 text-sm text-muted-foreground max-w-md mx-auto">
@@ -533,6 +682,12 @@ export function PredictionList() {
                         {question.leadingLabel && (
                           <Badge variant="secondary" className="text-xs">
                             Leading: {question.leadingLabel}
+                          </Badge>
+                        )}
+                        {claimStatusMap[question.id] && (
+                          <Badge className="text-xs bg-emerald-600 hover:bg-emerald-700">
+                            <Gift className="h-3 w-3 mr-1" aria-hidden />
+                            Claim winnings
                           </Badge>
                         )}
                       </div>

--- a/components/search/PredictiveSearchInput.tsx
+++ b/components/search/PredictiveSearchInput.tsx
@@ -32,6 +32,8 @@ interface PredictiveSearchInputProps {
   resetKey?: number;
   onQueryChange: (query: string) => void;
   onSelect?: (result: SuggestResult) => void;
+  /** Client-side suggestions (e.g. from already-loaded list data). */
+  localSuggest?: (query: string) => SuggestResult[];
   className?: string;
   inputClassName?: string;
   showClear?: boolean;
@@ -43,6 +45,7 @@ export function PredictiveSearchInput({
   resetKey = 0,
   onQueryChange,
   onSelect,
+  localSuggest,
   className,
   inputClassName,
   showClear = true,
@@ -83,11 +86,27 @@ export function PredictiveSearchInput({
     onQueryChangeRef.current(debounced);
   }, [debounced]);
 
+  const localSuggestRef = useRef(localSuggest);
+  useEffect(() => {
+    localSuggestRef.current = localSuggest;
+  }, [localSuggest]);
+
   useEffect(() => {
     if (debounced.trim().length < 2) {
       setResults([]);
       setFetchError(null);
       setOpen(false);
+      return;
+    }
+
+    const localResults = localSuggestRef.current?.(debounced.trim()) ?? [];
+
+    if (localResults.length > 0) {
+      setResults(localResults);
+      setFetchError(null);
+      setOpen(true);
+      setLoading(false);
+      setActiveIndex(-1);
       return;
     }
 

--- a/lib/predictions/categories.ts
+++ b/lib/predictions/categories.ts
@@ -1,0 +1,13 @@
+export const PREDICTION_CATEGORIES = [
+  { value: "creative tv", label: "Creative TV" },
+  { value: "songchain", label: "Songchain" },
+  { value: "general", label: "General" },
+  { value: "technology", label: "Technology" },
+  { value: "sports", label: "Sports" },
+  { value: "entertainment", label: "Entertainment" },
+] as const;
+
+export const ALL_CATEGORIES_VALUE = "all" as const;
+
+export type PredictionCategoryValue =
+  (typeof PREDICTION_CATEGORIES)[number]["value"];

--- a/lib/predictions/claim-status.ts
+++ b/lib/predictions/claim-status.ts
@@ -1,0 +1,153 @@
+import type { Address, PublicClient } from "viem";
+import { getAddress, isAddress } from "viem";
+import {
+  getAnswerHistory,
+  getBalanceOf,
+  isQuestionFinalized,
+  type AnswerHistoryEntry,
+} from "@/lib/sdk/reality-eth/reality-eth-question-wrapper";
+import { answerBytesToLabel } from "@/lib/predictions/parse-prediction-display";
+import type { ParsedPredictionDisplay } from "@/lib/predictions/parse-prediction-display";
+
+export type UserClaimStatus =
+  | "not_participant"
+  | "bonded_lost"
+  | "won_pending_claim"
+  | "won_withdrawable"
+  | "already_settled";
+
+export type UserClaimStatusResult = {
+  status: UserClaimStatus;
+  winningBondTotal: bigint;
+  winningAnswerLabel: string | null;
+  contractBalance: bigint;
+  userEntries: AnswerHistoryEntry[];
+};
+
+const ZERO_ANSWER =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+function normalizeAddresses(addresses: (string | null | undefined)[]): Address[] {
+  const seen = new Set<string>();
+  const result: Address[] = [];
+  for (const addr of addresses) {
+    if (!addr || !isAddress(addr)) continue;
+    const normalized = getAddress(addr).toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(getAddress(addr));
+  }
+  return result;
+}
+
+function normalizeAnswerHex(hex: string): string {
+  return hex.toLowerCase();
+}
+
+function filterUserEntries(
+  history: AnswerHistoryEntry[],
+  addresses: Address[]
+): AnswerHistoryEntry[] {
+  const addrSet = new Set(addresses.map((a) => a.toLowerCase()));
+  return history.filter(
+    (e) => !e.is_commitment && addrSet.has(e.user.toLowerCase())
+  );
+}
+
+function sumWinningBonds(
+  entries: AnswerHistoryEntry[],
+  finalAnswer: string
+): bigint {
+  const target = normalizeAnswerHex(finalAnswer);
+  return entries
+    .filter((e) => normalizeAnswerHex(e.answer) === target)
+    .reduce((sum, e) => sum + e.bond, 0n);
+}
+
+export async function getUserClaimStatus(params: {
+  publicClient: PublicClient;
+  questionId: string;
+  addresses: (string | null | undefined)[];
+  finalAnswer: string | null;
+  parsed: ParsedPredictionDisplay;
+}): Promise<UserClaimStatusResult> {
+  const addrs = normalizeAddresses(params.addresses);
+  const empty: UserClaimStatusResult = {
+    status: "not_participant",
+    winningBondTotal: 0n,
+    winningAnswerLabel: null,
+    contractBalance: 0n,
+    userEntries: [],
+  };
+
+  if (!params.finalAnswer || params.finalAnswer === ZERO_ANSWER) {
+    return empty;
+  }
+
+  if (addrs.length === 0) {
+    return empty;
+  }
+
+  const finalized = await isQuestionFinalized(
+    params.publicClient,
+    params.questionId
+  );
+  if (!finalized) {
+    return empty;
+  }
+
+  const history = await getAnswerHistory(params.publicClient, params.questionId);
+  const userEntries = filterUserEntries(history, addrs);
+
+  if (userEntries.length === 0) {
+    return empty;
+  }
+
+  const winningBondTotal = sumWinningBonds(userEntries, params.finalAnswer);
+  const winningAnswerLabel = answerBytesToLabel(
+    params.finalAnswer,
+    params.parsed
+  );
+
+  let contractBalance = 0n;
+  for (const addr of addrs) {
+    contractBalance += await getBalanceOf(params.publicClient, addr);
+  }
+
+  if (winningBondTotal > 0n) {
+    if (contractBalance > 0n) {
+      return {
+        status: "won_withdrawable",
+        winningBondTotal,
+        winningAnswerLabel,
+        contractBalance,
+        userEntries,
+      };
+    }
+    return {
+      status: "won_pending_claim",
+      winningBondTotal,
+      winningAnswerLabel,
+      contractBalance,
+      userEntries,
+    };
+  }
+
+  if (contractBalance > 0n) {
+    return {
+      status: "won_withdrawable",
+      winningBondTotal: 0n,
+      winningAnswerLabel,
+      contractBalance,
+      userEntries,
+    };
+  }
+
+  return {
+    status: "bonded_lost",
+    winningBondTotal: 0n,
+    winningAnswerLabel,
+    contractBalance: 0n,
+    userEntries,
+  };
+}

--- a/lib/predictions/enrich-prediction-display.ts
+++ b/lib/predictions/enrich-prediction-display.ts
@@ -1,0 +1,126 @@
+import {
+  parsePredictionDisplay,
+  applyPredictionMetadataOverride,
+  type ParsedPredictionDisplay,
+} from "@/lib/predictions/parse-prediction-display";
+import {
+  parsePrecogReference,
+  stripPrecogReference,
+  fetchPrecogMarket,
+  type PrecogMarketRef,
+} from "@/lib/predictions/precog-markets";
+
+export type PredictionMetadataOverride = {
+  title?: string | null;
+  questionType?: string | null;
+  category?: string | null;
+  outcomes?: string[] | null;
+};
+
+export type EnrichedPredictionDisplay = {
+  parsed: ParsedPredictionDisplay;
+  precogRef: PrecogMarketRef | null;
+};
+
+function parseSubgraphOutcomes(outcomesRaw: unknown): string[] {
+  if (Array.isArray(outcomesRaw)) {
+    return outcomesRaw.map(String).filter(Boolean);
+  }
+  if (typeof outcomesRaw === "string" && outcomesRaw.length > 0) {
+    return outcomesRaw.split("\n").filter(Boolean);
+  }
+  return [];
+}
+
+function mergeOutcomes(
+  parsed: ParsedPredictionDisplay,
+  ...sources: (string[] | undefined)[]
+): ParsedPredictionDisplay {
+  for (const src of sources) {
+    if (src && src.length > 0) {
+      const type =
+        parsed.type === "bool" && src.length > 2
+          ? "single-select"
+          : parsed.type;
+      return { ...parsed, type, outcomes: src };
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Synchronous enrichment from on-chain text + optional subgraph/metadata fields.
+ */
+export function enrichPredictionDisplaySync(
+  questionText: string,
+  templateId?: string | number | bigint | null,
+  options?: {
+    subgraphOutcomes?: unknown;
+    subgraphCategory?: string | null;
+    metadata?: PredictionMetadataOverride | null;
+  }
+): EnrichedPredictionDisplay {
+  let parsed = parsePredictionDisplay(questionText, templateId);
+  const precogRef = parsePrecogReference(parsed.title);
+
+  if (precogRef) {
+    parsed = { ...parsed, title: stripPrecogReference(parsed.title) };
+  }
+
+  const subgraphOutcomes = parseSubgraphOutcomes(options?.subgraphOutcomes);
+  if (options?.subgraphCategory?.trim()) {
+    parsed = { ...parsed, category: options.subgraphCategory.trim() };
+  }
+
+  parsed = mergeOutcomes(parsed, subgraphOutcomes);
+  parsed = applyPredictionMetadataOverride(parsed, options?.metadata ?? null);
+
+  if (options?.metadata?.outcomes?.length) {
+    parsed = mergeOutcomes(parsed, options.metadata.outcomes);
+  }
+
+  return { parsed, precogRef };
+}
+
+/**
+ * Full enrichment including async Precog market fetch when reference detected.
+ */
+export async function enrichPredictionDisplay(
+  questionText: string,
+  templateId?: string | number | bigint | null,
+  options?: {
+    subgraphOutcomes?: unknown;
+    subgraphCategory?: string | null;
+    metadata?: PredictionMetadataOverride | null;
+    fetchImpl?: typeof fetch;
+  }
+): Promise<EnrichedPredictionDisplay> {
+  const base = enrichPredictionDisplaySync(questionText, templateId, options);
+
+  if (!base.precogRef) return base;
+
+  const precog = await fetchPrecogMarket(
+    base.precogRef.chainId,
+    base.precogRef.marketId,
+    options?.fetchImpl
+  );
+
+  if (!precog) return base;
+
+  let parsed = base.parsed;
+  if (precog.title?.trim()) {
+    parsed = { ...parsed, title: precog.title.trim() };
+  }
+  if (precog.category?.trim()) {
+    parsed = { ...parsed, category: precog.category.trim() };
+  }
+  if (precog.outcomes.length > 0) {
+    parsed = {
+      ...parsed,
+      type: "single-select",
+      outcomes: precog.outcomes,
+    };
+  }
+
+  return { parsed, precogRef: base.precogRef };
+}

--- a/lib/predictions/parse-prediction-display.test.ts
+++ b/lib/predictions/parse-prediction-display.test.ts
@@ -114,4 +114,27 @@ describe("parsePredictionDisplay", () => {
     expect(parsed.title).toBe("Test question?");
     expect(parsed.title).not.toContain("[Badly formatted question]");
   });
+
+  it("maps ordinal answer to outcome label when outcomes exist", () => {
+    const parsed = parsePredictionDisplay(
+      'Pick a movie?\u241f"Movie A","Movie B","Movie C","Movie D","Movie E"\u241fgeneral\u241fen_US',
+      2
+    );
+    expect(
+      answerBytesToLabel(
+        "0x0000000000000000000000000000000000000000000000000000000000000005",
+        parsed
+      )
+    ).toBe("Movie E");
+  });
+
+  it("applies metadata outcomes override", () => {
+    const parsed = parsePredictionDisplay("Test?\u241fgeneral\u241fen_US", 0);
+    const updated = applyPredictionMetadataOverride(parsed, {
+      outcomes: ["Alpha", "Beta", "Gamma"],
+      questionType: "single-select",
+    });
+    expect(updated.outcomes).toEqual(["Alpha", "Beta", "Gamma"]);
+    expect(updated.type).toBe("single-select");
+  });
 });

--- a/lib/predictions/parse-prediction-display.ts
+++ b/lib/predictions/parse-prediction-display.ts
@@ -99,14 +99,17 @@ function isValidQuestionType(value: string): value is ParsedPredictionDisplay["t
   );
 }
 
+export type PredictionMetadataInput = {
+  title?: string | null;
+  questionType?: string | null;
+  category?: string | null;
+  outcomes?: string[] | null;
+};
+
 /** Prefer Supabase-stored title when on-chain parse failed. */
 export function applyPredictionMetadataOverride(
   parsed: ParsedPredictionDisplay,
-  metadata?: {
-    title?: string | null;
-    questionType?: string | null;
-    category?: string | null;
-  } | null
+  metadata?: PredictionMetadataInput | null
 ): ParsedPredictionDisplay {
   if (!metadata) return parsed;
 
@@ -131,6 +134,16 @@ export function applyPredictionMetadataOverride(
 
   if (metadata.category?.trim()) {
     next = { ...next, category: metadata.category.trim() };
+  }
+
+  if (metadata.outcomes?.length) {
+    next = { ...next, outcomes: metadata.outcomes.filter(Boolean) };
+    if (
+      next.type === "bool" &&
+      next.outcomes.length > 2
+    ) {
+      next = { ...next, type: "single-select" };
+    }
   }
 
   return next;
@@ -215,6 +228,29 @@ function decodeUintAnswer(answerHex: string): string | null {
   }
 }
 
+/** Map small integer answers to outcome labels (Precog-style ordinal indexing). */
+function outcomeLabelFromIndex(
+  answerHex: string,
+  outcomes: string[]
+): string | null {
+  if (outcomes.length === 0) return null;
+  try {
+    const value = BigInt(answerHex);
+    if (value < 0n || value >= BigInt(outcomes.length + 1)) return null;
+    // Try 1-based index first (answer 1 → outcomes[0])
+    if (value >= 1n && value <= BigInt(outcomes.length)) {
+      return outcomes[Number(value) - 1];
+    }
+    // Then 0-based index
+    if (value < BigInt(outcomes.length)) {
+      return outcomes[Number(value)];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 /**
  * Map bytes32 answer to human-readable label.
  */
@@ -236,6 +272,8 @@ export function answerBytesToLabel(
   }
 
   if (effectiveType === "uint") {
+    const indexLabel = outcomeLabelFromIndex(answerHex, parsed.outcomes);
+    if (indexLabel) return indexLabel;
     return decodeUintAnswer(answerHex) ?? answerHex;
   }
 
@@ -252,6 +290,8 @@ export function answerBytesToLabel(
   if (normalized === ZERO_ANSWER.toLowerCase()) return "No";
 
   if (looksLikeUintAnswer(normalized)) {
+    const indexLabel = outcomeLabelFromIndex(answerHex, parsed.outcomes);
+    if (indexLabel) return indexLabel;
     return decodeUintAnswer(answerHex);
   }
 

--- a/lib/predictions/precog-markets.ts
+++ b/lib/predictions/precog-markets.ts
@@ -30,6 +30,20 @@ export type PrecogMarketData = {
 
 const precogCache = new Map<string, { data: PrecogMarketData; expires: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_SIZE = 1000;
+
+function evictPrecogCacheIfNeeded(): void {
+  if (precogCache.size <= CACHE_MAX_SIZE) return;
+  const now = Date.now();
+  for (const [key, entry] of precogCache.entries()) {
+    if (entry.expires <= now) {
+      precogCache.delete(key);
+    }
+  }
+  if (precogCache.size > CACHE_MAX_SIZE) {
+    precogCache.clear();
+  }
+}
 
 function cacheKey(chainId: number, marketId: number): string {
   return `${chainId}:${marketId}`;
@@ -105,6 +119,7 @@ export async function fetchPrecogMarket(
       const json = await res.json();
       const data = parsePrecogMarketPayload(json);
       if (data.outcomes.length > 0 || data.title) {
+        evictPrecogCacheIfNeeded();
         precogCache.set(key, { data, expires: Date.now() + CACHE_TTL_MS });
         return data;
       }

--- a/lib/predictions/precog-markets.ts
+++ b/lib/predictions/precog-markets.ts
@@ -1,0 +1,117 @@
+/** Matches `[core.precog.markets/8453/18]` suffix in question titles. */
+export const PRECOG_REF_PATTERN =
+  /\[core\.precog\.markets\/(\d+)\/(\d+)\]\s*$/i;
+
+export type PrecogMarketRef = {
+  chainId: number;
+  marketId: number;
+  raw: string;
+};
+
+export function parsePrecogReference(text: string): PrecogMarketRef | null {
+  const match = (text ?? "").trim().match(PRECOG_REF_PATTERN);
+  if (!match) return null;
+  return {
+    chainId: Number(match[1]),
+    marketId: Number(match[2]),
+    raw: match[0],
+  };
+}
+
+export function stripPrecogReference(text: string): string {
+  return (text ?? "").replace(PRECOG_REF_PATTERN, "").trim();
+}
+
+export type PrecogMarketData = {
+  title?: string;
+  outcomes: string[];
+  category?: string;
+};
+
+const precogCache = new Map<string, { data: PrecogMarketData; expires: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function cacheKey(chainId: number, marketId: number): string {
+  return `${chainId}:${marketId}`;
+}
+
+function normalizeOutcomes(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => {
+      if (typeof item === "string") return item.trim();
+      if (item && typeof item === "object" && "label" in item) {
+        return String((item as { label: unknown }).label).trim();
+      }
+      if (item && typeof item === "object" && "name" in item) {
+        return String((item as { name: unknown }).name).trim();
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+/** Parse Precog API JSON into display-friendly outcomes. */
+export function parsePrecogMarketPayload(json: unknown): PrecogMarketData {
+  if (!json || typeof json !== "object") {
+    return { outcomes: [] };
+  }
+  const obj = json as Record<string, unknown>;
+  const market =
+    obj.market && typeof obj.market === "object"
+      ? (obj.market as Record<string, unknown>)
+      : obj;
+
+  let outcomes = normalizeOutcomes(market.outcomes);
+  if (outcomes.length === 0) outcomes = normalizeOutcomes(market.options);
+  if (outcomes.length === 0) outcomes = normalizeOutcomes(market.choices);
+
+  const title =
+    typeof market.title === "string"
+      ? market.title
+      : typeof market.question === "string"
+        ? market.question
+        : undefined;
+
+  const category =
+    typeof market.category === "string" ? market.category : undefined;
+
+  return { title, outcomes, category };
+}
+
+export async function fetchPrecogMarket(
+  chainId: number,
+  marketId: number,
+  fetchImpl: typeof fetch = fetch
+): Promise<PrecogMarketData | null> {
+  const key = cacheKey(chainId, marketId);
+  const cached = precogCache.get(key);
+  if (cached && cached.expires > Date.now()) {
+    return cached.data;
+  }
+
+  const endpoints = [
+    `https://core.precog.markets/api/markets/${chainId}/${marketId}`,
+    `https://core.precog.markets/api/v1/markets/${chainId}/${marketId}`,
+  ];
+
+  for (const url of endpoints) {
+    try {
+      const res = await fetchImpl(url, {
+        headers: { Accept: "application/json" },
+        next: { revalidate: 300 },
+      });
+      if (!res.ok) continue;
+      const json = await res.json();
+      const data = parsePrecogMarketPayload(json);
+      if (data.outcomes.length > 0 || data.title) {
+        precogCache.set(key, { data, expires: Date.now() + CACHE_TTL_MS });
+        return data;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/lib/predictions/reality-question-types.ts
+++ b/lib/predictions/reality-question-types.ts
@@ -1,0 +1,47 @@
+import type { QuestionType } from "@/lib/sdk/reality-eth/reality-eth-utils";
+import { getTemplateIdForQuestionType } from "@/lib/predictions/reality-template";
+
+export type RealityQuestionTypeOption = {
+  value: QuestionType;
+  label: string;
+  description: string;
+  templateId: number;
+  requiresOutcomes: boolean;
+};
+
+export const REALITY_QUESTION_TYPES: RealityQuestionTypeOption[] = [
+  {
+    value: "bool",
+    label: "Yes / No",
+    description: "Binary question with Yes and No answers.",
+    templateId: getTemplateIdForQuestionType("bool"),
+    requiresOutcomes: false,
+  },
+  {
+    value: "uint",
+    label: "Number",
+    description: "Numeric answer (e.g. price, count, score).",
+    templateId: getTemplateIdForQuestionType("uint"),
+    requiresOutcomes: false,
+  },
+  {
+    value: "single-select",
+    label: "Single choice",
+    description: "Pick exactly one option from a list.",
+    templateId: getTemplateIdForQuestionType("single-select"),
+    requiresOutcomes: true,
+  },
+  {
+    value: "multiple-select",
+    label: "Multiple choice",
+    description: "Pick one or more options from a list.",
+    templateId: getTemplateIdForQuestionType("multiple-select"),
+    requiresOutcomes: true,
+  },
+];
+
+export function getRealityQuestionTypeOption(
+  type: QuestionType
+): RealityQuestionTypeOption | undefined {
+  return REALITY_QUESTION_TYPES.find((t) => t.value === type);
+}

--- a/supabase/migrations/20260606120000_prediction_outcomes_column.sql
+++ b/supabase/migrations/20260606120000_prediction_outcomes_column.sql
@@ -1,0 +1,7 @@
+-- Store outcome labels for Creative TV-created prediction markets (display + search).
+
+ALTER TABLE public.prediction_market_creations
+  ADD COLUMN IF NOT EXISTS outcomes jsonb;
+
+COMMENT ON COLUMN public.prediction_market_creations.outcomes IS
+  'Human-readable outcome labels for select-type prediction markets.';


### PR DESCRIPTION
## Summary
- Add a unified prediction display pipeline (Precog, subgraph, Supabase metadata) so answers render as meaningful labels instead of raw Yes/No/index values.
- Fix the predictions list with category filtering, client-side search suggestions, and split fetch/filter logic to avoid reload flicker on keystroke.
- Personalize claim/withdraw UX by detecting whether the connected wallet bonded on the winning answer, and align the create form with standard Reality.eth question types.

## Test plan
- [ ] Open `/predict`, search by title/category/outcome, and confirm results filter without full-page reload
- [ ] Use category + source filters together and verify list results update correctly
- [ ] Open a resolved Precog market and confirm title/answer labels are human-readable (no `[core.precog.markets/…]` suffix or bare `5`)
- [ ] On a resolved market where you bonded on the winning answer, verify personalized claim/withdraw messaging and list badge
- [ ] Create a prediction using each Reality.eth question type and confirm outcomes/metadata persist
- [ ] Apply Supabase migration `20260606120000_prediction_outcomes_column.sql` before testing stored outcomes in prod-like env


Made with [Cursor](https://cursor.com)