### PR TITLE
Show total ETH bonded on prediction markets

### DIFF
--- a/app/api/predictions/stake-stats/route.ts
+++ b/app/api/predictions/stake-stats/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { serverLogger } from "@/lib/utils/logger";
+import {
+  buildSubgraphRequestHeaders,
+  formatGraphQlErrors,
+  getGraphQlResponseErrors,
+  isGraphQlResponseSuccessful,
+  resolveSubgraphEndpoints,
+} from "@/lib/subgraph/creative-platform-proxy";
+import { computeListStakeSummary } from "@/lib/predictions/stake-stats";
+
+const MAX_IDS = 25;
+
+const STAKE_STATS_QUERY = `
+  query GetQuestionsStakeStats($ids: [ID!]!) {
+    questions(where: { id_in: $ids }) {
+      id
+      bounty
+      last_bond
+      answers {
+        bond
+      }
+    }
+  }
+`;
+
+type SubgraphQuestion = {
+  id: string;
+  bounty?: string;
+  last_bond?: string;
+  answers?: Array<{ bond: string }>;
+};
+
+export async function GET(request: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.generous(request);
+  if (rl) return rl;
+
+  const idsParam = request.nextUrl.searchParams.get("ids")?.trim();
+  if (!idsParam) {
+    return NextResponse.json(
+      { error: "ids query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  const ids = idsParam
+    .split(",")
+    .map((id) => id.trim().toLowerCase())
+    .filter((id) => /^0x[a-f0-9]{64}$/.test(id));
+
+  if (ids.length === 0) {
+    return NextResponse.json(
+      { error: "At least one valid questionId is required" },
+      { status: 400 }
+    );
+  }
+
+  if (ids.length > MAX_IDS) {
+    return NextResponse.json(
+      { error: `Maximum ${MAX_IDS} question IDs per request` },
+      { status: 400 }
+    );
+  }
+
+  const endpoints = resolveSubgraphEndpoints("reality-eth");
+  if (endpoints.length === 0) {
+    return NextResponse.json(
+      { error: "Reality.eth subgraph not configured" },
+      { status: 503 }
+    );
+  }
+
+  let questions: SubgraphQuestion[] | null = null;
+
+  for (const endpoint of endpoints) {
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: buildSubgraphRequestHeaders(endpoint),
+        body: JSON.stringify({
+          query: STAKE_STATS_QUERY,
+          variables: { ids },
+        }),
+      });
+
+      if (!response.ok) continue;
+
+      const data = (await response.json()) as {
+        data?: { questions?: SubgraphQuestion[] };
+        errors?: unknown[];
+      };
+
+      if (!isGraphQlResponseSuccessful(data)) {
+        serverLogger.debug(
+          "Stake stats subgraph error:",
+          formatGraphQlErrors(getGraphQlResponseErrors(data))
+        );
+        continue;
+      }
+
+      questions = data.data?.questions ?? [];
+      break;
+    } catch (err) {
+      serverLogger.debug("Stake stats subgraph fetch failed:", err);
+    }
+  }
+
+  if (questions === null) {
+    return NextResponse.json(
+      { error: "Failed to fetch stake stats from subgraph" },
+      { status: 502 }
+    );
+  }
+
+  const stats: Record<string, ReturnType<typeof computeListStakeSummary>> = {};
+
+  for (const q of questions) {
+    const answers = (q.answers ?? []).map((a) => ({ answer: "", bond: a.bond }));
+    stats[q.id.toLowerCase()] = computeListStakeSummary({
+      bounty: q.bounty ?? "0",
+      leadingBond: q.last_bond ?? "0",
+      answers,
+    });
+  }
+
+  return NextResponse.json(
+    { stats },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
+      },
+    }
+  );
+}

--- a/components/predictions/BetForm.tsx
+++ b/components/predictions/BetForm.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useSmartAccountClient } from "@account-kit/react";
 import { base } from "@account-kit/infra";
-import { createPublicClient, http, fallback, parseEther, keccak256, stringToHex } from "viem";
+import {
+  createPublicClient,
+  http,
+  fallback,
+  parseEther,
+  keccak256,
+  stringToHex,
+} from "viem";
 import {
   Form,
   FormField,
@@ -25,6 +32,14 @@ import { submitAnswer } from "@/lib/sdk/reality-eth/reality-eth-question-wrapper
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
 import { usePredictionAccess } from "@/lib/hooks/predictions/usePredictionAccess";
 import { logger } from '@/lib/utils/logger';
+import type { ParsedPredictionDisplay } from "@/lib/predictions/parse-prediction-display";
+import {
+  estimateEarningsIfWin,
+  formatEth,
+  minBondRequired,
+  resolveSelectedAnswerHex,
+  type StakeStats,
+} from "@/lib/predictions/stake-stats";
 
 
 const betSchema = z.object({
@@ -38,9 +53,21 @@ interface BetFormProps {
   questionId: string;
   questionType: "bool" | "single-select" | "multiple-select" | "uint";
   outcomes?: string[];
+  stakeStats?: StakeStats | null;
+  parsed?: ParsedPredictionDisplay;
+  minBond?: bigint;
+  leadingBond?: bigint;
 }
 
-export function BetForm({ questionId, questionType, outcomes }: BetFormProps) {
+export function BetForm({
+  questionId,
+  questionType,
+  outcomes,
+  stakeStats = null,
+  parsed,
+  minBond = 0n,
+  leadingBond = 0n,
+}: BetFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -61,6 +88,47 @@ export function BetForm({ questionId, questionType, outcomes }: BetFormProps) {
       bond: "0.01", // Default 0.01 ETH
     },
   });
+
+  const watchedAnswer = form.watch("answer");
+  const watchedBond = form.watch("bond");
+
+  const requiredMinBond = useMemo(
+    () => minBondRequired(minBond, leadingBond),
+    [minBond, leadingBond]
+  );
+
+  const selectedOutcomeLabel = useMemo(() => {
+    if (!watchedAnswer || !parsed) return null;
+    if (questionType === "bool") {
+      return watchedAnswer === "true" ? "Yes" : "No";
+    }
+    if (questionType === "single-select" && outcomes) {
+      const idx = parseInt(watchedAnswer, 10);
+      return outcomes[idx] ?? null;
+    }
+    return null;
+  }, [watchedAnswer, parsed, questionType, outcomes]);
+
+  const estimatedEarnings = useMemo(() => {
+    if (!stakeStats || !parsed || !watchedAnswer || !watchedBond) return null;
+    let userBond: bigint;
+    try {
+      userBond = parseEther(watchedBond);
+    } catch {
+      return null;
+    }
+    const answerHex = resolveSelectedAnswerHex(
+      watchedAnswer,
+      questionType,
+      outcomes
+    );
+    if (!answerHex) return null;
+    return estimateEarningsIfWin({
+      stats: stakeStats,
+      selectedAnswerHex: answerHex,
+      userBond,
+    });
+  }, [stakeStats, parsed, watchedAnswer, watchedBond, questionType, outcomes]);
 
   async function onSubmit(values: BetFormData) {
     setError(null);
@@ -115,6 +183,15 @@ export function BetForm({ questionId, questionType, outcomes }: BetFormProps) {
       }
 
       const bond = parseEther(values.bond);
+
+      if (bond < requiredMinBond) {
+        setError(
+          `Bond must be at least ${formatEth(requiredMinBond)} ETH to participate.`
+        );
+        setIsSubmitting(false);
+        return;
+      }
+
       const maxPrevious = 0n; // Start with 0, can be increased for higher bonds
 
       const hash = await submitAnswer(publicClient, accountKitClient as any, {
@@ -213,9 +290,29 @@ export function BetForm({ questionId, questionType, outcomes }: BetFormProps) {
               </FormControl>
               <FormMessage />
               <p className="text-xs text-gray-500">
-                The bond amount you're staking on this answer. Higher bonds
+                The bond amount you&apos;re staking on this answer. Higher bonds
                 have more weight.
+                {requiredMinBond > 0n && (
+                  <>
+                    {" "}
+                    Minimum: {formatEth(requiredMinBond)} ETH.
+                  </>
+                )}
               </p>
+              {stakeStats && stakeStats.totalPrizePool > 0n && (
+                <p className="text-xs text-muted-foreground">
+                  Prize pool: {formatEth(stakeStats.totalPrizePool)} ETH
+                </p>
+              )}
+              {estimatedEarnings != null && selectedOutcomeLabel && (
+                <p
+                  className="text-xs text-emerald-600 dark:text-emerald-400"
+                  title="Approximate payout if this outcome wins. Actual winnings depend on final bonds and bounty distribution."
+                >
+                  If &quot;{selectedOutcomeLabel}&quot; wins, you could earn
+                  ~{formatEth(estimatedEarnings)} ETH (approximate).
+                </p>
+              )}
             </FormItem>
           )}
         />

--- a/components/predictions/BetForm.tsx
+++ b/components/predictions/BetForm.tsx
@@ -57,6 +57,7 @@ interface BetFormProps {
   parsed?: ParsedPredictionDisplay;
   minBond?: bigint;
   leadingBond?: bigint;
+  leadingAnswerHex?: string;
 }
 
 export function BetForm({
@@ -67,6 +68,7 @@ export function BetForm({
   parsed,
   minBond = 0n,
   leadingBond = 0n,
+  leadingAnswerHex,
 }: BetFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -187,6 +189,20 @@ export function BetForm({
       if (bond < requiredMinBond) {
         setError(
           `Bond must be at least ${formatEth(requiredMinBond)} ETH to participate.`
+        );
+        setIsSubmitting(false);
+        return;
+      }
+
+      const zeroAnswer =
+        "0x0000000000000000000000000000000000000000000000000000000000000000";
+      if (
+        leadingAnswerHex &&
+        leadingAnswerHex.toLowerCase() !== zeroAnswer &&
+        answerBytes32.toLowerCase() === leadingAnswerHex.toLowerCase()
+      ) {
+        setError(
+          "You cannot submit the same answer as the current leading answer."
         );
         setIsSubmitting(false);
         return;

--- a/components/predictions/PredictionDetails.tsx
+++ b/components/predictions/PredictionDetails.tsx
@@ -483,6 +483,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
             parsed={parsed}
             minBond={question.min_bond}
             leadingBond={question.bond}
+            leadingAnswerHex={question.best_answer}
           />
         </Card>
       )}

--- a/components/predictions/PredictionDetails.tsx
+++ b/components/predictions/PredictionDetails.tsx
@@ -20,6 +20,11 @@ import {
   type ParsedPredictionDisplay,
 } from "@/lib/predictions/parse-prediction-display";
 import { enrichPredictionDisplay } from "@/lib/predictions/enrich-prediction-display";
+import {
+  computeStakeStats,
+  formatEth,
+  type StakeStats,
+} from "@/lib/predictions/stake-stats";
 import { BetForm } from "./BetForm";
 import { ClaimWinningsCard } from "./ClaimWinningsCard";
 import { Clock, Share2 } from "lucide-react";
@@ -60,6 +65,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
   const [answerTimeline, setAnswerTimeline] = useState<AnswerTimelineEntry[]>(
     []
   );
+  const [stakeStats, setStakeStats] = useState<StakeStats | null>(null);
 
   const publicClient = useMemo(
     () =>
@@ -125,6 +131,12 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
         let subgraphCategory: string | null = null;
         let timeline: AnswerTimelineEntry[] = [];
         let parsedDisplay: ParsedPredictionDisplay | null = null;
+        let subgraphAnswers: Array<{
+          answer: string;
+          bond: string;
+          answerer: string;
+          created: string;
+        }> = [];
 
         if (typeof window !== "undefined") {
           try {
@@ -146,6 +158,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
 
             subgraphOutcomes = subgraphData?.question?.outcomes;
             subgraphCategory = subgraphData?.question?.category ?? null;
+            subgraphAnswers = subgraphData?.question?.answers ?? [];
 
             const { parsed: previewParsed } = await enrichPredictionDisplay(
               questionDataRaw.question ?? "",
@@ -154,7 +167,7 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
             );
             parsedDisplay = previewParsed;
 
-            timeline = (subgraphData?.question?.answers ?? [])
+            timeline = subgraphAnswers
               .slice()
               .reverse()
               .slice(0, 8)
@@ -190,8 +203,17 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
           parsed,
         };
 
+        const computedStake = computeStakeStats({
+          bounty: questionDataRaw.bounty ?? 0n,
+          minBond: questionDataRaw.min_bond ?? 0n,
+          leadingBond: questionDataRaw.bond ?? 0n,
+          answers: subgraphAnswers,
+          parsed,
+        });
+
         setQuestion(questionData);
         setAnswerTimeline(timeline);
+        setStakeStats(computedStake);
 
         try {
           const answer = await getFinalAnswer(publicClient, questionId);
@@ -334,6 +356,28 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
         <div className="text-foreground/90">{parsed.description}</div>
       )}
 
+      {stakeStats && stakeStats.totalPrizePool > 0n && (
+        <Card className="p-4 bg-violet-50 dark:bg-violet-950/30 border-violet-200 dark:border-violet-800">
+          <h3 className="text-sm font-medium text-violet-700 dark:text-violet-300 mb-1">
+            At stake
+          </h3>
+          <div className="text-2xl font-bold text-violet-900 dark:text-violet-100">
+            {formatEth(stakeStats.totalPrizePool)} ETH
+          </div>
+          <div className="mt-2 text-xs text-violet-700/80 dark:text-violet-300/80 space-y-0.5">
+            {stakeStats.bounty > 0n && (
+              <div>Bounty: {formatEth(stakeStats.bounty)} ETH</div>
+            )}
+            {stakeStats.totalBonded > 0n && (
+              <div>Total bonded: {formatEth(stakeStats.totalBonded)} ETH</div>
+            )}
+            {stakeStats.minBond > 0n && (
+              <div>Min bond: {formatEth(stakeStats.minBond)} ETH</div>
+            )}
+          </div>
+        </Card>
+      )}
+
       {parsed.outcomes.length > 0 && (
         <Card className="p-4">
           <h3 className="text-sm font-medium text-muted-foreground mb-2">
@@ -343,12 +387,18 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
             {parsed.outcomes.map((o) => {
               const isFinal = isResolved && finalLabel === o;
               const isLeading = !isResolved && leadingLabel === o;
+              const outcomeStake = stakeStats?.perOutcome.find(
+                (entry) => entry.label === o
+              );
               return (
                 <Badge
                   key={o}
                   variant={isFinal || isLeading ? "default" : "outline"}
                 >
                   {o}
+                  {outcomeStake && outcomeStake.totalBond > 0n
+                    ? ` · ${formatEth(outcomeStake.totalBond)} ETH`
+                    : ""}
                   {isFinal ? " · final" : isLeading ? " · leading" : ""}
                 </Badge>
               );
@@ -429,6 +479,10 @@ export function PredictionDetails({ questionId }: PredictionDetailsProps) {
             questionId={questionId}
             questionType={parsed.type as QuestionType}
             outcomes={parsed.outcomes}
+            stakeStats={stakeStats}
+            parsed={parsed}
+            minBond={question.min_bond}
+            leadingBond={question.bond}
           />
         </Card>
       )}

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -654,20 +654,22 @@ export function PredictionList() {
                           : "No timeout"}
                       </span>
                     </div>
-                    {stakeStatsMap[question.id] &&
-                    BigInt(stakeStatsMap[question.id].totalPrizePool) > 0n ? (
-                      <div>
-                        Pool:{" "}
-                        {formatEth(
-                          BigInt(stakeStatsMap[question.id].totalPrizePool)
-                        )}{" "}
-                        ETH
-                      </div>
-                    ) : question.bounty && Number(question.bounty) > 0 ? (
-                      <div>
-                        Bounty: {(Number(question.bounty) / 1e18).toFixed(4)} ETH
-                      </div>
-                    ) : null}
+                    {(() => {
+                      const stakeSummary =
+                        stakeStatsMap[question.id.toLowerCase()];
+                      return stakeSummary &&
+                        BigInt(stakeSummary.totalPrizePool) > 0n ? (
+                        <div>
+                          Pool:{" "}
+                          {formatEth(BigInt(stakeSummary.totalPrizePool))} ETH
+                        </div>
+                      ) : question.bounty && Number(question.bounty) > 0 ? (
+                        <div>
+                          Bounty: {(Number(question.bounty) / 1e18).toFixed(4)}{" "}
+                          ETH
+                        </div>
+                      ) : null;
+                    })()}
                   </div>
                 </div>
                 <div className="flex flex-col gap-2 w-full md:w-auto mt-2 md:mt-0">

--- a/components/predictions/PredictionList.tsx
+++ b/components/predictions/PredictionList.tsx
@@ -36,6 +36,10 @@ import {
 } from "@/components/ui/select";
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
 import type { UserClaimStatus } from "@/lib/predictions/claim-status";
+import {
+  formatEth,
+  type ListStakeSummary,
+} from "@/lib/predictions/stake-stats";
 
 const APP_ARBITRATOR = "0x0000000000000000000000000000000000000000";
 
@@ -121,7 +125,11 @@ export function PredictionList() {
   const [claimStatusMap, setClaimStatusMap] = useState<
     Record<string, UserClaimStatus>
   >({});
+  const [stakeStatsMap, setStakeStatsMap] = useState<
+    Record<string, ListStakeSummary>
+  >({});
   const fetchedClaimStatusRef = useRef<Set<string>>(new Set());
+  const fetchedStakeStatsRef = useRef<Set<string>>(new Set());
 
   const { isConnected, walletAddress, smartAccountAddress } = useWalletStatus();
 
@@ -129,6 +137,11 @@ export function PredictionList() {
     fetchedClaimStatusRef.current.clear();
     setClaimStatusMap({});
   }, [walletAddress, smartAccountAddress]);
+
+  useEffect(() => {
+    fetchedStakeStatsRef.current.clear();
+    setStakeStatsMap({});
+  }, [sourceFilter, categoryFilter, searchQuery, currentPage]);
 
   useEffect(() => {
     async function fetchQuestions() {
@@ -370,6 +383,40 @@ export function PredictionList() {
     };
   }, [isConnected, walletAddress, smartAccountAddress, questions]);
 
+  useEffect(() => {
+    const pendingIds = questions
+      .map((q) => q.id)
+      .filter((id) => !fetchedStakeStatsRef.current.has(id));
+
+    if (pendingIds.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/predictions/stake-stats?ids=${encodeURIComponent(pendingIds.join(","))}`
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          stats?: Record<string, ListStakeSummary>;
+        };
+        if (cancelled) return;
+        for (const id of pendingIds) {
+          fetchedStakeStatsRef.current.add(id);
+        }
+        if (data.stats) {
+          setStakeStatsMap((prev) => ({ ...prev, ...data.stats }));
+        }
+      } catch {
+        // Non-fatal
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [questions]);
+
   const localSuggest = useCallback(
     (query: string) => {
       const sq = query.trim().toLowerCase();
@@ -607,9 +654,20 @@ export function PredictionList() {
                           : "No timeout"}
                       </span>
                     </div>
-                    {question.bounty && Number(question.bounty) > 0 && (
-                      <div>Bounty: {(Number(question.bounty) / 1e18).toFixed(4)} ETH</div>
-                    )}
+                    {stakeStatsMap[question.id] &&
+                    BigInt(stakeStatsMap[question.id].totalPrizePool) > 0n ? (
+                      <div>
+                        Pool:{" "}
+                        {formatEth(
+                          BigInt(stakeStatsMap[question.id].totalPrizePool)
+                        )}{" "}
+                        ETH
+                      </div>
+                    ) : question.bounty && Number(question.bounty) > 0 ? (
+                      <div>
+                        Bounty: {(Number(question.bounty) / 1e18).toFixed(4)} ETH
+                      </div>
+                    ) : null}
                   </div>
                 </div>
                 <div className="flex flex-col gap-2 w-full md:w-auto mt-2 md:mt-0">

--- a/docs/predictions.md
+++ b/docs/predictions.md
@@ -134,6 +134,23 @@ Proxies Precog market fetch with in-memory cache (5 min TTL). Used when question
 
 Autocomplete over `prediction_market_creations` via `autocomplete_prediction_creations` RPC. Minimum query length: 2 characters.
 
+### `GET /api/predictions/stake-stats?ids=0x…,0x…`
+
+Batch stake summary for list cards (max 25 IDs). Returns per-question `totalPrizePool`, `totalBonded`, `leadingBond`, and `answerCount` from subgraph answers. Cached 60s at the edge.
+
+## Stake display
+
+| Metric | Meaning |
+|--------|---------|
+| **Prize pool** | Bounty + sum of all bonded answers (ETH locked until resolution) |
+| **Leading bond** | Bond backing the current best answer; minimum to overtake with a different answer |
+| **Min bond** | Floor set when the question was created |
+| **Per-outcome stake** | Total ETH bonded on each outcome label |
+
+Detail page (`/predict/[questionId]`) shows a full breakdown and per-outcome totals. List cards show **Pool: X ETH** when bonds exist; otherwise bounty only. `BetForm` shows prize pool context and an approximate earnings hint when the user selects an outcome and bond amount.
+
+Computation lives in `lib/predictions/stake-stats.ts`.
+
 ## Supabase: `prediction_market_creations`
 
 | Column | Purpose |

--- a/lib/predictions/stake-stats.ts
+++ b/lib/predictions/stake-stats.ts
@@ -152,6 +152,12 @@ export function resolveSelectedAnswerHex(
   return null;
 }
 
+/**
+ * Estimates potential earnings if the selected outcome wins.
+ * Note: Reality.eth uses a sequential bonding model where incorrect bonds are distributed
+ * to the next correct answerer, rather than a proportional pool-based distribution.
+ * This pool-based calculation serves as a simplified heuristic for estimation.
+ */
 export function estimateEarningsIfWin(params: {
   stats: StakeStats;
   selectedAnswerHex: string;
@@ -176,8 +182,8 @@ export function estimateEarningsIfWin(params: {
   return params.userBond + share;
 }
 
-/** Minimum bond to participate: max(min_bond, leadingBond + 1 wei when leading exists). */
+/** Minimum bond to participate: max(min_bond, 2× leading bond when a leading answer exists). */
 export function minBondRequired(minBond: bigint, leadingBond: bigint): bigint {
-  const beatLeading = leadingBond > 0n ? leadingBond + 1n : 0n;
+  const beatLeading = leadingBond > 0n ? leadingBond * 2n : 0n;
   return minBond > beatLeading ? minBond : beatLeading;
 }

--- a/lib/predictions/stake-stats.ts
+++ b/lib/predictions/stake-stats.ts
@@ -1,0 +1,183 @@
+import { formatEther, keccak256, stringToHex } from "viem";
+import {
+  answerBytesToLabel,
+  type ParsedPredictionDisplay,
+} from "@/lib/predictions/parse-prediction-display";
+
+export type AnswerBondInput = {
+  answer: string;
+  bond: string | bigint;
+};
+
+export type PerOutcomeStake = {
+  label: string;
+  answerHex: string;
+  totalBond: bigint;
+  count: number;
+};
+
+export type StakeStats = {
+  totalBonded: bigint;
+  totalPrizePool: bigint;
+  perOutcome: PerOutcomeStake[];
+  leadingBond: bigint;
+  minBond: bigint;
+  bounty: bigint;
+};
+
+export type ListStakeSummary = {
+  totalBonded: string;
+  totalPrizePool: string;
+  leadingBond: string;
+  answerCount: number;
+};
+
+function toBigInt(value: string | bigint | undefined | null): bigint {
+  if (value == null) return 0n;
+  if (typeof value === "bigint") return value;
+  try {
+    return BigInt(value);
+  } catch {
+    return 0n;
+  }
+}
+
+function normalizeAnswerHex(hex: string): string {
+  return hex.toLowerCase();
+}
+
+export function computeStakeStats(params: {
+  bounty: string | bigint;
+  minBond: string | bigint;
+  leadingBond: string | bigint;
+  answers: AnswerBondInput[];
+  parsed: ParsedPredictionDisplay;
+}): StakeStats {
+  const bounty = toBigInt(params.bounty);
+  const minBond = toBigInt(params.minBond);
+  const leadingBond = toBigInt(params.leadingBond);
+
+  const byAnswer = new Map<
+    string,
+    { label: string; totalBond: bigint; count: number }
+  >();
+
+  let totalBonded = 0n;
+  for (const entry of params.answers) {
+    const bond = toBigInt(entry.bond);
+    totalBonded += bond;
+    const hex = normalizeAnswerHex(entry.answer);
+    const label =
+      answerBytesToLabel(entry.answer, params.parsed) ??
+      `${hex.slice(0, 10)}…`;
+    const existing = byAnswer.get(hex);
+    if (existing) {
+      existing.totalBond += bond;
+      existing.count += 1;
+    } else {
+      byAnswer.set(hex, { label, totalBond: bond, count: 1 });
+    }
+  }
+
+  const perOutcome: PerOutcomeStake[] = [...byAnswer.entries()].map(
+    ([answerHex, value]) => ({
+      answerHex,
+      ...value,
+    })
+  );
+
+  perOutcome.sort((a, b) => {
+    if (a.totalBond > b.totalBond) return -1;
+    if (a.totalBond < b.totalBond) return 1;
+    return 0;
+  });
+
+  return {
+    totalBonded,
+    totalPrizePool: bounty + totalBonded,
+    perOutcome,
+    leadingBond,
+    minBond,
+    bounty,
+  };
+}
+
+export function toListStakeSummary(stats: StakeStats, answerCount: number): ListStakeSummary {
+  return {
+    totalBonded: stats.totalBonded.toString(),
+    totalPrizePool: stats.totalPrizePool.toString(),
+    leadingBond: stats.leadingBond.toString(),
+    answerCount,
+  };
+}
+
+export function computeListStakeSummary(params: {
+  bounty: string | bigint;
+  leadingBond: string | bigint;
+  answers: AnswerBondInput[];
+}): ListStakeSummary {
+  const bounty = toBigInt(params.bounty);
+  const leadingBond = toBigInt(params.leadingBond);
+  let totalBonded = 0n;
+  for (const entry of params.answers) {
+    totalBonded += toBigInt(entry.bond);
+  }
+  return {
+    totalBonded: totalBonded.toString(),
+    totalPrizePool: (bounty + totalBonded).toString(),
+    leadingBond: leadingBond.toString(),
+    answerCount: params.answers.length,
+  };
+}
+
+export function formatEth(wei: bigint, decimals = 4): string {
+  return Number(formatEther(wei)).toFixed(decimals);
+}
+
+export function resolveSelectedAnswerHex(
+  selectedAnswer: string,
+  questionType: ParsedPredictionDisplay["type"],
+  outcomes?: string[]
+): `0x${string}` | null {
+  if (questionType === "bool") {
+    return selectedAnswer === "true"
+      ? "0x0000000000000000000000000000000000000000000000000000000000000001"
+      : "0x0000000000000000000000000000000000000000000000000000000000000000";
+  }
+  if (questionType === "single-select" && outcomes) {
+    const idx = parseInt(selectedAnswer, 10);
+    if (Number.isNaN(idx) || idx < 0 || idx >= outcomes.length) return null;
+    return keccak256(stringToHex(outcomes[idx])) as `0x${string}`;
+  }
+  return null;
+}
+
+export function estimateEarningsIfWin(params: {
+  stats: StakeStats;
+  selectedAnswerHex: string;
+  userBond: bigint;
+}): bigint | null {
+  if (params.userBond <= 0n) return null;
+
+  const selectedHex = normalizeAnswerHex(params.selectedAnswerHex);
+  const outcome = params.stats.perOutcome.find(
+    (o) => normalizeAnswerHex(o.answerHex) === selectedHex
+  );
+  const outcomeBond = outcome?.totalBond ?? 0n;
+  const totalOutcomeBondAfter = outcomeBond + params.userBond;
+  const otherBonds = params.stats.totalBonded - outcomeBond;
+  const distributable = otherBonds + params.stats.bounty;
+
+  const share =
+    totalOutcomeBondAfter > 0n
+      ? (params.userBond * distributable) / totalOutcomeBondAfter
+      : 0n;
+
+  return params.userBond + share;
+}
+
+/** Minimum bond to participate: max(min_bond, leadingBond + 1 wei when leading exists). */
+export function minBondRequired(minBond: bigint, leadingBond: bigint): bigint {
+  const beatLeading = leadingBond > 0n ? leadingBond + 1n : 0n;
+  return minBond > beatLeading ? minBond : beatLeading;
+}


### PR DESCRIPTION
## Summary
- Add `stake-stats` helpers to compute prize pool (bounty + bonded answers), per-outcome stakes, and approximate winnings
- Add batch `GET /api/predictions/stake-stats` for list cards with 60s edge cache
- Surface pool totals on prediction detail/list views and earnings context in BetForm

## Test plan
- [ ] Open `/predict/[id]` with bonded answers — verify prize pool equals bounty + sum of answer bonds
- [ ] Confirm per-outcome ETH totals on outcome badges match recent answers timeline
- [ ] Open `/predict` — list cards show **Pool: X ETH**; pagination loads stats for visible page only
- [ ] In BetForm, select outcome + bond — prize pool and approximate earnings update; min bond error when too low
- [ ] Market with bounty=0 and no answers — pool UI hidden or falls back to bounty-only list display
- [ ] Resolved market — pool still visible; BetForm remains hidden (existing behavior)


Made with [Cursor](https://cursor.com)