### PR TITLE
Fix Songchain feed repost duplicates and double media players

### DIFF
--- a/components/songchain/SongchainAuthorTimeline.tsx
+++ b/components/songchain/SongchainAuthorTimeline.tsx
@@ -14,7 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { SongchainPostCard } from "@/components/songchain/SongchainPostCard";
-import { isRootFeedPost } from "@/lib/songchain/post-utils";
+import { normalizeFeedPosts } from "@/lib/songchain/post-utils";
 
 type SongchainAuthorTimelineProps = {
   authorAddress: string;
@@ -44,7 +44,7 @@ export function SongchainAuthorTimeline({
         },
       });
       if (result.isErr()) throw new Error(result.error.message);
-      setPosts(result.value.items.filter(isRootFeedPost));
+      setPosts(normalizeFeedPosts(result.value.items));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load timeline");
       setPosts([]);

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -43,8 +43,11 @@ import { SongchainFollowButton } from "@/components/songchain/SongchainGraphPane
 import { SongchainPostMedia } from "@/components/songchain/SongchainPostMedia";
 import {
   extractPostMedia,
+  getEmbeddedCreativeTVUrls,
+  hasAttachedVideoOrLivestream,
   postText,
   resolvePostContent,
+  stripAttachedMediaBoilerplate,
 } from "@/lib/songchain/post-utils";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils/utils";
@@ -94,6 +97,16 @@ export function SongchainPostCard({
   const [upvoted, setUpvoted] = useState(hasReacted);
   const reactions =
     content != null && "stats" in content ? (content.stats?.upvotes ?? 0) : 0;
+  const reposts =
+    content != null && "stats" in content ? (content.stats?.reposts ?? 0) : 0;
+  const embeddedCreativeTVUrls = useMemo(
+    () => getEmbeddedCreativeTVUrls(media),
+    [media],
+  );
+  const skipAllInternalPreviews = useMemo(
+    () => hasAttachedVideoOrLivestream(media),
+    [media],
+  );
   const isOwner =
     !!lensAccount &&
     !!content &&
@@ -139,7 +152,10 @@ export function SongchainPostCard({
     setDisplayText(null);
   }, [content?.id, post]);
 
-  const resolvedPostText = displayText ?? postText(post);
+  const resolvedPostText = stripAttachedMediaBoilerplate(
+    displayText ?? postText(post),
+    media,
+  );
 
   if (!content) return null;
 
@@ -309,7 +325,12 @@ export function SongchainPostCard({
             <SongchainPostMedia media={media} compact />
           )}
           {resolvedPostText && (
-            <SongchainPostContent text={resolvedPostText} compact={compact} />
+            <SongchainPostContent
+              text={resolvedPostText}
+              compact={compact}
+              embeddedCreativeTVUrls={embeddedCreativeTVUrls}
+              skipAllInternalPreviews={skipAllInternalPreviews}
+            />
           )}
           <div className="mt-auto flex flex-wrap items-center gap-1 pt-2 border-t border-border/40">
             <span className="text-xs text-muted-foreground mr-auto">
@@ -349,12 +370,16 @@ export function SongchainPostCard({
               size="sm"
               disabled={pending === "repost"}
               onClick={handleRepost}
-              aria-label="Repost"
+              aria-label={`Repost${reposts > 0 ? ` (${reposts})` : ""}`}
+              className="gap-1"
             >
               {pending === "repost" ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Repeat2 className="h-4 w-4" />
+              )}
+              {reposts > 0 && (
+                <span className="text-[10px] tabular-nums">{reposts}</span>
               )}
             </Button>
             <Button

--- a/components/songchain/SongchainPostContent.tsx
+++ b/components/songchain/SongchainPostContent.tsx
@@ -6,18 +6,23 @@ import { ExternalLink } from "lucide-react";
 import { linkifyPostText } from "@/lib/utils/linkify-post-text";
 import { CreativeTVLinkPreview } from "@/components/songchain/CreativeTVLinkPreview";
 import { ExternalLinkPreview } from "@/components/songchain/ExternalLinkPreview";
+import { shouldSkipLinkPreview } from "@/lib/songchain/post-utils";
 import { cn } from "@/lib/utils/utils";
 
 type SongchainPostContentProps = {
   text: string;
   compact?: boolean;
   className?: string;
+  embeddedCreativeTVUrls?: Set<string>;
+  skipAllInternalPreviews?: boolean;
 };
 
 export function SongchainPostContent({
   text,
   compact = false,
   className,
+  embeddedCreativeTVUrls,
+  skipAllInternalPreviews = false,
 }: SongchainPostContentProps) {
   const segments = useMemo(() => linkifyPostText(text), [text]);
 
@@ -27,6 +32,19 @@ export function SongchainPostContent({
       .map((segment) => segment.value);
     return Array.from(new Set(urls));
   }, [segments]);
+
+  const internalUrlsForPreview = useMemo(() => {
+    if (compact) return [];
+    const embedded = embeddedCreativeTVUrls ?? new Set<string>();
+    return uniqueInternalUrls.filter(
+      (url) => !shouldSkipLinkPreview(url, embedded, skipAllInternalPreviews),
+    );
+  }, [
+    compact,
+    uniqueInternalUrls,
+    embeddedCreativeTVUrls,
+    skipAllInternalPreviews,
+  ]);
 
   const uniqueExternalUrls = useMemo(() => {
     const urls = segments
@@ -77,10 +95,9 @@ export function SongchainPostContent({
         })}
       </p>
 
-      {!compact &&
-        uniqueInternalUrls.map((url) => (
-          <CreativeTVLinkPreview key={`preview-internal-${url}`} url={url} />
-        ))}
+      {internalUrlsForPreview.map((url) => (
+        <CreativeTVLinkPreview key={`preview-internal-${url}`} url={url} />
+      ))}
 
       {!compact &&
         uniqueExternalUrls.map((url) => (

--- a/hooks/useSongchainFeed.ts
+++ b/hooks/useSongchainFeed.ts
@@ -13,7 +13,7 @@ import {
   getLensContractAddressError,
 } from '@/lib/sdk/lens/primitive-id';
 import { checkLensFeedExists } from '@/lib/songchain/lens-feed';
-import { isRootFeedPost } from '@/lib/songchain/post-utils';
+import { normalizeFeedPosts } from '@/lib/songchain/post-utils';
 import { waitForPostIndexed } from '@/lib/songchain/wait-for-post-index';
 import type { PendingFeedPost, SongchainCreatedPost } from '@/lib/songchain/feed-types';
 
@@ -21,16 +21,6 @@ type UseSongchainFeedOptions = {
   feedId: string | null;
   enabled?: boolean;
 };
-
-function filterRootPosts(items: AnyPost[]): AnyPost[] {
-  const seen = new Set<string>();
-  return items.filter((item) => {
-    if (!isRootFeedPost(item)) return false;
-    if (seen.has(item.id)) return false;
-    seen.add(item.id);
-    return true;
-  });
-}
 
 export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOptions) {
   const [posts, setPosts] = useState<AnyPost[]>([]);
@@ -98,8 +88,8 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
         setPosts((prev) => {
           const combined =
             mode === 'append'
-              ? filterRootPosts([...prev, ...page.items])
-              : filterRootPosts([...page.items]);
+              ? normalizeFeedPosts([...prev, ...page.items])
+              : normalizeFeedPosts([...page.items]);
           return combined;
         });
       } catch (err) {
@@ -162,7 +152,7 @@ export function useSongchainFeed({ feedId, enabled = true }: UseSongchainFeedOpt
           if (controller.signal.aborted) return;
 
           if (indexed) {
-            setPosts((prev) => filterRootPosts([indexed, ...prev]));
+            setPosts((prev) => normalizeFeedPosts([indexed, ...prev]));
             setPendingPosts((prev) => prev.filter((p) => p.postId !== created.postId));
           } else {
             setPendingPosts((prev) =>

--- a/lib/songchain/post-utils.test.ts
+++ b/lib/songchain/post-utils.test.ts
@@ -36,12 +36,25 @@ describe('normalizeFeedPosts', () => {
     expect(result[0].id).toBe('post-1');
   });
 
+  it('includes reposted content when original is not on the page', () => {
+    const original = mockPost('post-1', 'Post', {
+      metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
+    });
+    const repost = mockPost('repost-1', 'Repost', {
+      repostOf: original,
+    });
+
+    const result = normalizeFeedPosts([repost]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('post-1');
+  });
+
   it('dedupes by underlying content id', () => {
     const original = mockPost('post-1', 'Post', {
       metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
     });
-    const duplicate = mockPost('post-1-dup', 'Post', {
-      metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
+    const duplicate = mockPost('repost-1', 'Repost', {
+      repostOf: original,
     });
 
     const result = normalizeFeedPosts([original, duplicate]);

--- a/lib/songchain/post-utils.test.ts
+++ b/lib/songchain/post-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { AnyPost } from '@lens-protocol/graphql';
+import {
+  getEmbeddedCreativeTVUrls,
+  hasAttachedVideoOrLivestream,
+  normalizeFeedPosts,
+  shouldSkipLinkPreview,
+  stripAttachedMediaBoilerplate,
+  type PostMediaItem,
+} from './post-utils';
+
+function mockPost(
+  id: string,
+  typename: string,
+  extra: Record<string, unknown> = {},
+): AnyPost {
+  return {
+    id,
+    __typename: typename,
+    author: { address: '0xabc' },
+    ...extra,
+  } as unknown as AnyPost;
+}
+
+describe('normalizeFeedPosts', () => {
+  it('excludes repost wrappers', () => {
+    const original = mockPost('post-1', 'Post', {
+      metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
+    });
+    const repost = mockPost('repost-1', 'Repost', {
+      repostOf: original,
+    });
+
+    const result = normalizeFeedPosts([repost, original]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('post-1');
+  });
+
+  it('dedupes by underlying content id', () => {
+    const original = mockPost('post-1', 'Post', {
+      metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
+    });
+    const duplicate = mockPost('post-1-dup', 'Post', {
+      metadata: { content: 'hello', __typename: 'TextOnlyMetadata' },
+    });
+
+    const result = normalizeFeedPosts([original, duplicate]);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('media link preview dedup', () => {
+  const liveMedia: PostMediaItem[] = [
+    {
+      type: 'livestream',
+      url: 'https://tv.creativeplatform.xyz/watch/abc123',
+    },
+  ];
+
+  it('skips all internal previews when video or livestream attached', () => {
+    expect(hasAttachedVideoOrLivestream(liveMedia)).toBe(true);
+    expect(
+      shouldSkipLinkPreview(
+        'https://tv.creativeplatform.xyz/discover/uuid',
+        new Set(),
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('extracts embedded watch urls from media', () => {
+    const urls = getEmbeddedCreativeTVUrls(liveMedia);
+    expect(urls.has('https://tv.creativeplatform.xyz/watch/abc123')).toBe(true);
+    expect(urls.has('/watch/abc123')).toBe(true);
+  });
+
+  it('strips boilerplate when media is attached', () => {
+    const text =
+      'My caption\n\nWatch on Creative TV: https://tv.creativeplatform.xyz/discover/uuid';
+    const videoMedia: PostMediaItem[] = [
+      { type: 'video', url: 'https://example.com/video.mp4' },
+    ];
+    expect(stripAttachedMediaBoilerplate(text, videoMedia)).toBe('My caption');
+  });
+});

--- a/lib/songchain/post-utils.ts
+++ b/lib/songchain/post-utils.ts
@@ -1,5 +1,6 @@
 import type { AnyPost } from '@lens-protocol/graphql';
 import { resolveOrbMediaUrl } from '@/lib/sdk/orb/media';
+import { parseCreativeTVUrl } from '@/lib/utils/creative-tv-url';
 
 export function resolvePostContent(post: AnyPost): AnyPost | null {
   if (post.__typename === 'Repost') {
@@ -18,6 +19,25 @@ export function isRootFeedPost(post: AnyPost): boolean {
   if (contentTypename === 'Comment') return false;
   if ('commentOn' in content && content.commentOn) return false;
   return true;
+}
+
+/** Feed list: exclude repost wrappers and dedupe by underlying post content id. */
+export function normalizeFeedPosts(items: AnyPost[]): AnyPost[] {
+  const seenContentIds = new Set<string>();
+  const result: AnyPost[] = [];
+
+  for (const item of items) {
+    if ((item.__typename as string) === 'Repost') continue;
+    if (!isRootFeedPost(item)) continue;
+
+    const content = resolvePostContent(item);
+    const contentId = content?.id ?? item.id;
+    if (seenContentIds.has(contentId)) continue;
+    seenContentIds.add(contentId);
+    result.push(item);
+  }
+
+  return result;
 }
 
 export type PostMediaType = 'image' | 'video' | 'audio' | 'livestream';
@@ -170,6 +190,83 @@ export function extractPostMedia(post: AnyPost): PostMediaItem[] {
   }
 
   return items;
+}
+
+function addCreativeTvUrlVariants(rawUrl: string, out: Set<string>) {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return;
+  out.add(trimmed);
+
+  try {
+    const parsed = parseCreativeTVUrl(trimmed);
+    if (parsed.kind === 'watch') {
+      out.add(parsed.fallbackUrl);
+      out.add(`/watch/${parsed.playbackId}`);
+    } else if (parsed.kind === 'discover') {
+      out.add(parsed.fallbackUrl);
+      out.add(`/discover/${parsed.assetId}`);
+    }
+  } catch {
+    const watchMatch = trimmed.match(/\/watch\/([^/?#]+)/i);
+    if (watchMatch?.[1]) {
+      out.add(`/watch/${watchMatch[1]}`);
+    }
+    const discoverMatch = trimmed.match(/\/discover\/([^/?#]+)/i);
+    if (discoverMatch?.[1]) {
+      out.add(`/discover/${discoverMatch[1]}`);
+    }
+  }
+}
+
+/** Creative TV URLs already represented by attached media (skip duplicate link previews). */
+export function getEmbeddedCreativeTVUrls(media: PostMediaItem[]): Set<string> {
+  const urls = new Set<string>();
+  for (const item of media) {
+    if (item.url) addCreativeTvUrlVariants(item.url, urls);
+  }
+  return urls;
+}
+
+export function hasAttachedVideoOrLivestream(media: PostMediaItem[]): boolean {
+  return media.some((item) => item.type === 'video' || item.type === 'livestream');
+}
+
+export function stripAttachedMediaBoilerplate(
+  text: string,
+  media: PostMediaItem[],
+): string {
+  if (!hasAttachedVideoOrLivestream(media)) return text;
+
+  return text
+    .replace(/\n\nWatch on Creative TV:\s*https?:\/\/[^\s]+/gi, '')
+    .replace(/\n\nhttps?:\/\/[^\s/]+(?:\/[^\s]*)?\/watch\/[^\s]+/gi, '')
+    .replace(/\n\nI'm live on Creative TV —\s*https?:\/\/[^\s]+/gi, '')
+    .trim();
+}
+
+export function shouldSkipLinkPreview(
+  url: string,
+  embeddedUrls: Set<string>,
+  skipAllInternal: boolean,
+): boolean {
+  if (skipAllInternal) return true;
+  if (embeddedUrls.has(url)) return true;
+
+  try {
+    const parsed = parseCreativeTVUrl(url);
+    if (parsed.kind === 'watch' || parsed.kind === 'discover') {
+      if (embeddedUrls.has(parsed.fallbackUrl)) return true;
+      const path =
+        parsed.kind === 'watch'
+          ? `/watch/${parsed.playbackId}`
+          : `/discover/${parsed.assetId}`;
+      if (embeddedUrls.has(path)) return true;
+    }
+  } catch {
+    // not a creative TV url
+  }
+
+  return false;
 }
 
 export function extractCreatedPostId(value: unknown): string | null {

--- a/lib/songchain/post-utils.ts
+++ b/lib/songchain/post-utils.ts
@@ -21,20 +21,21 @@ export function isRootFeedPost(post: AnyPost): boolean {
   return true;
 }
 
-/** Feed list: exclude repost wrappers and dedupe by underlying post content id. */
+/** Feed list: collapse repost wrappers to underlying content and dedupe by content id. */
 export function normalizeFeedPosts(items: AnyPost[]): AnyPost[] {
   const seenContentIds = new Set<string>();
   const result: AnyPost[] = [];
 
   for (const item of items) {
-    if ((item.__typename as string) === 'Repost') continue;
     if (!isRootFeedPost(item)) continue;
 
     const content = resolvePostContent(item);
-    const contentId = content?.id ?? item.id;
+    if (!content) continue;
+
+    const contentId = content.id;
     if (seenContentIds.has(contentId)) continue;
     seenContentIds.add(contentId);
-    result.push(item);
+    result.push(content);
   }
 
   return result;
@@ -197,16 +198,14 @@ function addCreativeTvUrlVariants(rawUrl: string, out: Set<string>) {
   if (!trimmed) return;
   out.add(trimmed);
 
-  try {
-    const parsed = parseCreativeTVUrl(trimmed);
-    if (parsed.kind === 'watch') {
-      out.add(parsed.fallbackUrl);
-      out.add(`/watch/${parsed.playbackId}`);
-    } else if (parsed.kind === 'discover') {
-      out.add(parsed.fallbackUrl);
-      out.add(`/discover/${parsed.assetId}`);
-    }
-  } catch {
+  const parsed = parseCreativeTVUrl(trimmed);
+  if (parsed.kind === 'watch') {
+    out.add(parsed.fallbackUrl);
+    out.add(`/watch/${parsed.playbackId}`);
+  } else if (parsed.kind === 'discover') {
+    out.add(parsed.fallbackUrl);
+    out.add(`/discover/${parsed.assetId}`);
+  } else {
     const watchMatch = trimmed.match(/\/watch\/([^/?#]+)/i);
     if (watchMatch?.[1]) {
       out.add(`/watch/${watchMatch[1]}`);
@@ -238,9 +237,9 @@ export function stripAttachedMediaBoilerplate(
   if (!hasAttachedVideoOrLivestream(media)) return text;
 
   return text
-    .replace(/\n\nWatch on Creative TV:\s*https?:\/\/[^\s]+/gi, '')
-    .replace(/\n\nhttps?:\/\/[^\s/]+(?:\/[^\s]*)?\/watch\/[^\s]+/gi, '')
-    .replace(/\n\nI'm live on Creative TV —\s*https?:\/\/[^\s]+/gi, '')
+    .replace(/\s*Watch on Creative TV:\s*https?:\/\/[^\s]+/gi, '')
+    .replace(/\s*https?:\/\/[^\s/]+(?:\/[^\s]*)?\/watch\/[^\s]+/gi, '')
+    .replace(/\s*I'm live on Creative TV —\s*https?:\/\/[^\s]+/gi, '')
     .trim();
 }
 
@@ -252,18 +251,14 @@ export function shouldSkipLinkPreview(
   if (skipAllInternal) return true;
   if (embeddedUrls.has(url)) return true;
 
-  try {
-    const parsed = parseCreativeTVUrl(url);
-    if (parsed.kind === 'watch' || parsed.kind === 'discover') {
-      if (embeddedUrls.has(parsed.fallbackUrl)) return true;
-      const path =
-        parsed.kind === 'watch'
-          ? `/watch/${parsed.playbackId}`
-          : `/discover/${parsed.assetId}`;
-      if (embeddedUrls.has(path)) return true;
-    }
-  } catch {
-    // not a creative TV url
+  const parsed = parseCreativeTVUrl(url);
+  if (parsed.kind === 'watch' || parsed.kind === 'discover') {
+    if (embeddedUrls.has(parsed.fallbackUrl)) return true;
+    const path =
+      parsed.kind === 'watch'
+        ? `/watch/${parsed.playbackId}`
+        : `/discover/${parsed.assetId}`;
+    if (embeddedUrls.has(path)) return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Collapse Lens reposts into a count on the original post instead of rendering duplicate cards with a different author
- Suppress duplicate Creative TV link previews when video or livestream media is already attached to the post
- Strip boilerplate “Watch on Creative TV” text from posts with attached media

## Test plan
- [ ] User A posts → User B reposts → feed shows one card (A’s post) with repost count on the original
- [ ] User B comments → comment stays inline under A’s card only
- [ ] Video post shows one media player (top); no second Livepeer player at bottom; link in text remains clickable
- [ ] Livestream post shows one livestream block; no duplicate watch player below
- [ ] Text-only post with pasted Creative TV URL still shows link preview
- [ ] Author timeline dialog has no repost duplicates


Made with [Cursor](https://cursor.com)