### PR TITLE
Add MeToken-gated live stream playback

### DIFF
--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -44,6 +44,13 @@ export async function POST(req: NextRequest) {
       stream &&
       isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
     ) {
+      if (!stream.creator_id) {
+        return NextResponse.json(
+          { message: "Stream creator not found" },
+          { status: 400 }
+        );
+      }
+
       if (!userAddress && !smartAccountAddress) {
         return NextResponse.json(
           {
@@ -59,7 +66,7 @@ export async function POST(req: NextRequest) {
 
       const access = await checkMeTokenAccess({
         viewerAddresses: [userAddress, smartAccountAddress],
-        creatorAddress: stream.creator_id!,
+        creatorAddress: stream.creator_id,
         requiredAmount: stream.metoken_price!,
       });
 

--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -2,54 +2,104 @@ import { signAccessJwt } from "@livepeer/core/crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { checkBotId } from "botid/server";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { getStreamByPlaybackId } from "@/services/streams";
+import {
+  checkMeTokenAccess,
+  isMeTokenGateActive,
+} from "@/lib/utils/metoken-access";
 
 export async function POST(req: NextRequest) {
-    const verification = await checkBotId();
-    if (verification.isBot) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const accessControlPrivateKey = process.env.ACCESS_CONTROL_PRIVATE_KEY;
+    const accessControlPublicKey = process.env.NEXT_PUBLIC_ACCESS_CONTROL_PUBLIC_KEY;
+
+    if (!accessControlPrivateKey || !accessControlPublicKey) {
+      console.error("Missing Access Control Keys");
+      return NextResponse.json(
+        { message: "Server configuration error: Missing access keys" },
+        { status: 500 }
+      );
     }
-    const rl = await rateLimiters.standard(req);
-    if (rl) return rl;
 
-    try {
-        const accessControlPrivateKey = process.env.ACCESS_CONTROL_PRIVATE_KEY;
-        const accessControlPublicKey = process.env.NEXT_PUBLIC_ACCESS_CONTROL_PUBLIC_KEY;
+    const body = await req.json();
+    const { playbackId, userAddress, smartAccountAddress } = body;
 
-        if (!accessControlPrivateKey || !accessControlPublicKey) {
-            console.error("Missing Access Control Keys");
-            return NextResponse.json(
-                { message: "Server configuration error: Missing access keys" },
-                { status: 500 }
-            );
-        }
+    if (!playbackId) {
+      return NextResponse.json(
+        { message: "Missing playbackId" },
+        { status: 400 }
+      );
+    }
 
-        const body = await req.json();
-        const { playbackId, userAddress } = body;
+    const stream = await getStreamByPlaybackId(playbackId);
 
-        if (!playbackId) {
-            return NextResponse.json(
-                { message: "Missing playbackId" },
-                { status: 400 }
-            );
-        }
-
-        const token = await signAccessJwt({
-            privateKey: accessControlPrivateKey,
-            publicKey: accessControlPublicKey,
-            issuer: "https://crtv3.app",
-            playbackId,
-            expiration: 3600, // 1 hour
-            custom: {
-                userId: userAddress || "anonymous"
-            }
-        });
-
-        return NextResponse.json({ token });
-    } catch (error) {
-        console.error("Error signing JWT:", error);
+    if (
+      stream &&
+      isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
+    ) {
+      if (!userAddress && !smartAccountAddress) {
         return NextResponse.json(
-            { message: "Internal server error" },
-            { status: 500 }
+          {
+            code: "METOKEN_REQUIRED",
+            connectWallet: true,
+            creatorAddress: stream.creator_id,
+            required: String(stream.metoken_price),
+            message: "Connect your wallet to verify MeToken balance",
+          },
+          { status: 403 }
         );
+      }
+
+      const access = await checkMeTokenAccess({
+        viewerAddresses: [userAddress, smartAccountAddress],
+        creatorAddress: stream.creator_id!,
+        requiredAmount: stream.metoken_price!,
+      });
+
+      if (!access.allowed) {
+        return NextResponse.json(
+          {
+            code: "METOKEN_REQUIRED",
+            connectWallet: access.reason === "no_viewer_address",
+            meTokenAddress: access.meTokenAddress,
+            symbol: access.symbol,
+            required: access.requiredFormatted,
+            balance: access.balanceFormatted,
+            creatorAddress: stream.creator_id,
+            message:
+              access.reason === "no_viewer_address"
+                ? "Connect your wallet to verify MeToken balance"
+                : "Insufficient MeToken balance to watch this stream",
+          },
+          { status: 403 }
+        );
+      }
     }
+
+    const token = await signAccessJwt({
+      privateKey: accessControlPrivateKey,
+      publicKey: accessControlPublicKey,
+      issuer: "https://crtv3.app",
+      playbackId,
+      expiration: 3600,
+      custom: {
+        userId: userAddress || smartAccountAddress || "anonymous",
+      },
+    });
+
+    return NextResponse.json({ token });
+  } catch (error) {
+    console.error("Error signing JWT:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/app/api/streams/access/[playbackId]/route.ts
+++ b/app/api/streams/access/[playbackId]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getStreamByPlaybackId } from "@/services/streams";
+import { createServiceClient } from "@/lib/sdk/supabase/service";
+import { isMeTokenGateActive } from "@/lib/utils/metoken-access";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ playbackId: string }> },
+) {
+  try {
+    const { playbackId } = await params;
+    if (!playbackId?.trim()) {
+      return NextResponse.json({ error: "playbackId is required" }, { status: 400 });
+    }
+
+    const stream = await getStreamByPlaybackId(playbackId);
+    if (!stream) {
+      return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+    }
+
+    const requiresMetoken = isMeTokenGateActive(
+      stream.requires_metoken,
+      stream.metoken_price,
+    );
+
+    let meTokenSymbol: string | null = null;
+    let meTokenAddress: string | null = null;
+
+    if (requiresMetoken && stream.creator_id) {
+      const supabase = createServiceClient();
+      const { data: meToken } = await supabase
+        .from("metokens")
+        .select("address, symbol")
+        .eq("owner_address", stream.creator_id.toLowerCase())
+        .maybeSingle();
+
+      meTokenSymbol = meToken?.symbol ?? null;
+      meTokenAddress = meToken?.address ?? null;
+    }
+
+    return NextResponse.json({
+      requiresMetoken,
+      metokenPrice: requiresMetoken ? stream.metoken_price : null,
+      meTokenSymbol,
+      meTokenAddress,
+      creatorAddress: stream.creator_id,
+      streamName: stream.name ?? null,
+      thumbnailUrl: stream.thumbnail_url ?? null,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "Failed to fetch stream access metadata",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/streams/creator/[address]/route.ts
+++ b/app/api/streams/creator/[address]/route.ts
@@ -22,6 +22,8 @@ export async function GET(
       thumbnail_url: stream.thumbnail_url,
       is_live: stream.is_live,
       last_live_at: stream.last_live_at,
+      requires_metoken: stream.requires_metoken ?? false,
+      metoken_price: stream.metoken_price ?? null,
     });
   } catch (error) {
     return NextResponse.json(

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -28,6 +28,8 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { LivestreamThumbnail } from "@/components/Live/LivestreamThumbnail";
 import { StreamThumbnailUploader } from "@/components/Live/StreamThumbnailUploader";
+import { StreamNameEditor } from "@/components/Live/StreamNameEditor";
+import { StreamMeTokenGateEditor } from "@/components/Live/StreamMeTokenGateEditor";
 import { StreamIPRegistration } from "@/components/Live/StreamIPRegistration";
 import { CreatorClipsList } from "@/components/Live/CreatorClipsList";
 import { getThumbnailUrl } from "@/services/livepeer-thumbnails";
@@ -61,6 +63,8 @@ export default function LivePage() {
   const [allowClipping, setAllowClipping] = useState(true);
   const [isUpdatingClipPref, setIsUpdatingClipPref] = useState(false);
   const [streamName, setStreamName] = useState<string | null>(null);
+  const [requiresMetoken, setRequiresMetoken] = useState(false);
+  const [metokenPrice, setMetokenPrice] = useState<number | null>(null);
   const [storyIpId, setStoryIpId] = useState<string | null>(null);
   const [storyLicenseTermsId, setStoryLicenseTermsId] = useState<string | null>(null);
   const [storyRevShare, setStoryRevShare] = useState<number | null>(null);
@@ -94,6 +98,8 @@ export default function LivePage() {
           setThumbnailUrl(stream.thumbnail_url || null);
           setAllowClipping(stream.allow_clipping ?? true);
           setStreamName(stream.name ?? null);
+          setRequiresMetoken(stream.requires_metoken ?? false);
+          setMetokenPrice(stream.metoken_price ?? null);
           setStoryIpId(stream.story_ip_id ?? null);
           setStoryLicenseTermsId(stream.story_license_terms_id ?? null);
           setStoryRevShare(stream.story_commercial_rev_share ?? null);
@@ -170,6 +176,18 @@ export default function LivePage() {
 
   function handleThumbnailUpdated(url: string) {
     setThumbnailUrl(url);
+  }
+
+  function handleNameUpdated(name: string) {
+    setStreamName(name);
+  }
+
+  function handleGateUpdated(config: {
+    requiresMetoken: boolean;
+    metokenPrice: number | null;
+  }) {
+    setRequiresMetoken(config.requiresMetoken);
+    setMetokenPrice(config.metokenPrice);
   }
 
   async function handleToggleClipping(next: boolean) {
@@ -297,15 +315,8 @@ export default function LivePage() {
   return (
     <ProfilePageGuard>
       <MembershipGuard>
-        <div className="min-h-screen p-6">
-          <div className="mb-8 rounded-lg bg-white dark:bg-gray-800/60 p-8 shadow-md">
-            <h1 className="mb-6 flex items-center justify-center gap-2 text-center text-4xl font-bold text-red-600 dark:text-red-400">
-              <VideoIcon className="h-10 w-10" />
-              <span>LIVE</span>
-            </h1>
-            <p className="mb-8 text-center text-gray-600 dark:text-gray-400">THE STAGE IS YOURS</p>
-          </div>
-          <div className="my-5 p-4">
+        <div className="min-h-screen p-4 md:p-6">
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <Breadcrumb>
               <BreadcrumbList>
                 <BreadcrumbItem>
@@ -328,33 +339,27 @@ export default function LivePage() {
                 </BreadcrumbItem>
               </BreadcrumbList>
             </Breadcrumb>
+            <h1 className="flex items-center gap-2 text-lg font-bold text-red-600 dark:text-red-400">
+              <VideoIcon className="h-5 w-5" />
+              <span>Live Studio</span>
+            </h1>
           </div>
           <div>
-            {thumbnailLoading ? (
-              <div className="flex items-center justify-center h-40 text-gray-400">
-                Loading thumbnail...
-              </div>
-            ) : thumbnailError ? (
-              <div className="flex items-center justify-center h-40 text-red-400">
-                {thumbnailError}
-              </div>
-            ) : thumbnailUrl ? (
-              <LivestreamThumbnail thumbnailUrl={thumbnailUrl} />
-            ) : null}
-
-            {streamKey && streamId && user?.address && (
-              <div className="my-6 flex justify-center">
-                <StreamThumbnailUploader
-                  creatorAddress={user.address}
-                  playbackId={playbackId || streamId} // Fallback to streamId if playbackId missing, though unlikely
-                  currentThumbnailUrl={thumbnailUrl}
-                  onThumbnailUpdated={handleThumbnailUpdated}
-                />
-              </div>
-            )}
-
             {!streamKey ? (
               <div className="flex flex-col items-center justify-center my-8">
+                {thumbnailLoading ? (
+                  <div className="flex items-center justify-center h-32 text-gray-400 mb-6">
+                    Loading thumbnail...
+                  </div>
+                ) : thumbnailError ? (
+                  <div className="flex items-center justify-center h-32 text-red-400 mb-6">
+                    {thumbnailError}
+                  </div>
+                ) : thumbnailUrl ? (
+                  <div className="mb-6 w-full max-w-md">
+                    <LivestreamThumbnail thumbnailUrl={thumbnailUrl} />
+                  </div>
+                ) : null}
                 <button
                   onClick={handleCreateStream}
                   disabled={isCreatingStream}
@@ -367,7 +372,7 @@ export default function LivePage() {
                 )}
               </div>
             ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6">
                 <div className="lg:col-span-2 relative">
                   <Broadcast streamKey={streamKey} streamId={streamId} creatorAddress={user.address} />
                   {user?.address && (
@@ -413,6 +418,7 @@ export default function LivePage() {
                       streamId={chatStreamId}
                       sessionId={chatSessionId}
                       creatorAddress={user.address}
+                      className="h-[min(70vh,520px)]"
                     />
                   ) : (
                     <div className="border rounded-lg p-4 text-sm text-muted-foreground">
@@ -420,6 +426,28 @@ export default function LivePage() {
                     </div>
                   )}
                 </div>
+              </div>
+            )}
+
+            {streamKey && streamId && user?.address && (
+              <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl mx-auto">
+                <StreamThumbnailUploader
+                  creatorAddress={user.address}
+                  playbackId={playbackId || streamId}
+                  currentThumbnailUrl={thumbnailUrl}
+                  onThumbnailUpdated={handleThumbnailUpdated}
+                />
+                <StreamNameEditor
+                  creatorAddress={user.address}
+                  currentName={streamName}
+                  onNameUpdated={handleNameUpdated}
+                />
+                <StreamMeTokenGateEditor
+                  creatorAddress={user.address}
+                  requiresMetoken={requiresMetoken}
+                  metokenPrice={metokenPrice}
+                  onGateUpdated={handleGateUpdated}
+                />
               </div>
             )}
             {streamId && user?.address && (

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -86,6 +86,10 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
   const [jwt, setJwt] = useState<string | undefined>(undefined);
   const [isChecking, setIsChecking] = useState(false);
   const [gatePrefetch, setGatePrefetch] = useState<LiveStreamGateInfo | null>(null);
+  const streamDataRef = useRef(streamData);
+  streamDataRef.current = streamData;
+  const gatePrefetchRef = useRef(gatePrefetch);
+  gatePrefetchRef.current = gatePrefetch;
 
   const requestStreamJwt = useCallback(async (): Promise<{
     ok: boolean;
@@ -123,14 +127,15 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
           required: errData.required,
           balance: errData.balance,
           creatorAddress: errData.creatorAddress,
-          streamName: streamData?.name ?? gatePrefetch?.streamName ?? null,
+          streamName:
+            streamDataRef.current?.name ?? gatePrefetchRef.current?.streamName ?? null,
         },
       };
     }
 
     logger.warn("Failed to sign JWT for stream:", errData);
     return { ok: false };
-  }, [playbackId, user?.address, smartAccountAddress, streamData?.name, gatePrefetch?.streamName]);
+  }, [playbackId, user?.address, smartAccountAddress]);
 
   const fetchPlaybackSources = useCallback(async (isInitial = false) => {
     if (!playbackId) {

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, type ReactNode } from "react";
+import { useState, useEffect, useCallback, useRef, type ReactNode } from "react";
 import { useParams } from "next/navigation";
 import { useInterval } from "@/lib/hooks/useInterval";
 import { Player } from "@/components/Player/Player";
@@ -11,8 +11,13 @@ import { ClipCreator } from "@/components/Live/ClipCreator";
 import { DigitalTwinOverlay } from "@/components/Live/DigitalTwinOverlay";
 import { Src } from "@livepeer/react";
 import { useUser } from "@account-kit/react";
+import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle } from "lucide-react";
+import {
+  LiveStreamMeTokenGate,
+  type LiveStreamGateInfo,
+} from "@/components/Live/LiveStreamMeTokenGate";
 import Link from "next/link";
 import { RealtimeViewsComponent } from "@/components/Player/RealtimeViewsComponent";
 import { ViewsComponent } from "@/components/Player/ViewsComponent";
@@ -46,6 +51,7 @@ interface WatchClientProps {
 type StreamStatus =
   | { kind: "loading" }
   | { kind: "live"; sources: Src[] }
+  | { kind: "metoken-gated"; gate: LiveStreamGateInfo; sources: Src[] }
   | { kind: "offline-temporary"; attempts: number }
   | { kind: "offline-permanent" }
   | { kind: "not-found" }
@@ -74,10 +80,57 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
     : params.playbackId;
 
   const user = useUser();
+  const { address: smartAccountAddress } = useModularAccount();
   const [status, setStatus] = useState<StreamStatus>({ kind: "loading" });
   const [streamData, setStreamData] = useState<import("@/services/streams").Stream | null>(null);
   const [jwt, setJwt] = useState<string | undefined>(undefined);
   const [isChecking, setIsChecking] = useState(false);
+  const [gatePrefetch, setGatePrefetch] = useState<LiveStreamGateInfo | null>(null);
+
+  const requestStreamJwt = useCallback(async (): Promise<{
+    ok: boolean;
+    token?: string;
+    gate?: LiveStreamGateInfo;
+  }> => {
+    if (!playbackId) {
+      return { ok: false };
+    }
+
+    const jwtRes = await fetch("/api/livepeer/sign-jwt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        playbackId,
+        userAddress: user?.address,
+        smartAccountAddress,
+      }),
+    });
+
+    if (jwtRes.ok) {
+      const { token } = await jwtRes.json();
+      return { ok: true, token };
+    }
+
+    const errData = await jwtRes.json().catch(() => ({}));
+    if (jwtRes.status === 403 && errData.code === "METOKEN_REQUIRED") {
+      return {
+        ok: false,
+        gate: {
+          code: errData.code,
+          connectWallet: errData.connectWallet,
+          meTokenAddress: errData.meTokenAddress,
+          symbol: errData.symbol,
+          required: errData.required,
+          balance: errData.balance,
+          creatorAddress: errData.creatorAddress,
+          streamName: streamData?.name ?? gatePrefetch?.streamName ?? null,
+        },
+      };
+    }
+
+    logger.warn("Failed to sign JWT for stream:", errData);
+    return { ok: false };
+  }, [playbackId, user?.address, smartAccountAddress, streamData?.name, gatePrefetch?.streamName]);
 
   const fetchPlaybackSources = useCallback(async (isInitial = false) => {
     if (!playbackId) {
@@ -112,29 +165,23 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         setStreamData(streamRecord as import("@/services/streams").Stream);
       }
 
-      // Happy path — stream is live.
+      // Happy path — stream is live; JWT required for playback.
       if (sources && sources.length > 0) {
-        setStatus({ kind: "live", sources });
-
         try {
-          const jwtRes = await fetch("/api/livepeer/sign-jwt", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              playbackId,
-              userAddress: user?.address
-            }),
-          });
-
-          if (jwtRes.ok) {
-            const { token } = await jwtRes.json();
-            setJwt(token);
+          const jwtResult = await requestStreamJwt();
+          if (jwtResult.ok && jwtResult.token) {
+            setJwt(jwtResult.token);
+            setStatus({ kind: "live", sources });
+          } else if (jwtResult.gate) {
+            setJwt(undefined);
+            setStatus({ kind: "metoken-gated", gate: jwtResult.gate, sources });
           } else {
-            const errData = await jwtRes.json().catch(() => ({}));
-            logger.warn("Failed to sign JWT for stream:", errData);
+            setJwt(undefined);
+            setStatus({ kind: "live", sources });
           }
         } catch (jwtErr) {
           logger.error("Error signing JWT:", jwtErr);
+          setStatus({ kind: "live", sources });
         }
         return;
       }
@@ -159,7 +206,54 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
     } finally {
       setIsChecking(false);
     }
-  }, [playbackId, user?.address, videoTitle]);
+  }, [playbackId, user?.address, smartAccountAddress, videoTitle, requestStreamJwt]);
+
+  useEffect(() => {
+    if (!playbackId) return;
+
+    fetch(`/api/streams/access/${encodeURIComponent(playbackId)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data?.requiresMetoken) return;
+        setGatePrefetch({
+          code: "METOKEN_REQUIRED",
+          creatorAddress: data.creatorAddress,
+          symbol: data.meTokenSymbol ?? undefined,
+          required: data.metokenPrice != null ? String(data.metokenPrice) : undefined,
+          streamName: data.streamName,
+        });
+      })
+      .catch((err) => logger.warn("Failed to prefetch stream gate metadata:", err));
+  }, [playbackId]);
+
+  const retryAfterGate = useCallback(async () => {
+    if (status.kind !== "metoken-gated") return;
+    setIsChecking(true);
+    try {
+      const jwtResult = await requestStreamJwt();
+      if (jwtResult.ok && jwtResult.token) {
+        setJwt(jwtResult.token);
+        setStatus({ kind: "live", sources: status.sources });
+      } else if (jwtResult.gate) {
+        setStatus({ kind: "metoken-gated", gate: jwtResult.gate, sources: status.sources });
+      }
+    } finally {
+      setIsChecking(false);
+    }
+  }, [status, requestStreamJwt]);
+
+  const prevWalletKeyRef = useRef("");
+  useEffect(() => {
+    const walletKey = `${user?.address ?? ""}:${smartAccountAddress ?? ""}`;
+    if (status.kind !== "metoken-gated") {
+      prevWalletKeyRef.current = walletKey;
+      return;
+    }
+    if (walletKey === prevWalletKeyRef.current) return;
+    prevWalletKeyRef.current = walletKey;
+    if (!user?.address && !smartAccountAddress) return;
+    void retryAfterGate();
+  }, [user?.address, smartAccountAddress, status.kind, retryAfterGate]);
 
   // Initial fetch
   useEffect(() => {
@@ -252,6 +346,16 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                   <Skeleton className="h-4 w-32" />
                 </div>
               </div>
+            )}
+
+            {status.kind === "metoken-gated" && (
+              <LiveStreamMeTokenGate
+                gate={status.gate}
+                playbackId={playbackId as string}
+                streamTitle={videoTitle || streamData?.name || status.gate.streamName}
+                thumbnailUrl={streamData?.thumbnail_url}
+                onAccessGranted={() => void retryAfterGate()}
+              />
             )}
 
             {status.kind === "live" && (

--- a/components/Live/LiveStreamMeTokenGate.tsx
+++ b/components/Live/LiveStreamMeTokenGate.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Wallet } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuthModal } from "@account-kit/react";
+import { VideoMeTokenBuyDialog } from "@/components/Videos/VideoMeTokenBuyDialog";
+
+export interface LiveStreamGateInfo {
+  code?: string;
+  connectWallet?: boolean;
+  meTokenAddress?: string;
+  symbol?: string;
+  required?: string;
+  balance?: string;
+  creatorAddress?: string;
+  streamName?: string | null;
+}
+
+interface LiveStreamMeTokenGateProps {
+  gate: LiveStreamGateInfo;
+  playbackId: string;
+  streamTitle?: string | null;
+  thumbnailUrl?: string | null;
+  onAccessGranted?: () => void;
+}
+
+export function LiveStreamMeTokenGate({
+  gate,
+  playbackId,
+  streamTitle,
+  thumbnailUrl,
+  onAccessGranted,
+}: LiveStreamMeTokenGateProps) {
+  const { openAuthModal } = useAuthModal();
+  const [buyDialogOpen, setBuyDialogOpen] = useState(false);
+
+  const symbol = gate.symbol ?? "MeToken";
+  const required = gate.required ?? "0";
+  const balance = gate.balance ?? "0";
+  const needsWallet = Boolean(gate.connectWallet);
+
+  return (
+    <>
+      <div className="aspect-video bg-gray-900 rounded-lg overflow-hidden flex flex-col items-center justify-center relative">
+        {thumbnailUrl && (
+          <div className="absolute inset-0 z-0 opacity-40">
+            <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" />
+          </div>
+        )}
+        <div className="z-10 flex flex-col items-center gap-3 p-6 bg-black/70 rounded-xl backdrop-blur-sm text-center max-w-md">
+          <Lock className="h-10 w-10 text-amber-400" />
+          <h3 className="text-xl font-bold text-white">
+            {streamTitle || "Live Stream"} is MeToken-gated
+          </h3>
+          <p className="text-gray-300 text-sm">
+            Hold at least <span className="font-semibold text-white">{required} {symbol}</span> to
+            watch this live stream.
+          </p>
+          {!needsWallet && (
+            <p className="text-xs text-gray-400">
+              Your balance: {balance} {symbol}
+            </p>
+          )}
+          <div className="flex flex-wrap items-center justify-center gap-2 mt-1">
+            {needsWallet ? (
+              <Button onClick={() => openAuthModal()}>
+                <Wallet className="h-4 w-4 mr-2" />
+                Connect Wallet
+              </Button>
+            ) : (
+              <Button onClick={() => setBuyDialogOpen(true)}>
+                Buy {symbol}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {gate.creatorAddress && (
+        <VideoMeTokenBuyDialog
+          open={buyDialogOpen}
+          onOpenChange={(open) => {
+            setBuyDialogOpen(open);
+            if (!open) {
+              onAccessGranted?.();
+            }
+          }}
+          playbackId={playbackId}
+          videoTitle={streamTitle ?? undefined}
+          creatorAddress={gate.creatorAddress}
+        />
+      )}
+    </>
+  );
+}

--- a/components/Live/LivestreamGrid.tsx
+++ b/components/Live/LivestreamGrid.tsx
@@ -11,7 +11,7 @@ import { logger } from '@/lib/utils/logger';
 
 
 import { getActiveStreams, ActiveStream } from "@/services/streams";
-import { RefreshCcw } from "lucide-react";
+import { Lock, RefreshCcw } from "lucide-react";
 
 // Removed fetchStreamsFromApi since we use getActiveStreams now
 
@@ -97,8 +97,18 @@ export default function LivestreamGrid() {
                       </div>
                     </div>
                   )}
-                  <div className="absolute right-2 top-2 rounded-full bg-red-500 px-2 py-1 text-xs text-white">
-                    LIVE
+                  <div className="absolute right-2 top-2 flex items-center gap-1">
+                    {stream.requires_metoken && (
+                      <span
+                        className="rounded-full bg-amber-500/90 px-2 py-1 text-xs text-white"
+                        title="MeToken required to watch"
+                      >
+                        <Lock className="inline h-3 w-3" />
+                      </span>
+                    )}
+                    <span className="rounded-full bg-red-500 px-2 py-1 text-xs text-white">
+                      LIVE
+                    </span>
                   </div>
                 </div>
                 <div className="p-4">

--- a/components/Live/StreamMeTokenGateEditor.tsx
+++ b/components/Live/StreamMeTokenGateEditor.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Loader2, Lock } from "lucide-react";
+import { toast } from "sonner";
+import { updateStream } from "@/services/streams";
+import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
+import { logger } from "@/lib/utils/logger";
+
+interface StreamMeTokenGateEditorProps {
+  creatorAddress: string;
+  requiresMetoken?: boolean;
+  metokenPrice?: number | null;
+  onGateUpdated: (config: { requiresMetoken: boolean; metokenPrice: number | null }) => void;
+}
+
+export function StreamMeTokenGateEditor({
+  creatorAddress,
+  requiresMetoken = false,
+  metokenPrice = null,
+  onGateUpdated,
+}: StreamMeTokenGateEditorProps) {
+  const { userMeToken, loading: meTokenLoading, checkUserMeToken } = useMeTokensSupabase();
+  const [requireMeToken, setRequireMeToken] = useState(requiresMetoken);
+  const [price, setPrice] = useState(
+    metokenPrice !== null && metokenPrice !== undefined ? String(metokenPrice) : "0",
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    checkUserMeToken();
+  }, [checkUserMeToken]);
+
+  useEffect(() => {
+    setRequireMeToken(requiresMetoken);
+    setPrice(
+      metokenPrice !== null && metokenPrice !== undefined ? String(metokenPrice) : "0",
+    );
+  }, [requiresMetoken, metokenPrice]);
+
+  const saveGate = async () => {
+    const parsedPrice = Number(price);
+    if (requireMeToken && (Number.isNaN(parsedPrice) || parsedPrice < 0)) {
+      toast.error("Enter a valid minimum balance (0 or greater)");
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      await updateStream(creatorAddress, {
+        requires_metoken: requireMeToken,
+        metoken_price: requireMeToken ? parsedPrice : null,
+      });
+      onGateUpdated({
+        requiresMetoken: requireMeToken,
+        metokenPrice: requireMeToken ? parsedPrice : null,
+      });
+      toast.success("MeToken access settings saved");
+    } catch (error) {
+      logger.error("Error updating stream MeToken gate:", error);
+      toast.error("Failed to save MeToken settings. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isDirty =
+    requireMeToken !== requiresMetoken ||
+    (requireMeToken &&
+      Number(price) !== (metokenPrice ?? 0));
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4 border rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <h3 className="font-semibold flex items-center gap-2">
+        <Lock className="w-4 h-4" />
+        MeToken Access
+      </h3>
+
+      {meTokenLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Loading MeToken...
+        </div>
+      ) : !userMeToken ? (
+        <div className="text-center space-y-2 max-w-xs">
+          <p className="text-sm text-muted-foreground">
+            Create a MeToken first to gate live playback for your holders.
+          </p>
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/profile/${creatorAddress}`}>Create MeToken</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="flex w-full max-w-xs flex-col gap-4">
+          <div className="flex items-center justify-between gap-3">
+            <Label htmlFor="require-metoken-live" className="text-sm">
+              Require MeToken for Access
+            </Label>
+            <Switch
+              id="require-metoken-live"
+              checked={requireMeToken}
+              onCheckedChange={setRequireMeToken}
+              disabled={isSaving}
+            />
+          </div>
+
+          {requireMeToken && (
+            <div className="space-y-2">
+              <Label htmlFor="metoken-min-balance">Minimum MeToken Balance Required</Label>
+              <div className="relative">
+                <Input
+                  id="metoken-min-balance"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
+                  className="pr-20"
+                  disabled={isSaving}
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
+                  {userMeToken.symbol}
+                </span>
+              </div>
+              <p className="text-xs text-gray-500">
+                Users will need to hold at least this amount of your MeToken to watch live playback.
+              </p>
+            </div>
+          )}
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void saveGate()}
+            disabled={isSaving || !isDirty}
+            className="self-end"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="w-3 h-3 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save Access Settings"
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Live/StreamNameEditor.tsx
+++ b/components/Live/StreamNameEditor.tsx
@@ -29,6 +29,8 @@ export function StreamNameEditor({
   }, [currentName]);
 
   const saveName = async () => {
+    if (isSaving) return;
+
     const trimmedName = name.trim();
     if (!trimmedName) {
       toast.error("Stream title cannot be empty");

--- a/components/Live/StreamNameEditor.tsx
+++ b/components/Live/StreamNameEditor.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2, Type } from "lucide-react";
+import { toast } from "sonner";
+import { updateStream } from "@/services/streams";
+import { logger } from "@/lib/utils/logger";
+
+const MAX_NAME_LENGTH = 100;
+
+interface StreamNameEditorProps {
+  creatorAddress: string;
+  currentName?: string | null;
+  onNameUpdated: (name: string) => void;
+}
+
+export function StreamNameEditor({
+  creatorAddress,
+  currentName,
+  onNameUpdated,
+}: StreamNameEditorProps) {
+  const [name, setName] = useState(currentName?.trim() || "Live Stream");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setName(currentName?.trim() || "Live Stream");
+  }, [currentName]);
+
+  const saveName = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      toast.error("Stream title cannot be empty");
+      return;
+    }
+
+    if (trimmedName === (currentName?.trim() || "Live Stream")) {
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      await updateStream(creatorAddress, { name: trimmedName });
+      onNameUpdated(trimmedName);
+      toast.success("Stream title updated");
+    } catch (error) {
+      logger.error("Error updating stream name:", error);
+      toast.error("Failed to update stream title. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleBlur = () => {
+    void saveName();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.currentTarget.blur();
+    }
+  };
+
+  const isDirty = name.trim() !== (currentName?.trim() || "Live Stream");
+  const isEmpty = name.trim().length === 0;
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4 border rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <h3 className="font-semibold flex items-center gap-2">
+        <Type className="w-4 h-4" />
+        Stream Title
+      </h3>
+
+      <div className="flex w-full max-w-xs flex-col gap-2">
+        <Input
+          id="stream-name"
+          name="streamName"
+          value={name}
+          onChange={(e) => setName(e.target.value.slice(0, MAX_NAME_LENGTH))}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder="Live Stream"
+          maxLength={MAX_NAME_LENGTH}
+          disabled={isSaving}
+          aria-label="Stream title"
+        />
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-gray-500">
+            {name.length}/{MAX_NAME_LENGTH}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void saveName()}
+            disabled={isSaving || isEmpty || !isDirty}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="w-3 h-3 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save Title"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-500 text-center max-w-xs">
+        This title appears on the live grid, share dialogs, and when viewers discover your stream.
+      </p>
+    </div>
+  );
+}

--- a/components/Videos/VideoMeTokenBuyDialog.tsx
+++ b/components/Videos/VideoMeTokenBuyDialog.tsx
@@ -34,6 +34,8 @@ interface VideoMeTokenBuyDialogProps {
   onOpenChange: (open: boolean) => void;
   playbackId: string;
   videoTitle?: string;
+  /** When set (e.g. live streams), fetch creator MeToken directly instead of VOD asset lookup */
+  creatorAddress?: string;
 }
 
 interface MeToken {
@@ -49,6 +51,7 @@ export function VideoMeTokenBuyDialog({
   onOpenChange,
   playbackId,
   videoTitle,
+  creatorAddress,
 }: VideoMeTokenBuyDialogProps) {
   const [meToken, setMeToken] = useState<MeToken | null>(null);
   const [videoAsset, setVideoAsset] = useState<{ id?: number; playback_id?: string; attributes?: any; creator_metoken_id?: string } | null>(null);
@@ -100,44 +103,45 @@ export function VideoMeTokenBuyDialog({
       setIsLoadingMeToken(true);
       setError(null);
       try {
-        // Fetch video asset to get token information
-        const fetchedVideoAsset = await fetchVideoAssetByPlaybackId(playbackId);
-        setVideoAsset(fetchedVideoAsset);
-
-        if (!fetchedVideoAsset) {
-          setError('Video asset not found.');
-          setIsLoadingMeToken(false);
-          return;
-        }
-
-        // Prioritize Content Coin over Creator MeToken
-        const contentCoinId = fetchedVideoAsset?.attributes?.content_coin_id;
-        const creatorMeTokenId = fetchedVideoAsset?.creator_metoken_id;
-
         let fetchUrl: string | null = null;
 
-        // First, try to fetch Content Coin (video-specific token)
-        if (contentCoinId) {
-          if (contentCoinId.startsWith('0x')) {
-            // It's an address - use the address endpoint
-            fetchUrl = `/api/metokens/${contentCoinId}`;
-          } else {
-            // It's an ID - use the by-id endpoint
-            fetchUrl = `/api/metokens/by-id/${contentCoinId}`;
-          }
-        } else if (creatorMeTokenId) {
-          // Fallback to creator's MeToken if no Content Coin exists
-          fetchUrl = `/api/metokens/by-id/${creatorMeTokenId}`;
-        }
+        if (creatorAddress) {
+          fetchUrl = `/api/metokens?owner=${encodeURIComponent(creatorAddress)}`;
+        } else {
+          // Fetch video asset to get token information
+          const fetchedVideoAsset = await fetchVideoAssetByPlaybackId(playbackId);
+          setVideoAsset(fetchedVideoAsset);
 
-        if (!fetchUrl) {
-          setError('This video does not have an associated MeToken or Content Coin.');
-          setIsLoadingMeToken(false);
-          return;
+          if (!fetchedVideoAsset) {
+            setError('Video asset not found.');
+            setIsLoadingMeToken(false);
+            return;
+          }
+
+          // Prioritize Content Coin over Creator MeToken
+          const contentCoinId = fetchedVideoAsset?.attributes?.content_coin_id;
+          const creatorMeTokenId = fetchedVideoAsset?.creator_metoken_id;
+
+          // First, try to fetch Content Coin (video-specific token)
+          if (contentCoinId) {
+            if (contentCoinId.startsWith('0x')) {
+              fetchUrl = `/api/metokens/${contentCoinId}`;
+            } else {
+              fetchUrl = `/api/metokens/by-id/${contentCoinId}`;
+            }
+          } else if (creatorMeTokenId) {
+            fetchUrl = `/api/metokens/by-id/${creatorMeTokenId}`;
+          }
+
+          if (!fetchUrl) {
+            setError('This video does not have an associated MeToken or Content Coin.');
+            setIsLoadingMeToken(false);
+            return;
+          }
         }
 
         // Fetch MeToken/Content Coin
-        const response = await fetch(fetchUrl);
+        const response = await fetch(fetchUrl!);
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           throw new Error(errorData.error || 'Failed to fetch MeToken');
@@ -173,7 +177,7 @@ export function VideoMeTokenBuyDialog({
     };
 
     fetchMeToken();
-  }, [open, playbackId]);
+  }, [open, playbackId, creatorAddress]);
 
   // Vault Address fetch effect removed
 

--- a/lib/utils/metoken-access.ts
+++ b/lib/utils/metoken-access.ts
@@ -1,0 +1,138 @@
+import { createPublicClient, erc20Abi, formatEther, getAddress, parseEther } from "viem";
+import { alchemy, base } from "@account-kit/infra";
+import { createServiceClient } from "@/lib/sdk/supabase/service";
+
+const publicClient = createPublicClient({
+  chain: base,
+  transport: alchemy({
+    apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY as string,
+  }),
+});
+
+export type MeTokenAccessDenyReason =
+  | "no_metoken"
+  | "insufficient_balance"
+  | "no_viewer_address";
+
+export interface MeTokenAccessResult {
+  allowed: boolean;
+  meTokenAddress?: string;
+  symbol?: string;
+  name?: string;
+  balance?: bigint;
+  required?: bigint;
+  requiredFormatted?: string;
+  balanceFormatted?: string;
+  reason?: MeTokenAccessDenyReason | "creator_bypass";
+}
+
+async function getMeTokenByOwner(ownerAddress: string) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("metokens")
+    .select("address, symbol, name, owner_address")
+    .eq("owner_address", ownerAddress.toLowerCase())
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch MeToken: ${error.message}`);
+  }
+
+  return data;
+}
+
+function normalizeAddresses(addresses: (string | undefined | null)[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const addr of addresses) {
+    if (!addr) continue;
+    const lower = addr.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    result.push(lower);
+  }
+
+  return result;
+}
+
+export async function checkMeTokenAccess(params: {
+  viewerAddresses: (string | undefined | null)[];
+  creatorAddress: string;
+  requiredAmount: number | string | null;
+  bypassForCreator?: boolean;
+}): Promise<MeTokenAccessResult> {
+  const {
+    viewerAddresses,
+    creatorAddress,
+    requiredAmount,
+    bypassForCreator = true,
+  } = params;
+
+  const normalizedCreator = creatorAddress.toLowerCase();
+  const normalizedViewers = normalizeAddresses(viewerAddresses);
+
+  if (
+    bypassForCreator &&
+    normalizedViewers.some((viewer) => viewer === normalizedCreator)
+  ) {
+    return { allowed: true, reason: "creator_bypass" };
+  }
+
+  const required = parseEther(String(requiredAmount ?? 0));
+  const meToken = await getMeTokenByOwner(normalizedCreator);
+
+  if (!meToken?.address) {
+    return { allowed: false, reason: "no_metoken" };
+  }
+
+  const baseResult = {
+    meTokenAddress: meToken.address,
+    symbol: meToken.symbol,
+    name: meToken.name,
+    required,
+    requiredFormatted: formatEther(required),
+  };
+
+  if (normalizedViewers.length === 0) {
+    return {
+      allowed: false,
+      reason: "no_viewer_address",
+      ...baseResult,
+    };
+  }
+
+  let maxBalance = BigInt(0);
+  for (const viewer of normalizedViewers) {
+    try {
+      const balance = await publicClient.readContract({
+        address: meToken.address as `0x${string}`,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [getAddress(viewer)],
+      });
+      if (balance > maxBalance) {
+        maxBalance = balance;
+      }
+    } catch {
+      // Skip unreadable addresses
+    }
+  }
+
+  const allowed = maxBalance >= required;
+
+  return {
+    allowed,
+    ...baseResult,
+    balance: maxBalance,
+    balanceFormatted: formatEther(maxBalance),
+    reason: allowed ? undefined : "insufficient_balance",
+  };
+}
+
+export function isMeTokenGateActive(
+  requiresMetoken?: boolean | null,
+  metokenPrice?: number | string | null,
+): boolean {
+  return Boolean(requiresMetoken) && metokenPrice !== null && metokenPrice !== undefined;
+}

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -19,6 +19,8 @@ export interface Stream {
     story_ip_registration_tx?: string | null;
     story_ip_registered_at?: string | null;
     story_commercial_rev_share?: number | null;
+    requires_metoken?: boolean;
+    metoken_price?: number | null;
     created_at: string;
     updated_at: string;
 }
@@ -77,7 +79,7 @@ export async function getStreamByPlaybackId(playbackId: string) {
 
     const { data, error } = await supabase
         .from("streams")
-        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, allow_clipping, story_ip_id, story_license_terms_id, story_commercial_rev_share, story_ip_registered_at")
+        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, allow_clipping, requires_metoken, metoken_price, story_ip_id, story_license_terms_id, story_commercial_rev_share, story_ip_registered_at")
         .eq("playback_id", playbackId)
         .maybeSingle();
 
@@ -180,6 +182,7 @@ export interface ActiveStream {
     name?: string | null;
     is_live: boolean;
     last_live_at?: string | null;
+    requires_metoken?: boolean;
     created_at: string;
 }
 
@@ -191,7 +194,7 @@ export async function getActiveStreams() {
 
     const { data, error } = await supabase
         .from("streams")
-        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, created_at")
+        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, requires_metoken, created_at")
         .eq("is_live", true)
         .order("last_live_at", { ascending: false });
 

--- a/supabase/migrations/20260608120000_add_metoken_fields_to_streams.sql
+++ b/supabase/migrations/20260608120000_add_metoken_fields_to_streams.sql
@@ -1,0 +1,10 @@
+-- Add MeToken gating fields to streams table (mirrors video_assets semantics)
+
+ALTER TABLE streams
+ADD COLUMN IF NOT EXISTS requires_metoken BOOLEAN DEFAULT FALSE NOT NULL,
+ADD COLUMN IF NOT EXISTS metoken_price DECIMAL(20, 8) NULL;
+
+COMMENT ON COLUMN streams.requires_metoken IS 'Whether live playback requires holding the creator''s MeToken';
+COMMENT ON COLUMN streams.metoken_price IS 'Minimum MeToken balance required to watch live playback (null if not required)';
+
+CREATE INDEX IF NOT EXISTS idx_streams_requires_metoken ON streams(requires_metoken) WHERE requires_metoken = TRUE;

--- a/supabase/migrations/20260608120000_add_metoken_fields_to_streams.sql
+++ b/supabase/migrations/20260608120000_add_metoken_fields_to_streams.sql
@@ -1,10 +1,12 @@
 -- Add MeToken gating fields to streams table (mirrors video_assets semantics)
 
-ALTER TABLE streams
+ALTER TABLE public.streams
 ADD COLUMN IF NOT EXISTS requires_metoken BOOLEAN DEFAULT FALSE NOT NULL,
 ADD COLUMN IF NOT EXISTS metoken_price DECIMAL(20, 8) NULL;
 
-COMMENT ON COLUMN streams.requires_metoken IS 'Whether live playback requires holding the creator''s MeToken';
-COMMENT ON COLUMN streams.metoken_price IS 'Minimum MeToken balance required to watch live playback (null if not required)';
+COMMENT ON COLUMN public.streams.requires_metoken IS 'Whether live playback requires holding the creator''s MeToken';
+COMMENT ON COLUMN public.streams.metoken_price IS 'Minimum MeToken balance required to watch live playback (null if not required)';
 
-CREATE INDEX IF NOT EXISTS idx_streams_requires_metoken ON streams(requires_metoken) WHERE requires_metoken = TRUE;
+CREATE INDEX IF NOT EXISTS idx_streams_requires_metoken
+ON public.streams(requires_metoken)
+WHERE requires_metoken = TRUE;


### PR DESCRIPTION
## Summary
- Adds `requires_metoken` and `metoken_price` to `public.streams` so creators can require a minimum MeToken balance for live playback.
- Enforces access server-side in `sign-jwt` via on-chain balance checks (EOA + smart account) before issuing Livepeer JWTs.
- Adds live studio gate editor, watch-page gated UX with buy/connect flow, public access metadata API, and discover grid lock badge.

## Test plan
- [ ] Run `supabase db push` and verify columns/index with SQL invariant checks
- [ ] Gate off: `/watch/{playbackId}` plays as before
- [ ] Gate on + sufficient balance: JWT issued, player loads
- [ ] Gate on + insufficient balance: 403 gate UI, no playback, buy CTA works
- [ ] Creator watching own stream: always plays
- [ ] Smart account holds tokens, EOA empty: access granted
- [ ] Chat remains available when playback is gated (v1)


Made with [Cursor](https://cursor.com)