### PR TITLE
Fix build: readonly AnyPost[] in normalizeFeedPosts

### DIFF
--- a/lib/songchain/post-utils.ts
+++ b/lib/songchain/post-utils.ts
@@ -22,7 +22,7 @@ export function isRootFeedPost(post: AnyPost): boolean {
 }
 
 /** Feed list: collapse repost wrappers to underlying content and dedupe by content id. */
-export function normalizeFeedPosts(items: AnyPost[]): AnyPost[] {
+export function normalizeFeedPosts(items: readonly AnyPost[]): AnyPost[] {
   const seenContentIds = new Set<string>();
   const result: AnyPost[] = [];
 


### PR DESCRIPTION
## Summary
- Fixes Vercel build failure after #176 merge: `SongchainAuthorTimeline` passes `readonly AnyPost[]` from Lens SDK into `normalizeFeedPosts`.

## Test plan
- [x] TypeScript accepts `result.value.items` in `SongchainAuthorTimeline.tsx`
- [ ] Vercel preview build passes


Made with [Cursor](https://cursor.com)