### PR TITLE
Cut predict subgraph to Graph Studio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,9 @@ GOLDSKY_REALITY_ETH_PROJECT_ID=
 # Any other Reality.eth-compatible proxy (product-specific deployments) — set the contract address here.
 # NEXT_PUBLIC_REALITY_ETH_ARBITRATOR=
 
-# --- Graph Studio (merged creative-platform subgraph) ---
-# goldsky | studio | dual
-SUBGRAPH_PROVIDER_MODE=goldsky
+# --- Graph Studio (merged creative-platform subgraph — production primary) ---
+# studio (default) | goldsky (rollback) | dual
+SUBGRAPH_PROVIDER_MODE=studio
 # Full query URL, e.g. https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>
 GRAPH_STUDIO_CREATIVE_PLATFORM_URL=
 # Deploy key used by scripts/graph-studio/deploy-creative-platform.sh

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -119,19 +119,27 @@ No configuration is required as these are public endpoints:
 
 **Note:** The Reality.eth subgraph endpoint is accessed via `/api/reality-eth-subgraph` to handle CORS.
 
-#### Graph Studio (Merged Creative Platform Subgraph)
+#### Graph Studio (Merged Creative Platform Subgraph) — Primary
+
+Production uses **The Graph Studio only** (`SUBGRAPH_PROVIDER_MODE=studio`). The merged
+`creative-platform` subgraph serves MeTokens and Reality.eth (`questions`, `answers`).
 
 `SUBGRAPH_PROVIDER_MODE` (Optional)
-- Supported values: `goldsky` (default), `studio`, `dual`
-- `dual` attempts Graph Studio first, then falls back to Goldsky
+- Default: **`studio`**
+- Supported values: `studio` (production), `goldsky` (emergency rollback), `dual` (Studio first, then Goldsky)
 
 `GRAPH_STUDIO_CREATIVE_PLATFORM_URL` (Required for `studio` or `dual`)
-- Full GraphQL query URL for your Graph Studio deployment
-- Example format: `https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>`
+- Full GraphQL query URL from Graph Studio → **Query** tab after deploy
+- Example: `https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>`
+- If you see `deployment ... does not exist`, redeploy and update this URL
 
 `GRAPH_STUDIO_DEPLOY_KEY` (Deployment only)
 - Used by `scripts/graph-studio/deploy-creative-platform.sh`
-- Keep server-side only
+- Keep server-side only; see `GRAPH_STUDIO_MIGRATION.md`
+
+#### Goldsky (Legacy rollback)
+
+Goldsky endpoints remain available when `SUBGRAPH_PROVIDER_MODE=goldsky` or `dual`:
 
 ### 5. Coinbase CDP Configuration (Onramp/Offramp)
 
@@ -327,11 +335,11 @@ NEXT_PUBLIC_NFT_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
 # Optional
 NEXT_PUBLIC_SUPPORT_URL=https://your-support-url.com
 
-# Note: SUBGRAPH_QUERY_KEY is no longer needed - now using Goldsky public endpoints
-# Optional Graph Studio migration vars
-# SUBGRAPH_PROVIDER_MODE=dual
-# GRAPH_STUDIO_CREATIVE_PLATFORM_URL=https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>
-# GRAPH_STUDIO_DEPLOY_KEY=<deploy-key>
+# Note: SUBGRAPH_QUERY_KEY is no longer needed — production uses Graph Studio
+# Graph Studio (primary) — see GRAPH_STUDIO_MIGRATION.md
+SUBGRAPH_PROVIDER_MODE=studio
+GRAPH_STUDIO_CREATIVE_PLATFORM_URL=https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>
+# GRAPH_STUDIO_DEPLOY_KEY=<deploy-key>  # deploy script only, server-side
 ```
 
 3. Replace the placeholder values with your actual keys

--- a/app/api/metokens-subgraph/route.ts
+++ b/app/api/metokens-subgraph/route.ts
@@ -2,27 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import { checkBotId } from 'botid/server';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
-
-// MeTokens subgraph endpoint - now using Goldsky
-// Deployment ID: QmVaWYhk4HKhk9rNQi11RKujTVS4KHF1uHGNVUF4f7xJ53
-const DEFAULT_PROJECT_ID = 'project_cmh0iv6s500dbw2p22vsxcfo6';
-const PROJECT_ID = process.env.GOLDSKY_PROJECT_ID || DEFAULT_PROJECT_ID;
-
-const getSubgraphUrl = (subgraphName: string, version: string, specificAccessType?: 'public' | 'private') => {
-  const isPrivate = !!process.env.GOLDSKY_API_KEY;
-  const accessType = specificAccessType || (isPrivate ? 'private' : 'public');
-  return `https://api.goldsky.com/api/${accessType}/${PROJECT_ID}/subgraphs/${subgraphName}/${version}/gn`;
-};
-
-type ProviderMode = 'goldsky' | 'studio' | 'dual';
-
-const getProviderMode = (): ProviderMode => {
-  const rawMode = process.env.SUBGRAPH_PROVIDER_MODE?.toLowerCase();
-  if (rawMode === 'studio' || rawMode === 'dual' || rawMode === 'goldsky') return rawMode;
-  return 'goldsky';
-};
-
-const getStudioUrl = () => process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL;
+import {
+  buildSubgraphRequestHeaders,
+  formatGraphQlErrors,
+  getSubgraphProviderMode,
+  GOLDSKY_ROLLBACK_HINT,
+  isGraphQlResponseSuccessful,
+  resolveSubgraphEndpoints,
+  STUDIO_URL_HINT,
+} from '@/lib/subgraph/creative-platform-proxy';
 
 export async function POST(request: NextRequest) {
   const verification = await checkBotId();
@@ -32,123 +20,109 @@ export async function POST(request: NextRequest) {
   const rl = await rateLimiters.generous(request);
   if (rl) return rl;
 
-  // Read body once at the start so we can reuse it in error handlers
-  let body: any;
+  let body: unknown;
   try {
     body = await request.json();
-  } catch (parseError) {
+  } catch {
     return NextResponse.json(
       {
         error: 'Invalid Request Body',
         message: 'Failed to parse request body as JSON',
       },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   try {
     serverLogger.debug('Subgraph proxy received request:', {
-      query: body.query?.substring(0, 100) + '...',
-      variables: body.variables,
+      query: (body as { query?: string }).query?.substring(0, 100) + '...',
+      variables: (body as { variables?: unknown }).variables,
+      providerMode: getSubgraphProviderMode(),
     });
 
-    const providerMode = getProviderMode();
-    const studioEndpoint = getStudioUrl();
+    const candidateEndpoints = resolveSubgraphEndpoints('metokens');
 
-    // Determine Goldsky endpoints
-    const isPrivate = !!process.env.GOLDSKY_API_KEY;
-    const privateEndpoint = getSubgraphUrl('metokens', '1.0.2', 'private');
-    const publicEndpoint = getSubgraphUrl('metokens', '1.0.2', 'public');
-    const goldskyPrimary = isPrivate ? privateEndpoint : publicEndpoint;
-
-    const candidateEndpoints: string[] = [];
-    if (providerMode === 'studio' || providerMode === 'dual') {
-      if (studioEndpoint) candidateEndpoints.push(studioEndpoint);
-    }
-    if (providerMode === 'goldsky' || providerMode === 'dual' || !studioEndpoint) {
-      candidateEndpoints.push(goldskyPrimary);
-    }
-    if (isPrivate) candidateEndpoints.push(publicEndpoint);
-
-    // Prepare headers
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    if (isPrivate && process.env.GOLDSKY_API_KEY) {
-      headers['Authorization'] = `Bearer ${process.env.GOLDSKY_API_KEY}`;
+    if (candidateEndpoints.length === 0) {
+      return NextResponse.json(
+        {
+          error: 'MeTokens Subgraph Not Configured',
+          hint: STUDIO_URL_HINT,
+        },
+        { status: 503 },
+      );
     }
 
-    // Helper to perform fetch
-    const performFetch = async (url: string, headers: Record<string, string>) => {
-      return fetch(url, {
+    let lastHttpError: { status: number; details: string; endpoint: string } | null = null;
+    let lastGraphQlError: { message: string; endpoint: string } | null = null;
+
+    for (const endpoint of candidateEndpoints) {
+      const headers = buildSubgraphRequestHeaders(endpoint);
+      serverLogger.debug(`Forwarding MeTokens query to endpoint: ${endpoint}`);
+
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
       });
-    };
 
-    if (candidateEndpoints.length === 0) {
-      throw new Error('No subgraph endpoints configured. Set GRAPH_STUDIO_CREATIVE_PLATFORM_URL or Goldsky variables.');
-    }
-
-    let response: Response | null = null;
-    let subgraphEndpoint = '';
-
-    for (const endpoint of candidateEndpoints) {
-      subgraphEndpoint = endpoint;
-      const endpointHeaders = endpoint.includes('goldsky.com') ? headers : { 'Content-Type': 'application/json' };
-      if (!endpoint.includes('goldsky.com') && endpointHeaders['Authorization']) {
-        delete endpointHeaders['Authorization'];
+      if (!response.ok) {
+        const errorText = await response.text();
+        lastHttpError = { status: response.status, details: errorText, endpoint };
+        serverLogger.error('MeTokens subgraph HTTP error:', lastHttpError);
+        continue;
       }
-      response = await performFetch(endpoint, endpointHeaders);
-      if (response.ok) break;
-    }
 
-    if (!response) throw new Error('No subgraph endpoint available');
+      const data = await response.json();
 
+      if (!isGraphQlResponseSuccessful(data)) {
+        const message = formatGraphQlErrors(data.errors ?? []);
+        lastGraphQlError = { message, endpoint };
+        serverLogger.error('MeTokens subgraph GraphQL error:', { endpoint, message });
+        continue;
+      }
 
-    serverLogger.debug('Subgraph response status:', response.status);
-
-    if (!response.ok) {
-      // Use stored error text if available, otherwise read from response
-      const errorText = await response.text();
-      serverLogger.error('Subgraph request failed:', {
-        status: response.status,
-        statusText: response.statusText,
-        error: errorText,
+      serverLogger.debug('Subgraph query successful:', {
+        endpoint,
+        dataKeys: data.data ? Object.keys(data.data) : [],
       });
 
+      return NextResponse.json(data);
+    }
+
+    if (lastGraphQlError) {
+      const isDeploymentMissing = lastGraphQlError.message.toLowerCase().includes('does not exist');
       return NextResponse.json(
         {
-          error: 'Subgraph Query Failed',
-          details: errorText,
-          status: response.status,
-          hint: response.status === 404
-            ? 'Subgraph not found. Verify Studio URL or Goldsky deployment details.'
-            : response.status === 429
-              ? 'Rate limit exceeded. Please try again later.'
-              : 'Subgraph server error.',
+          errors: [{ message: lastGraphQlError.message }],
+          hint: isDeploymentMissing
+            ? `${STUDIO_URL_HINT} ${GOLDSKY_ROLLBACK_HINT}`
+            : 'Subgraph query failed. Verify Graph Studio deployment is synced.',
         },
-        { status: response.status }
+        { status: 502 },
       );
     }
 
-    const data = await response.json();
-
-    // Check for GraphQL errors in the response
-    if (data.errors && data.errors.length > 0) {
-      serverLogger.error('GraphQL errors in response:', data.errors);
-      return NextResponse.json(data); // Return errors to client
+    if (lastHttpError) {
+      return NextResponse.json(
+        {
+          error: 'Subgraph Query Failed',
+          details: lastHttpError.details,
+          status: lastHttpError.status,
+          hint:
+            lastHttpError.status === 404
+              ? STUDIO_URL_HINT
+              : lastHttpError.status === 429
+                ? 'Rate limit exceeded. Please try again later.'
+                : 'Subgraph server error.',
+        },
+        { status: lastHttpError.status },
+      );
     }
 
-    serverLogger.debug('Subgraph query successful:', {
-      hasData: !!data.data,
-      dataKeys: data.data ? Object.keys(data.data) : [],
-    });
-
-    return NextResponse.json(data);
-
+    return NextResponse.json(
+      { error: 'No subgraph endpoint available', hint: STUDIO_URL_HINT },
+      { status: 503 },
+    );
   } catch (error) {
     serverLogger.error('Error proxying subgraph request:', error);
 
@@ -156,14 +130,13 @@ export async function POST(request: NextRequest) {
       {
         error: 'Internal Server Error',
         message: error instanceof Error ? error.message : 'Unknown error',
-        hint: 'Check server logs for more details. Using Goldsky (Deployment ID: QmVaWYhk4HKhk9rNQi11RKujTVS4KHF1uHGNVUF4f7xJ53).',
+        hint: STUDIO_URL_HINT,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
-// Handle preflight requests for CORS
 export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,

--- a/app/api/metokens-subgraph/route.ts
+++ b/app/api/metokens-subgraph/route.ts
@@ -3,8 +3,10 @@ import { checkBotId } from 'botid/server';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import {
+  asGraphQlRequestBody,
   buildSubgraphRequestHeaders,
   formatGraphQlErrors,
+  getGraphQlResponseErrors,
   getSubgraphProviderMode,
   GOLDSKY_ROLLBACK_HINT,
   isGraphQlResponseSuccessful,
@@ -34,9 +36,10 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const bodyObj = asGraphQlRequestBody(body);
     serverLogger.debug('Subgraph proxy received request:', {
-      query: (body as { query?: string }).query?.substring(0, 100) + '...',
-      variables: (body as { variables?: unknown }).variables,
+      query: bodyObj.query?.substring(0, 100) + '...',
+      variables: bodyObj.variables,
       providerMode: getSubgraphProviderMode(),
     });
 
@@ -72,18 +75,31 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
-      const data = await response.json();
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch (jsonError) {
+        lastHttpError = {
+          status: response.status,
+          details: 'Failed to parse JSON response',
+          endpoint,
+        };
+        serverLogger.error('MeTokens subgraph JSON parse error:', jsonError);
+        continue;
+      }
 
       if (!isGraphQlResponseSuccessful(data)) {
-        const message = formatGraphQlErrors(data.errors ?? []);
+        const message = formatGraphQlErrors(getGraphQlResponseErrors(data));
         lastGraphQlError = { message, endpoint };
         serverLogger.error('MeTokens subgraph GraphQL error:', { endpoint, message });
         continue;
       }
 
+      const payload = data as { data: Record<string, unknown> };
+
       serverLogger.debug('Subgraph query successful:', {
         endpoint,
-        dataKeys: data.data ? Object.keys(data.data) : [],
+        dataKeys: payload.data ? Object.keys(payload.data) : [],
       });
 
       return NextResponse.json(data);

--- a/app/api/reality-eth-subgraph/route.ts
+++ b/app/api/reality-eth-subgraph/route.ts
@@ -2,29 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 import { checkBotId } from 'botid/server';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
-
-// Reality.eth subgraph endpoint - using Goldsky
-// Public URL: https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/reality-eth/1.0.0/gn
-// Uses the same project as MeTokens subgraphs
-// Set GOLDSKY_REALITY_ETH_PROJECT_ID environment variable to use a different project
-const DEFAULT_PROJECT_ID = 'project_cmh0iv6s500dbw2p22vsxcfo6';
-const PROJECT_ID = process.env.GOLDSKY_REALITY_ETH_PROJECT_ID || DEFAULT_PROJECT_ID;
-
-const getSubgraphUrl = (subgraphName: string, version: string, specificAccessType?: 'public' | 'private') => {
-  const isPrivate = !!process.env.GOLDSKY_API_KEY;
-  const accessType = specificAccessType || (isPrivate ? 'private' : 'public');
-  return `https://api.goldsky.com/api/${accessType}/${PROJECT_ID}/subgraphs/${subgraphName}/${version}/gn`;
-};
-
-type ProviderMode = 'goldsky' | 'studio' | 'dual';
-
-const getProviderMode = (): ProviderMode => {
-  const rawMode = process.env.SUBGRAPH_PROVIDER_MODE?.toLowerCase();
-  if (rawMode === 'studio' || rawMode === 'dual' || rawMode === 'goldsky') return rawMode;
-  return 'goldsky';
-};
-
-const getStudioUrl = () => process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL;
+import {
+  buildSubgraphRequestHeaders,
+  formatGraphQlErrors,
+  getSubgraphProviderMode,
+  GOLDSKY_ROLLBACK_HINT,
+  isGraphQlResponseSuccessful,
+  resolveSubgraphEndpoints,
+  STUDIO_URL_HINT,
+} from '@/lib/subgraph/creative-platform-proxy';
 
 export async function POST(request: NextRequest) {
   const verification = await checkBotId();
@@ -39,119 +25,105 @@ export async function POST(request: NextRequest) {
     serverLogger.debug('Reality.eth subgraph proxy received request:', {
       query: body.query?.substring(0, 100) + '...',
       variables: body.variables,
+      providerMode: getSubgraphProviderMode(),
     });
 
-    const providerMode = getProviderMode();
-    const studioEndpoint = getStudioUrl();
+    const candidateEndpoints = resolveSubgraphEndpoints('reality-eth');
 
-    // Determine Goldsky endpoints
-    const isPrivate = !!process.env.GOLDSKY_API_KEY;
-    const privateEndpoint = getSubgraphUrl('reality-eth', '1.0.0', 'private');
-    const publicEndpoint = getSubgraphUrl('reality-eth', '1.0.0', 'public');
-    const goldskyPrimary = isPrivate ? privateEndpoint : publicEndpoint;
-
-    const candidateEndpoints: string[] = [];
-    if (providerMode === 'studio' || providerMode === 'dual') {
-      if (studioEndpoint) candidateEndpoints.push(studioEndpoint);
-    }
-    if (providerMode === 'goldsky' || providerMode === 'dual' || !studioEndpoint) {
-      candidateEndpoints.push(goldskyPrimary);
-    }
-    if (isPrivate) candidateEndpoints.push(publicEndpoint);
-
-    // Prepare headers
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    if (isPrivate && process.env.GOLDSKY_API_KEY) {
-      headers['Authorization'] = `Bearer ${process.env.GOLDSKY_API_KEY}`;
+    if (candidateEndpoints.length === 0) {
+      return NextResponse.json(
+        {
+          error: 'Reality.eth Subgraph Not Configured',
+          hint: STUDIO_URL_HINT,
+        },
+        { status: 503 },
+      );
     }
 
-    // Helper to perform fetch
-    const performFetch = async (url: string, headers: Record<string, string>) => {
-      return fetch(url, {
+    let lastHttpError: { status: number; details: string; endpoint: string } | null = null;
+    let lastGraphQlError: { message: string; endpoint: string } | null = null;
+
+    for (const endpoint of candidateEndpoints) {
+      const headers = buildSubgraphRequestHeaders(endpoint);
+      serverLogger.debug(`Forwarding Reality.eth query to endpoint: ${endpoint}`);
+
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
       });
-    };
 
-    if (candidateEndpoints.length === 0) {
-      throw new Error('No subgraph endpoints configured. Set GRAPH_STUDIO_CREATIVE_PLATFORM_URL or Goldsky variables.');
-    }
-
-    let response: Response | null = null;
-    let subgraphEndpoint = '';
-    for (const endpoint of candidateEndpoints) {
-      subgraphEndpoint = endpoint;
-      const endpointHeaders = endpoint.includes('goldsky.com') ? headers : { 'Content-Type': 'application/json' };
-      if (!endpoint.includes('goldsky.com') && endpointHeaders['Authorization']) {
-        delete endpointHeaders['Authorization'];
+      if (!response.ok) {
+        const errorText = await response.text();
+        lastHttpError = { status: response.status, details: errorText, endpoint };
+        serverLogger.error('Reality.eth subgraph HTTP error:', lastHttpError);
+        continue;
       }
-      serverLogger.debug(`Forwarding Reality.eth query to endpoint: ${endpoint}`);
-      response = await performFetch(endpoint, endpointHeaders);
-      // Try every candidate until one succeeds. (Previous logic stopped on any 4xx,
-      // so a misconfigured Graph Studio URL blocked Goldsky fallback entirely.)
-      if (response.ok) break;
-    }
 
-    if (!response) throw new Error('No subgraph endpoint available');
+      const data = await response.json();
 
-    serverLogger.debug('Reality.eth subgraph response status:', response.status);
+      if (!isGraphQlResponseSuccessful(data)) {
+        const message = formatGraphQlErrors(data.errors ?? []);
+        lastGraphQlError = { message, endpoint };
+        serverLogger.error('Reality.eth subgraph GraphQL error:', { endpoint, message });
+        continue;
+      }
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      serverLogger.error('Goldsky Reality.eth subgraph request failed:', {
-        status: response.status,
-        statusText: response.statusText,
-        error: errorText,
+      serverLogger.debug('Reality.eth subgraph query successful:', {
+        endpoint,
+        dataKeys: data.data ? Object.keys(data.data) : [],
       });
 
-      return NextResponse.json(
-        {
-          error: 'Reality.eth Subgraph Query Failed',
-          details: errorText,
-          status: response.status,
-          hint: response.status === 404
-            ? 'Subgraph not found. Verify Studio URL or Goldsky deployment details.'
-            : response.status === 429
-              ? 'Rate limit exceeded. Please try again later.'
-              : 'Subgraph server error. The selected provider may be down or misconfigured.',
-        },
-        { status: response.status }
-      );
-    }
-
-    const data = await response.json();
-
-    // Check for GraphQL errors in the response
-    if (data.errors && data.errors.length > 0) {
-      serverLogger.error('GraphQL errors in response:', data.errors);
       return NextResponse.json(data);
     }
 
-    serverLogger.debug('Reality.eth subgraph query successful:', {
-      hasData: !!data.data,
-      dataKeys: data.data ? Object.keys(data.data) : [],
-    });
+    if (lastGraphQlError) {
+      const isDeploymentMissing = lastGraphQlError.message.toLowerCase().includes('does not exist');
+      return NextResponse.json(
+        {
+          errors: [{ message: lastGraphQlError.message }],
+          hint: isDeploymentMissing
+            ? `${STUDIO_URL_HINT} ${GOLDSKY_ROLLBACK_HINT}`
+            : 'Subgraph query failed. Verify Graph Studio deployment is synced.',
+        },
+        { status: 502 },
+      );
+    }
 
-    return NextResponse.json(data);
+    if (lastHttpError) {
+      return NextResponse.json(
+        {
+          error: 'Reality.eth Subgraph Query Failed',
+          details: lastHttpError.details,
+          status: lastHttpError.status,
+          hint:
+            lastHttpError.status === 404
+              ? STUDIO_URL_HINT
+              : lastHttpError.status === 429
+                ? 'Rate limit exceeded. Please try again later.'
+                : 'Subgraph server error. The selected provider may be down or misconfigured.',
+        },
+        { status: lastHttpError.status },
+      );
+    }
 
+    return NextResponse.json(
+      { error: 'No subgraph endpoint available', hint: STUDIO_URL_HINT },
+      { status: 503 },
+    );
   } catch (error) {
     serverLogger.error('Error proxying Reality.eth subgraph request:', error);
     return NextResponse.json(
       {
         error: 'Internal Server Error',
         message: error instanceof Error ? error.message : 'Unknown error',
-        hint: 'Check server logs for more details. Ensure the Reality.eth subgraph is deployed to Goldsky.',
+        hint: STUDIO_URL_HINT,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
-// Handle preflight requests for CORS
 export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,

--- a/app/api/reality-eth-subgraph/route.ts
+++ b/app/api/reality-eth-subgraph/route.ts
@@ -3,8 +3,10 @@ import { checkBotId } from 'botid/server';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import {
+  asGraphQlRequestBody,
   buildSubgraphRequestHeaders,
   formatGraphQlErrors,
+  getGraphQlResponseErrors,
   getSubgraphProviderMode,
   GOLDSKY_ROLLBACK_HINT,
   isGraphQlResponseSuccessful,
@@ -21,7 +23,8 @@ export async function POST(request: NextRequest) {
   if (rl) return rl;
 
   try {
-    const body = await request.json();
+    const rawBody = await request.json();
+    const body = asGraphQlRequestBody(rawBody);
     serverLogger.debug('Reality.eth subgraph proxy received request:', {
       query: body.query?.substring(0, 100) + '...',
       variables: body.variables,
@@ -50,7 +53,7 @@ export async function POST(request: NextRequest) {
       const response = await fetch(endpoint, {
         method: 'POST',
         headers,
-        body: JSON.stringify(body),
+        body: JSON.stringify(rawBody),
       });
 
       if (!response.ok) {
@@ -60,18 +63,31 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
-      const data = await response.json();
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch (jsonError) {
+        lastHttpError = {
+          status: response.status,
+          details: 'Failed to parse JSON response',
+          endpoint,
+        };
+        serverLogger.error('Reality.eth subgraph JSON parse error:', jsonError);
+        continue;
+      }
 
       if (!isGraphQlResponseSuccessful(data)) {
-        const message = formatGraphQlErrors(data.errors ?? []);
+        const message = formatGraphQlErrors(getGraphQlResponseErrors(data));
         lastGraphQlError = { message, endpoint };
         serverLogger.error('Reality.eth subgraph GraphQL error:', { endpoint, message });
         continue;
       }
 
+      const payload = data as { data: Record<string, unknown> };
+
       serverLogger.debug('Reality.eth subgraph query successful:', {
         endpoint,
-        dataKeys: data.data ? Object.keys(data.data) : [],
+        dataKeys: payload.data ? Object.keys(payload.data) : [],
       });
 
       return NextResponse.json(data);

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -188,8 +188,7 @@ export function PredictionList() {
 
         const parsedQuestions: Question[] = (fetchedQuestions || []).map((q) => {
           const rawQuestion = q.question || "";
-          const subgraphOutcomes =
-            typeof q.outcomes === "string" ? q.outcomes : q.outcomes;
+          const subgraphOutcomes = q.outcomes;
           const { parsed: display } = enrichPredictionDisplaySync(
             rawQuestion,
             q.template_id,

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -7,11 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
 import { Clock, Gift } from "lucide-react";
-import { request, gql } from "graphql-request";
+import { request } from "graphql-request";
 import { getAddress, isAddress } from "viem";
 import { logger } from "@/lib/utils/logger";
 import {
-  GET_LOG_NEW_QUESTIONS_LIST,
   GET_QUESTIONS_LIST,
   GET_QUESTIONS_LIST_BY_OPENING_TS,
   GET_QUESTIONS_LIST_MINIMAL,
@@ -145,89 +144,52 @@ export function PredictionList() {
         const endpoint = `${window.location.origin}/api/reality-eth-subgraph`;
         logger.debug('🔗 Fetching Reality.eth questions from:', endpoint);
 
-        // First, try to introspect the schema to see what fields are available
-        const INTROSPECTION_QUERY = gql`
-          query IntrospectSchema {
-            __schema {
-              queryType {
-                fields {
-                  name
-                  type {
-                    name
-                    kind
-                  }
-                }
-              }
-            }
-          }
-        `;
-
-        try {
-          const introspectionData = await request(endpoint, INTROSPECTION_QUERY) as any;
-          logger.debug('📋 Available query fields:', introspectionData?.__schema?.queryType?.fields);
-        } catch (introError) {
-          logger.warn('⚠️ Could not introspect schema:', introError);
-        }
-
-        // Graph Studio (creative-platform) exposes `questions`. Goldsky reality-eth uses `logNewQuestions`.
-        // Try `questions` first so Studio works; prefer a non-empty list if a later query shape returns [].
         const variables = {
           first: 200,
           skip: 0,
         };
 
-        const alternativeQueries = [
-          { field: "questions" as const, query: GET_QUESTIONS_LIST, label: "questions(orderBy:created)" },
-          { field: "questions" as const, query: GET_QUESTIONS_LIST_BY_OPENING_TS, label: "questions(orderBy:opening_ts)" },
-          { field: "questions" as const, query: GET_QUESTIONS_LIST_MINIMAL, label: "questions(minimal fields)" },
-          { field: "logNewQuestions" as const, query: GET_LOG_NEW_QUESTIONS_LIST, label: "logNewQuestions" },
-          { field: "log_new_questions" as const, query: gql`query GetQuestions($first: Int!, $skip: Int!) { log_new_questions(first: $first, skip: $skip, orderBy: opening_ts, orderDirection: desc) { id question_id template_id question arbitrator opening_ts timeout } }`, label: "log_new_questions" },
+        // Graph Studio creative-platform subgraph exposes `questions`.
+        const studioQueries = [
+          { query: GET_QUESTIONS_LIST, label: "questions(orderBy:created)" },
+          { query: GET_QUESTIONS_LIST_BY_OPENING_TS, label: "questions(orderBy:opening_ts)" },
+          { query: GET_QUESTIONS_LIST_MINIMAL, label: "questions(minimal fields)" },
         ];
 
-        let data: any = null;
-        let lastQueryError: any = null;
-        let usedField: (typeof alternativeQueries)[number]["field"] | null = null;
+        let data: { questions?: unknown[] } | null = null;
+        let lastQueryError: Error | null = null;
 
-        for (const alt of alternativeQueries) {
+        for (const candidate of studioQueries) {
           try {
-            logger.debug(`Trying subgraph query: ${alt.label}`);
-            const result = await request(endpoint, alt.query, variables) as any;
-            const rows = result?.[alt.field];
-            if (!Array.isArray(rows)) continue;
-            if (rows.length > 0) {
-              data = result;
-              usedField = alt.field;
-              logger.debug(`Using subgraph query: ${alt.label} (${rows.length} rows)`);
-              break;
-            }
-            if (!data) {
-              data = result;
-              usedField = alt.field;
-              logger.debug(`Subgraph query ${alt.label} returned 0 rows; will replace if a later query has data`);
-            }
-          } catch (e: any) {
-            lastQueryError = e;
-            logger.debug(`${alt.label} query failed:`, e?.message || e);
+            logger.debug(`Trying subgraph query: ${candidate.label}`);
+            const result = await request(endpoint, candidate.query, variables) as {
+              questions?: unknown[];
+            };
+            if (!Array.isArray(result?.questions)) continue;
+            data = result;
+            logger.debug(`Using subgraph query: ${candidate.label} (${result.questions.length} rows)`);
+            break;
+          } catch (e) {
+            lastQueryError = e instanceof Error ? e : new Error(String(e));
+            logger.debug(`${candidate.label} query failed:`, lastQueryError.message);
           }
         }
 
-        if (!data || !usedField) {
+        if (!data || !Array.isArray(data.questions)) {
           const errMsg = lastQueryError?.message || 'Unknown subgraph query error';
           throw new Error(
-            "The Reality.eth subgraph doesn't expose a compatible question field. " +
-            `Tried: ${alternativeQueries.map(q => q.label).join(', ')}. ` +
+            "Subgraph unavailable — check Graph Studio deployment URL. " +
+            `Tried: ${studioQueries.map((q) => q.label).join(', ')}. ` +
             `Last error: ${errMsg}`
           );
         }
 
-        const fetchedQuestions = data[usedField] as any[];
+        const fetchedQuestions = data.questions as any[];
 
         const parsedQuestions: Question[] = (fetchedQuestions || []).map((q) => {
           const rawQuestion = q.question || "";
           const subgraphOutcomes =
-            usedField === "questions" && typeof q.outcomes === "string"
-              ? q.outcomes
-              : q.outcomes;
+            typeof q.outcomes === "string" ? q.outcomes : q.outcomes;
           const { parsed: display } = enrichPredictionDisplaySync(
             rawQuestion,
             q.template_id,
@@ -240,7 +202,7 @@ export function PredictionList() {
           const description = display.description;
           const parsedCategory = display.category;
           const outcomes =
-            usedField === "questions" && typeof q.outcomes === "string"
+            typeof q.outcomes === "string"
               ? q.outcomes.split("\n").filter(Boolean)
               : display.outcomes;
           const enrichedDisplay = { ...display, outcomes };
@@ -248,104 +210,33 @@ export function PredictionList() {
             ? answerBytesToLabel(q.best_answer, enrichedDisplay)
             : null;
 
-          if (usedField === "questions") {
-            return {
-              id: q.id,
-              template_id: q.template_id?.toString() ?? "0",
-              question: q.question ?? "",
-              created: q.created?.toString() ?? "0",
-              opening_ts: q.opening_ts?.toString() ?? "0",
-              timeout: q.timeout?.toString() ?? "0",
-              finalize_ts: q.finalize_ts != null ? String(q.finalize_ts) : undefined,
-              is_pending_arbitration: Boolean(q.is_pending_arbitration),
-              bounty: q.bounty?.toString() ?? "0",
-              best_answer: q.best_answer,
-              history_hash: q.history_hash ?? "",
-              arbitrator: q.arbitrator ?? "",
-              min_bond: q.min_bond?.toString() ?? "0",
-              last_bond: q.last_bond?.toString() ?? "0",
-              last_bond_ts: q.last_bond_ts != null ? String(q.last_bond_ts) : undefined,
-              category: q.category ?? parsedCategory,
-              language: q.language ?? display.language,
-              outcomes,
-              title,
-              description,
-              parsedCategory,
-              leadingLabel,
-            };
-          }
-
           return {
-            id: q.question_id || q.id,
-            template_id: q.template_id?.toString() || "0",
-            question: q.question || "",
-            created: q.id || "0",
-            opening_ts: q.opening_ts?.toString() || "0",
-            timeout: q.timeout?.toString() || "0",
-            finalize_ts: undefined,
-            is_pending_arbitration: false,
-            bounty: "0",
+            id: q.id,
+            template_id: q.template_id?.toString() ?? "0",
+            question: q.question ?? "",
+            created: q.created?.toString() ?? "0",
+            opening_ts: q.opening_ts?.toString() ?? "0",
+            timeout: q.timeout?.toString() ?? "0",
+            finalize_ts: q.finalize_ts != null ? String(q.finalize_ts) : undefined,
+            is_pending_arbitration: Boolean(q.is_pending_arbitration),
+            bounty: q.bounty?.toString() ?? "0",
             best_answer: q.best_answer,
-            history_hash: "",
-            arbitrator: q.arbitrator || "",
-            min_bond: "0",
-            last_bond: "0",
-            last_bond_ts: undefined,
-            category: parsedCategory,
-            language: display.language,
+            history_hash: q.history_hash ?? "",
+            arbitrator: q.arbitrator ?? "",
+            min_bond: q.min_bond?.toString() ?? "0",
+            last_bond: q.last_bond?.toString() ?? "0",
+            last_bond_ts: q.last_bond_ts != null ? String(q.last_bond_ts) : undefined,
+            category: q.category ?? parsedCategory,
+            language: q.language ?? display.language,
             outcomes,
             title,
             description,
             parsedCategory,
             leadingLabel,
-          } as Question;
+          };
         });
 
         logger.debug(`Successfully fetched ${parsedQuestions.length} questions from Reality.eth subgraph`);
-
-        // Fetch bounties for these questions
-        const questionIds = parsedQuestions.map(q => q.id);
-
-        // `questions` entities already include `bounty`; log-only fallbacks may not.
-        if (usedField !== "questions" && questionIds.length > 0) {
-          const GET_BOUNTIES_QUERY = gql`
-            query GetBounties($questionIds: [String!]) {
-              logFundAnswerBounties(
-                where: { question_id_in: $questionIds }
-                orderBy: timestamp_
-                orderDirection: desc
-              ) {
-                question_id
-                bounty
-              }
-            }
-          `;
-
-          try {
-            logger.debug('💰 Fetching bounties for questions');
-            const bountyData = await request(endpoint, GET_BOUNTIES_QUERY, { questionIds }) as any;
-            const bounties = bountyData.logFundAnswerBounties || [];
-
-            const bountyMap = new Map<string, bigint>();
-
-            bounties.forEach((b: any) => {
-              const qId = b.question_id;
-              const amount = BigInt(b.bounty || 0);
-              const current = bountyMap.get(qId) || BigInt(0);
-              bountyMap.set(qId, current + amount);
-            });
-
-            parsedQuestions.forEach(q => {
-              if (bountyMap.has(q.id)) {
-                q.bounty = bountyMap.get(q.id)?.toString() || "0";
-              }
-            });
-
-            logger.debug(`Updated ${bountyMap.size} questions with bounty data`);
-          } catch (bountyError) {
-            logger.warn('Failed to fetch bounties:', bountyError);
-          }
-        }
 
         setRawQuestions(parsedQuestions);
       } catch (err: any) {
@@ -353,24 +244,18 @@ export function PredictionList() {
 
         let errorMessage = err?.message || 'Failed to load predictions.';
 
-        // Provide helpful error messages based on the error type
-        if (err?.message?.includes("no field `questions`") ||
-          err?.message?.includes("Type `Query` has no field `questions`")) {
+        if (
+          err?.message?.includes('Subgraph unavailable') ||
+          err?.message?.includes('does not exist')
+        ) {
           errorMessage =
-            "The Reality.eth subgraph schema doesn't match. " +
-            "This usually means:\n\n" +
-            "• The subgraph hasn't been deployed to Goldsky yet\n" +
-            "• The subgraph is still syncing/indexing data\n" +
-            "• The subgraph schema uses different field names\n\n" +
-            "Please check:\n" +
-            "1. Goldsky dashboard - verify the 'reality-eth' subgraph exists\n" +
-            "2. Subgraph status - ensure it's synced and indexed\n" +
-            "3. Subgraph schema - verify it includes a 'questions' query field";
-        } else if (err?.message?.includes("404") || err?.message?.includes("not found")) {
+            "Predictions subgraph unavailable. " +
+            "Redeploy creative-platform to Graph Studio and set GRAPH_STUDIO_CREATIVE_PLATFORM_URL " +
+            "(SUBGRAPH_PROVIDER_MODE=studio).";
+        } else if (err?.message?.includes('404') || err?.message?.includes('not found')) {
           errorMessage =
-            "Reality.eth subgraph not found. " +
-            "Please deploy the subgraph to Goldsky first. " +
-            "See REALITY_ETH_SUBGRAPH_HOSTING.md for deployment instructions.";
+            "Graph Studio subgraph not found. " +
+            "See GRAPH_STUDIO_MIGRATION.md for deployment instructions.";
         }
 
         setError(errorMessage);

--- a/env.example
+++ b/env.example
@@ -30,6 +30,19 @@ NEXT_PUBLIC_SONGCHAIN_GRAPH_ID=
 # SONGCHAIN_EXCLUSIVE_FEED_ID=
 # SONGCHAIN_GROUP_ID=
 
+# --- Subgraph (Graph Studio — primary) ---
+# See GRAPH_STUDIO_MIGRATION.md for deploy steps
+SUBGRAPH_PROVIDER_MODE=studio
+GRAPH_STUDIO_CREATIVE_PLATFORM_URL=https://gateway.thegraph.com/api/<query-key>/subgraphs/id/<deployment-id>
+# Or Studio query URL: https://api.studio.thegraph.com/query/<account-id>/creative-platform/version/latest
+# GRAPH_STUDIO_DEPLOY_KEY=          # deploy script only
+# GRAPH_STUDIO_SUBGRAPH_SLUG=       # e.g. youraccount/creative-platform if not default
+
+# --- Subgraph (Goldsky — emergency rollback only) ---
+# GOLDSKY_API_KEY=
+# GOLDSKY_PROJECT_ID=
+# GOLDSKY_REALITY_ETH_PROJECT_ID=
+
 # Optional Lens RPC override
 # NEXT_PUBLIC_LENS_RPC_URL=
 

--- a/lib/sdk/reality-eth/reality-eth-subgraph.ts
+++ b/lib/sdk/reality-eth/reality-eth-subgraph.ts
@@ -2,14 +2,15 @@ import { gql } from "@apollo/client";
 
 /**
  * Reality.eth Subgraph Queries
- * 
- * GraphQL queries for fetching Reality.eth questions and answers
- * from the Goldsky-hosted subgraph
  *
- * Note: The Goldsky `reality-eth/1.0.0` deployment exposes `logNewQuestions`, not `questions`.
+ * Production uses The Graph Studio (`creative-platform` merged subgraph), which exposes
+ * the `questions` entity. Use GET_QUESTIONS_LIST / GET_QUESTION for all app queries.
+ *
+ * GET_LOG_NEW_QUESTIONS_LIST is legacy Goldsky-only (`reality-eth/1.0.0` uses logNewQuestions).
+ * Kept for emergency rollback when SUBGRAPH_PROVIDER_MODE=goldsky.
  */
 
-/** List questions from log entities (Goldsky reality-eth subgraph). */
+/** @deprecated Goldsky reality-eth only — not in Graph Studio schema. Use GET_QUESTIONS_LIST. */
 export const GET_LOG_NEW_QUESTIONS_LIST = gql`
   query GetLogNewQuestionsList($first: Int!, $skip: Int!) {
     logNewQuestions(

--- a/lib/subgraph/creative-platform-proxy.test.ts
+++ b/lib/subgraph/creative-platform-proxy.test.ts
@@ -46,6 +46,11 @@ describe('creative-platform-proxy', () => {
     ).toBe(false);
   });
 
+  it('rejects null or non-object GraphQL payloads', () => {
+    expect(isGraphQlResponseSuccessful(null)).toBe(false);
+    expect(isGraphQlResponseSuccessful('error')).toBe(false);
+  });
+
   it('accepts valid GraphQL data', () => {
     expect(isGraphQlResponseSuccessful({ data: { questions: [] } })).toBe(true);
   });

--- a/lib/subgraph/creative-platform-proxy.test.ts
+++ b/lib/subgraph/creative-platform-proxy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  getSubgraphProviderMode,
+  isGraphQlResponseSuccessful,
+  resolveSubgraphEndpoints,
+} from './creative-platform-proxy';
+
+describe('creative-platform-proxy', () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('defaults SUBGRAPH_PROVIDER_MODE to studio', () => {
+    delete process.env.SUBGRAPH_PROVIDER_MODE;
+    expect(getSubgraphProviderMode()).toBe('studio');
+  });
+
+  it('studio mode uses only Graph Studio URL when configured', () => {
+    process.env.SUBGRAPH_PROVIDER_MODE = 'studio';
+    process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL =
+      'https://gateway.thegraph.com/api/test/subgraphs/id/test';
+    const endpoints = resolveSubgraphEndpoints('reality-eth');
+    expect(endpoints).toEqual([process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL]);
+  });
+
+  it('goldsky mode does not require Studio URL', () => {
+    process.env.SUBGRAPH_PROVIDER_MODE = 'goldsky';
+    delete process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL;
+    const endpoints = resolveSubgraphEndpoints('reality-eth');
+    expect(endpoints.length).toBeGreaterThan(0);
+    expect(endpoints[0]).toContain('goldsky.com');
+  });
+
+  it('treats GraphQL errors as unsuccessful', () => {
+    expect(
+      isGraphQlResponseSuccessful({
+        errors: [{ message: 'deployment does not exist' }],
+        data: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts valid GraphQL data', () => {
+    expect(isGraphQlResponseSuccessful({ data: { questions: [] } })).toBe(true);
+  });
+});

--- a/lib/subgraph/creative-platform-proxy.ts
+++ b/lib/subgraph/creative-platform-proxy.ts
@@ -75,12 +75,24 @@ export function buildSubgraphRequestHeaders(endpoint: string): Record<string, st
   return headers;
 }
 
-export function isGraphQlResponseSuccessful(data: {
-  data?: unknown;
-  errors?: Array<{ message?: string }>;
-}): boolean {
-  if (data.errors?.length) return false;
-  return data.data != null;
+export function isGraphQlResponseSuccessful(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false;
+  const payload = data as { data?: unknown; errors?: Array<{ message?: string }> };
+  if (payload.errors?.length) return false;
+  return payload.data != null;
+}
+
+export function getGraphQlResponseErrors(data: unknown): Array<{ message?: string }> {
+  if (data && typeof data === 'object' && Array.isArray((data as { errors?: unknown }).errors)) {
+    return (data as { errors: Array<{ message?: string }> }).errors;
+  }
+  return [{ message: 'Invalid or empty GraphQL response' }];
+}
+
+export function asGraphQlRequestBody(body: unknown): { query?: string; variables?: unknown } {
+  return body && typeof body === 'object'
+    ? (body as { query?: string; variables?: unknown })
+    : {};
 }
 
 export function formatGraphQlErrors(errors: Array<{ message?: string }>): string {

--- a/lib/subgraph/creative-platform-proxy.ts
+++ b/lib/subgraph/creative-platform-proxy.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared routing for the merged creative-platform subgraph (Graph Studio + optional Goldsky rollback).
+ */
+
+export type SubgraphProviderMode = 'goldsky' | 'studio' | 'dual';
+
+const DEFAULT_GOLDSKY_PROJECT_ID = 'project_cmh0iv6s500dbw2p22vsxcfo6';
+
+export function getSubgraphProviderMode(): SubgraphProviderMode {
+  const rawMode = process.env.SUBGRAPH_PROVIDER_MODE?.toLowerCase();
+  if (rawMode === 'studio' || rawMode === 'dual' || rawMode === 'goldsky') return rawMode;
+  return 'studio';
+}
+
+export function getStudioSubgraphUrl(): string | undefined {
+  return process.env.GRAPH_STUDIO_CREATIVE_PLATFORM_URL?.trim() || undefined;
+}
+
+function getGoldskyProjectId(realityEth = false): string {
+  if (realityEth && process.env.GOLDSKY_REALITY_ETH_PROJECT_ID) {
+    return process.env.GOLDSKY_REALITY_ETH_PROJECT_ID;
+  }
+  return process.env.GOLDSKY_PROJECT_ID || DEFAULT_GOLDSKY_PROJECT_ID;
+}
+
+function getGoldskyUrl(
+  subgraphName: string,
+  version: string,
+  realityEth = false,
+  accessType?: 'public' | 'private',
+): string {
+  const isPrivate = !!process.env.GOLDSKY_API_KEY;
+  const resolvedAccess = accessType ?? (isPrivate ? 'private' : 'public');
+  const projectId = getGoldskyProjectId(realityEth);
+  return `https://api.goldsky.com/api/${resolvedAccess}/${projectId}/subgraphs/${subgraphName}/${version}/gn`;
+}
+
+export type SubgraphProxyTarget = 'metokens' | 'reality-eth';
+
+export function resolveSubgraphEndpoints(target: SubgraphProxyTarget): string[] {
+  const mode = getSubgraphProviderMode();
+  const studioUrl = getStudioSubgraphUrl();
+  const isPrivate = !!process.env.GOLDSKY_API_KEY;
+
+  const goldskyPrimary =
+    target === 'reality-eth'
+      ? getGoldskyUrl('reality-eth', '1.0.0', true, isPrivate ? 'private' : 'public')
+      : getGoldskyUrl('metokens', '1.0.2', false, isPrivate ? 'private' : 'public');
+
+  const goldskyPublicFallback =
+    target === 'reality-eth'
+      ? getGoldskyUrl('reality-eth', '1.0.0', true, 'public')
+      : getGoldskyUrl('metokens', '1.0.2', false, 'public');
+
+  const endpoints: string[] = [];
+
+  if (mode === 'studio' || mode === 'dual') {
+    if (studioUrl) endpoints.push(studioUrl);
+  }
+  if (mode === 'goldsky' || mode === 'dual' || !studioUrl) {
+    endpoints.push(goldskyPrimary);
+  }
+  if (isPrivate && mode !== 'studio') {
+    endpoints.push(goldskyPublicFallback);
+  }
+
+  return endpoints;
+}
+
+export function buildSubgraphRequestHeaders(endpoint: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (endpoint.includes('goldsky.com') && process.env.GOLDSKY_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.GOLDSKY_API_KEY}`;
+  }
+  return headers;
+}
+
+export function isGraphQlResponseSuccessful(data: {
+  data?: unknown;
+  errors?: Array<{ message?: string }>;
+}): boolean {
+  if (data.errors?.length) return false;
+  return data.data != null;
+}
+
+export function formatGraphQlErrors(errors: Array<{ message?: string }>): string {
+  return errors.map((e) => e.message ?? 'Unknown GraphQL error').join('; ');
+}
+
+export const STUDIO_URL_HINT =
+  'Redeploy subgraphs/creative-platform to Graph Studio and set GRAPH_STUDIO_CREATIVE_PLATFORM_URL.';
+
+export const GOLDSKY_ROLLBACK_HINT =
+  'For emergency rollback, set SUBGRAPH_PROVIDER_MODE=goldsky in environment variables.';

--- a/scripts/graph-studio/deploy-creative-platform.sh
+++ b/scripts/graph-studio/deploy-creative-platform.sh
@@ -30,6 +30,18 @@ pnpm exec graph auth "$GRAPH_STUDIO_DEPLOY_KEY"
 pnpm exec graph codegen
 pnpm exec graph build
 # Use deploy key from ~/.graph-cli.json (written by graph auth) to avoid header/env mismatch.
-pnpm exec graph deploy "$SUBGRAPH_SLUG" subgraph.yaml --version-label "$VERSION_LABEL"
+pnpm exec graph deploy "$SUBGRAPH_SLUG" subgraph.yaml --version-label "$VERSION_LABEL" || {
+  echo ""
+  echo "Deploy failed. Common fixes:"
+  echo "  1. Copy Deploy key from Subgraph Studio → Settings (rotate if unsure)"
+  echo "  2. Set GRAPH_STUDIO_SUBGRAPH_SLUG to the exact slug from Studio → Deploy"
+  echo "     (e.g. myaccount/creative-platform; default is creative-platform)"
+  echo "  3. Re-run: GRAPH_STUDIO_DEPLOY_KEY=... VERSION_LABEL=$VERSION_LABEL ./scripts/graph-studio/deploy-creative-platform.sh"
+  exit 1
+}
 
 echo "Deployed $SUBGRAPH_SLUG with version label: $VERSION_LABEL"
+echo ""
+echo "Next: In Subgraph Studio → Query tab, copy the query URL and set:"
+echo "  GRAPH_STUDIO_CREATIVE_PLATFORM_URL=<query-url>"
+echo "  SUBGRAPH_PROVIDER_MODE=studio"


### PR DESCRIPTION
## Summary
- Default subgraph routing to Graph Studio (`SUBGRAPH_PROVIDER_MODE=studio`) via shared `creative-platform-proxy` module
- Simplify `/api/reality-eth-subgraph` and `/api/metokens-subgraph` to return actionable 502/503 errors when Studio deployments are stale or missing
- Update `PredictionList` to query `questions` only (remove Goldsky `logNewQuestions` fallbacks)
- Document Studio-first env setup and improve deploy script failure hints

## Test plan
- [ ] Redeploy `subgraphs/creative-platform` to Graph Studio and set `GRAPH_STUDIO_CREATIVE_PLATFORM_URL` in Vercel
- [ ] Set `SUBGRAPH_PROVIDER_MODE=studio` in Vercel and redeploy
- [ ] Verify `/predict` loads (list or empty state, no "Failed to load predictions")
- [ ] Verify `/predict/[id]` loads question detail via `question(id: ...)`
- [ ] Verify MeToken features still work via `/api/metokens-subgraph`
- [ ] Run `pnpm exec vitest run lib/subgraph/creative-platform-proxy.test.ts`


Made with [Cursor](https://cursor.com)