### PR TITLE
Harden MeToken live gate auth follow-ups

### DIFF
--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -4,9 +4,14 @@ import { checkBotId } from "botid/server";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { getStreamByPlaybackId } from "@/services/streams";
 import {
+  requireWalletAuth,
+  WalletAuthError,
+} from "@/lib/auth/require-wallet";
+import {
   checkMeTokenAccess,
   isMeTokenGateActive,
 } from "@/lib/utils/metoken-access";
+import { resolveVerifiedViewerAddresses } from "@/lib/utils/linked-identity";
 
 export async function POST(req: NextRequest) {
   const verification = await checkBotId();
@@ -29,7 +34,7 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const { playbackId, userAddress, smartAccountAddress } = body;
+    const { playbackId, companionAddress } = body;
 
     if (!playbackId) {
       return NextResponse.json(
@@ -41,53 +46,91 @@ export async function POST(req: NextRequest) {
     const stream = await getStreamByPlaybackId(playbackId);
 
     if (
-      stream &&
-      isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
+      !stream ||
+      !isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
     ) {
-      if (!stream.creator_id) {
-        return NextResponse.json(
-          { message: "Stream creator not found" },
-          { status: 400 }
-        );
-      }
-
-      if (!userAddress && !smartAccountAddress) {
-        return NextResponse.json(
-          {
-            code: "METOKEN_REQUIRED",
-            connectWallet: true,
-            creatorAddress: stream.creator_id,
-            required: String(stream.metoken_price),
-            message: "Connect your wallet to verify MeToken balance",
-          },
-          { status: 403 }
-        );
-      }
-
-      const access = await checkMeTokenAccess({
-        viewerAddresses: [userAddress, smartAccountAddress],
-        creatorAddress: stream.creator_id,
-        requiredAmount: stream.metoken_price!,
+      const token = await signAccessJwt({
+        privateKey: accessControlPrivateKey,
+        publicKey: accessControlPublicKey,
+        issuer: "https://crtv3.app",
+        playbackId,
+        expiration: 3600,
+        custom: {
+          userId: "anonymous",
+        },
       });
 
-      if (!access.allowed) {
+      return NextResponse.json({ token });
+    }
+
+    const gatedStream = stream;
+    const requiredAmount = gatedStream.metoken_price ?? 0;
+
+    if (!gatedStream.creator_id) {
+      return NextResponse.json(
+        { message: "Stream creator not found" },
+        { status: 400 }
+      );
+    }
+
+    let verifiedViewerAddress: string;
+
+    try {
+      const verified = await requireWalletAuth(req);
+      verifiedViewerAddress = verified.address;
+    } catch (err) {
+      if (err instanceof WalletAuthError) {
+        const missingHeaders = err.message.includes("Missing wallet auth headers");
+        const signingRejected =
+          !missingHeaders &&
+          (err.message.includes("Invalid wallet signature") ||
+            err.message.includes("too old"));
+
         return NextResponse.json(
           {
             code: "METOKEN_REQUIRED",
-            connectWallet: access.reason === "no_viewer_address",
-            meTokenAddress: access.meTokenAddress,
-            symbol: access.symbol,
-            required: access.requiredFormatted,
-            balance: access.balanceFormatted,
-            creatorAddress: stream.creator_id,
-            message:
-              access.reason === "no_viewer_address"
-                ? "Connect your wallet to verify MeToken balance"
-                : "Insufficient MeToken balance to watch this stream",
+            connectWallet: missingHeaders,
+            signingRequired: signingRejected,
+            creatorAddress: gatedStream.creator_id,
+            required: String(requiredAmount),
+            message: missingHeaders
+              ? "Connect your wallet to verify MeToken balance"
+              : err.message,
           },
           { status: 403 }
         );
       }
+      throw err;
+    }
+
+    const viewerAddresses = await resolveVerifiedViewerAddresses(
+      verifiedViewerAddress,
+      companionAddress,
+    );
+
+    const access = await checkMeTokenAccess({
+      viewerAddresses,
+      creatorAddress: gatedStream.creator_id,
+      requiredAmount,
+    });
+
+    if (!access.allowed) {
+      return NextResponse.json(
+        {
+          code: "METOKEN_REQUIRED",
+          connectWallet: access.reason === "no_viewer_address",
+          meTokenAddress: access.meTokenAddress,
+          symbol: access.symbol,
+          required: access.requiredFormatted,
+          balance: access.balanceFormatted,
+          creatorAddress: gatedStream.creator_id,
+          message:
+            access.reason === "no_viewer_address"
+              ? "Connect your wallet to verify MeToken balance"
+              : "Insufficient MeToken balance to watch this stream",
+        },
+        { status: 403 }
+      );
     }
 
     const token = await signAccessJwt({
@@ -97,7 +140,7 @@ export async function POST(req: NextRequest) {
       playbackId,
       expiration: 3600,
       custom: {
-        userId: userAddress || smartAccountAddress || "anonymous",
+        userId: verifiedViewerAddress,
       },
     });
 

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -31,6 +31,9 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Slash } from "lucide-react";
 import { logger } from '@/lib/utils/logger';
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { formatWalletAuthError } from "@/lib/auth/format-wallet-auth-error";
+import { isMeTokenGateActive } from "@/lib/utils/metoken-access";
 
 
 import { MeTokenShareButton } from "@/components/Market/MeTokenShareButton";
@@ -81,6 +84,7 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
 
   const user = useUser();
   const { address: smartAccountAddress } = useModularAccount();
+  const { getAuthHeaders, address: authAddress } = useWalletAuth();
   const [status, setStatus] = useState<StreamStatus>({ kind: "loading" });
   const [streamData, setStreamData] = useState<import("@/services/streams").Stream | null>(null);
   const [jwt, setJwt] = useState<string | undefined>(undefined);
@@ -91,6 +95,27 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
   const gatePrefetchRef = useRef(gatePrefetch);
   gatePrefetchRef.current = gatePrefetch;
 
+  const isGateLikelyActive = useCallback(() => {
+    const stream = streamDataRef.current;
+    if (
+      stream &&
+      isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
+    ) {
+      return true;
+    }
+    return Boolean(gatePrefetchRef.current?.code === "METOKEN_REQUIRED");
+  }, []);
+
+  const buildCompanionAddress = useCallback((): string | undefined => {
+    if (!authAddress) return undefined;
+    const verified = authAddress.toLowerCase();
+    const eoa = user?.address?.toLowerCase();
+    const sca = smartAccountAddress?.toLowerCase();
+    if (eoa && eoa !== verified) return eoa;
+    if (sca && sca !== verified) return sca;
+    return undefined;
+  }, [authAddress, user?.address, smartAccountAddress]);
+
   const requestStreamJwt = useCallback(async (): Promise<{
     ok: boolean;
     token?: string;
@@ -100,14 +125,66 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
       return { ok: false };
     }
 
+    const gateActive = isGateLikelyActive();
+    const streamName =
+      streamDataRef.current?.name ?? gatePrefetchRef.current?.streamName ?? null;
+    const gateBase: LiveStreamGateInfo = {
+      code: "METOKEN_REQUIRED",
+      streamName,
+      creatorAddress:
+        streamDataRef.current?.creator_id ??
+        gatePrefetchRef.current?.creatorAddress,
+      symbol: gatePrefetchRef.current?.symbol,
+      required:
+        streamDataRef.current?.metoken_price != null
+          ? String(streamDataRef.current.metoken_price)
+          : gatePrefetchRef.current?.required,
+    };
+
+    if (gateActive && !user?.address && !smartAccountAddress) {
+      return {
+        ok: false,
+        gate: {
+          ...gateBase,
+          connectWallet: true,
+          message: "Connect your wallet to verify MeToken balance",
+        },
+      };
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const body: { playbackId: string; companionAddress?: string } = {
+      playbackId,
+    };
+
+    if (gateActive && (user?.address || smartAccountAddress)) {
+      try {
+        Object.assign(headers, await getAuthHeaders());
+        const companion = buildCompanionAddress();
+        if (companion) {
+          body.companionAddress = companion;
+        }
+      } catch (authErr) {
+        logger.warn("Wallet auth unavailable for stream JWT:", authErr);
+        const walletConnected = Boolean(user?.address || smartAccountAddress);
+        return {
+          ok: false,
+          gate: {
+            ...gateBase,
+            connectWallet: !walletConnected,
+            signingRequired: walletConnected,
+            message: formatWalletAuthError(authErr),
+          },
+        };
+      }
+    }
+
     const jwtRes = await fetch("/api/livepeer/sign-jwt", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        playbackId,
-        userAddress: user?.address,
-        smartAccountAddress,
-      }),
+      headers,
+      body: JSON.stringify(body),
     });
 
     if (jwtRes.ok) {
@@ -122,20 +199,29 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         gate: {
           code: errData.code,
           connectWallet: errData.connectWallet,
+          signingRequired: errData.signingRequired,
+          message: errData.message,
           meTokenAddress: errData.meTokenAddress,
           symbol: errData.symbol,
           required: errData.required,
           balance: errData.balance,
           creatorAddress: errData.creatorAddress,
-          streamName:
-            streamDataRef.current?.name ?? gatePrefetchRef.current?.streamName ?? null,
+          streamName,
         },
       };
     }
 
     logger.warn("Failed to sign JWT for stream:", errData);
     return { ok: false };
-  }, [playbackId, user?.address, smartAccountAddress]);
+  }, [
+    playbackId,
+    user?.address,
+    smartAccountAddress,
+    authAddress,
+    getAuthHeaders,
+    isGateLikelyActive,
+    buildCompanionAddress,
+  ]);
 
   const fetchPlaybackSources = useCallback(async (isInitial = false) => {
     if (!playbackId) {

--- a/components/Live/LiveStreamMeTokenGate.tsx
+++ b/components/Live/LiveStreamMeTokenGate.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Lock, Wallet } from "lucide-react";
+import { Lock, PenLine, Wallet } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuthModal } from "@account-kit/react";
 import { VideoMeTokenBuyDialog } from "@/components/Videos/VideoMeTokenBuyDialog";
@@ -9,6 +9,8 @@ import { VideoMeTokenBuyDialog } from "@/components/Videos/VideoMeTokenBuyDialog
 export interface LiveStreamGateInfo {
   code?: string;
   connectWallet?: boolean;
+  signingRequired?: boolean;
+  message?: string;
   meTokenAddress?: string;
   symbol?: string;
   required?: string;
@@ -39,6 +41,7 @@ export function LiveStreamMeTokenGate({
   const required = gate.required ?? "0";
   const balance = gate.balance ?? "0";
   const needsWallet = Boolean(gate.connectWallet);
+  const needsSignature = Boolean(gate.signingRequired);
 
   return (
     <>
@@ -57,7 +60,10 @@ export function LiveStreamMeTokenGate({
             Hold at least <span className="font-semibold text-white">{required} {symbol}</span> to
             watch this live stream.
           </p>
-          {!needsWallet && (
+          {gate.message && (
+            <p className="text-xs text-amber-200/90">{gate.message}</p>
+          )}
+          {!needsWallet && !needsSignature && (
             <p className="text-xs text-gray-400">
               Your balance: {balance} {symbol}
             </p>
@@ -67,6 +73,11 @@ export function LiveStreamMeTokenGate({
               <Button onClick={() => openAuthModal()}>
                 <Wallet className="h-4 w-4 mr-2" />
                 Connect Wallet
+              </Button>
+            ) : needsSignature ? (
+              <Button onClick={() => onAccessGranted?.()}>
+                <PenLine className="h-4 w-4 mr-2" />
+                Approve Signature
               </Button>
             ) : (
               <Button onClick={() => setBuyDialogOpen(true)}>

--- a/lib/auth/format-wallet-auth-error.test.ts
+++ b/lib/auth/format-wallet-auth-error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatWalletAuthError,
+  isWalletSigningRejected,
+} from './format-wallet-auth-error';
+
+describe('formatWalletAuthError', () => {
+  it('detects user rejection', () => {
+    const err = new Error('User rejected the request');
+    expect(isWalletSigningRejected(err)).toBe(true);
+    expect(formatWalletAuthError(err)).toContain('cancelled');
+  });
+
+  it('maps missing wallet to connect copy', () => {
+    expect(formatWalletAuthError(new Error('Wallet not connected'))).toContain(
+      'Connect your wallet',
+    );
+  });
+});

--- a/lib/auth/format-wallet-auth-error.ts
+++ b/lib/auth/format-wallet-auth-error.ts
@@ -1,0 +1,46 @@
+function baseMessage(error: unknown, fallback: string): string {
+  return (
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : fallback
+  ).trim();
+}
+
+/** True when the user dismissed the wallet signature prompt. */
+export function isWalletSigningRejected(error: unknown): boolean {
+  const lower = baseMessage(error, '').toLowerCase();
+  return (
+    lower.includes('user rejected') ||
+    lower.includes('user denied') ||
+    lower.includes('rejected the request') ||
+    lower.includes('denied transaction') ||
+    lower.includes('denied message') ||
+    lower.includes('request rejected')
+  );
+}
+
+/** User-facing copy for wallet signature / auth header failures. */
+export function formatWalletAuthError(error: unknown): string {
+  const msg = baseMessage(error, 'Wallet authorization failed');
+  const lower = msg.toLowerCase();
+
+  if (lower.includes('wallet not connected')) {
+    return 'Connect your wallet with Get Started to continue.';
+  }
+  if (isWalletSigningRejected(error)) {
+    return 'Wallet signature was cancelled. Approve the signature to verify access.';
+  }
+  if (lower.includes('auth signature is too old')) {
+    return 'Your wallet authorization expired. Approve a new signature to continue.';
+  }
+  if (lower.includes('invalid wallet signature')) {
+    return 'Wallet signature was invalid. Approve the signature again to continue.';
+  }
+  if (lower.includes('missing wallet auth')) {
+    return 'Connect your wallet with Get Started to continue.';
+  }
+
+  return msg.length > 160 ? `${msg.slice(0, 157)}…` : msg;
+}

--- a/lib/hooks/metokens/useCreatorProfile.ts
+++ b/lib/hooks/metokens/useCreatorProfile.ts
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@account-kit/react';
 import { logger } from '@/lib/utils/logger';
+import { useWalletAuth } from '@/lib/auth/useWalletAuth';
+import { formatWalletAuthError } from '@/lib/auth/format-wallet-auth-error';
 
 import { 
   creatorProfileSupabaseService, 
@@ -24,12 +26,14 @@ export interface UseCreatorProfileResult {
 
 export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResult {
   const user = useUser();
+  const { getAuthHeaders, address: authAddress } = useWalletAuth();
   const [profile, setProfile] = useState<CreatorProfile | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Use targetAddress if provided, otherwise use user's address
+  // Reads use the requested owner; mutations sign with the connected wallet.
   const address = targetAddress || user?.address;
+  const mutationOwnerAddress = authAddress || address;
 
   // Fetch creator profile
   const fetchProfile = useCallback(async () => {
@@ -75,9 +79,20 @@ export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResu
     }
   }, [address]);
 
+  const requireMutationAuth = useCallback(async () => {
+    if (!mutationOwnerAddress) {
+      throw new Error('No address available');
+    }
+    try {
+      return await getAuthHeaders();
+    } catch (err) {
+      throw new Error(formatWalletAuthError(err));
+    }
+  }, [mutationOwnerAddress, getAuthHeaders]);
+
   // Update creator profile
   const updateProfile = useCallback(async (data: UpdateCreatorProfileData) => {
-    if (!address) {
+    if (!mutationOwnerAddress) {
       throw new Error('No address available');
     }
 
@@ -85,7 +100,12 @@ export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResu
     setError(null);
 
     try {
-      const profileData = await creatorProfileSupabaseService.updateCreatorProfile(address, data);
+      const authHeaders = await requireMutationAuth();
+      const profileData = await creatorProfileSupabaseService.updateCreatorProfile(
+        mutationOwnerAddress,
+        data,
+        authHeaders,
+      );
       setProfile(profileData);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update creator profile');
@@ -93,11 +113,11 @@ export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResu
     } finally {
       setLoading(false);
     }
-  }, [address]);
+  }, [mutationOwnerAddress, requireMutationAuth]);
 
   // Upsert creator profile (create or update)
   const upsertProfile = useCallback(async (data: CreateCreatorProfileData) => {
-    if (!address) {
+    if (!mutationOwnerAddress) {
       throw new Error('No address available');
     }
 
@@ -105,10 +125,14 @@ export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResu
     setError(null);
 
     try {
-      const profileData = await creatorProfileSupabaseService.upsertCreatorProfile({
-        ...data,
-        owner_address: address,
-      });
+      const authHeaders = await requireMutationAuth();
+      const profileData = await creatorProfileSupabaseService.upsertCreatorProfile(
+        {
+          ...data,
+          owner_address: mutationOwnerAddress,
+        },
+        authHeaders,
+      );
       setProfile(profileData);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to upsert creator profile');
@@ -116,7 +140,7 @@ export function useCreatorProfile(targetAddress?: string): UseCreatorProfileResu
     } finally {
       setLoading(false);
     }
-  }, [address]);
+  }, [mutationOwnerAddress, requireMutationAuth]);
 
   // Delete creator profile
   const deleteProfile = useCallback(async () => {

--- a/lib/sdk/orb/format-auth-error.ts
+++ b/lib/sdk/orb/format-auth-error.ts
@@ -1,3 +1,4 @@
+import { formatWalletAuthError } from '@/lib/auth/format-wallet-auth-error';
 import {
   isIncompleteOrbSessionError,
   isRevokedOrbSessionError,
@@ -44,11 +45,16 @@ export function formatOrbAuthError(error: unknown): string {
   if (isIncompleteOrbSessionError(error)) {
     return 'Sign in again with Orb to post and interact on Lens.';
   }
-  if (lower.includes('wallet not connected') || lower.includes('sign in with your wallet')) {
-    return 'Connect your wallet with Get Started before linking your Lens identity.';
-  }
-  if (lower.includes('user rejected') || lower.includes('denied')) {
-    return 'Wallet signature was cancelled. Approve the signature to link your profile.';
+  if (
+    lower.includes('wallet not connected') ||
+    lower.includes('sign in with your wallet') ||
+    lower.includes('user rejected') ||
+    lower.includes('denied')
+  ) {
+    return formatWalletAuthError(error).replace(
+      'verify access',
+      'link your profile',
+    );
   }
   if (
     lower.includes('lens_account_id') &&
@@ -74,11 +80,16 @@ export function formatOrbLinkError(error: unknown): string {
   if (lower.includes('too many') || lower.includes('rate limit')) {
     return "Profile link is busy — we'll retry shortly.";
   }
-  if (lower.includes('wallet not connected') || lower.includes('sign in with your wallet')) {
-    return 'Connect your wallet with Get Started before linking your Lens identity.';
-  }
-  if (lower.includes('user rejected') || lower.includes('denied')) {
-    return 'Wallet signature was cancelled. Approve the signature to link your profile.';
+  if (
+    lower.includes('wallet not connected') ||
+    lower.includes('sign in with your wallet') ||
+    lower.includes('user rejected') ||
+    lower.includes('denied')
+  ) {
+    return formatWalletAuthError(error).replace(
+      'verify access',
+      'link your profile',
+    );
   }
   if (
     lower.includes('lens_account_id') &&

--- a/lib/utils/linked-identity.ts
+++ b/lib/utils/linked-identity.ts
@@ -1,99 +1,141 @@
+import { predictModularAccountV2Address } from "@account-kit/smart-contracts";
 import { Address, createPublicClient, getAddress } from "viem";
 import { alchemy, base } from "@account-kit/infra";
+import {
+  modularAccountFactoryAddresses,
+  smaBytecodeImplementationAddresses,
+} from "@/lib/utils/modularAccount";
 import { logger } from '@/lib/utils/logger';
-
 
 /**
  * Linked Identity Utilities
- * 
+ *
  * Creative TV uses a "Linked Identity" approach:
  * - Primary Display: Smart Wallet address (or ENS/Basename if available)
  * - Background: EOA address for signing operations (Snapshot, approvals, etc.)
- * 
- * This allows users to have a secure Smart Wallet as their public identity
- * while using their EOA for signing operations that require ECDSA signatures.
  */
 
+const publicClient = createPublicClient({
+  chain: base,
+  transport: alchemy({
+    apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY as string,
+  }),
+});
+
+function predictSmaAddress(ownerAddress: string): string | null {
+  const factory = modularAccountFactoryAddresses[base.id];
+  const implementation = smaBytecodeImplementationAddresses[base.id];
+  if (!factory || !implementation) return null;
+
+  try {
+    return predictModularAccountV2Address({
+      factoryAddress: factory as Address,
+      implementationAddress: implementation as Address,
+      salt: 0n,
+      type: "SMA",
+      ownerAddress: getAddress(ownerAddress),
+    }).toLowerCase();
+  } catch (error) {
+    logger.warn("Failed to predict SMA address:", error);
+    return null;
+  }
+}
+
 /**
- * Check if an EOA is a permitted signer/owner of a Smart Wallet
- * 
- * For ModularAccountV2, we check if the EOA is the owner by:
- * 1. Checking if the Smart Wallet is deployed
- * 2. Reading the owner from the account contract
- * 
- * @param eoaAddress - The EOA address to verify
- * @param smartWalletAddress - The Smart Wallet address to check against
- * @returns Promise<boolean> - True if EOA is a permitted signer
+ * Returns true when `companionAddress` is the EOA owner of `smartWalletAddress`
+ * (counterfactual or deployed SMA), verified via CREATE2 prediction — not
+ * client trust alone.
  */
 export async function isPermittedSigner(
   eoaAddress: string,
   smartWalletAddress: string
 ): Promise<boolean> {
   try {
-    // Normalize addresses
-    const normalizedEOA = getAddress(eoaAddress);
-    const normalizedSmartWallet = getAddress(smartWalletAddress);
+    const normalizedEOA = getAddress(eoaAddress).toLowerCase();
+    const normalizedSmartWallet = getAddress(smartWalletAddress).toLowerCase();
 
-    // If addresses are the same, it's an EOA account (not a smart wallet)
-    if (normalizedEOA.toLowerCase() === normalizedSmartWallet.toLowerCase()) {
+    if (normalizedEOA === normalizedSmartWallet) {
       return true;
     }
 
-    // Create public client to read from chain
-    const publicClient = createPublicClient({
-      chain: base,
-      transport: alchemy({
-        apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY as string,
-      }),
-    });
-
-    // Check if Smart Wallet is deployed
-    const code = await publicClient.getCode({
-      address: normalizedSmartWallet,
-    });
-
-    if (!code || code === "0x") {
-      // Smart Wallet not deployed, so EOA is the account
-      return normalizedEOA.toLowerCase() === normalizedSmartWallet.toLowerCase();
+    const predicted = predictSmaAddress(normalizedEOA);
+    if (predicted && predicted === normalizedSmartWallet) {
+      return true;
     }
 
-    // For ModularAccountV2, we need to check the owner
-    // The owner is stored in the account's storage
-    // We can use the factory's getAddress function or read directly from the account
-    
-    // Try to read owner from the account contract
-    // ModularAccountV2 uses a specific storage slot for the owner
-    // This is a simplified check - in production you might want to use the account's ABI
-    
-    // For now, we'll assume if the Smart Wallet is deployed and the EOA matches
-    // the user's connected EOA, it's a permitted signer
-    // In a full implementation, you'd read the owner from the account contract
-    
-    // TODO: Implement proper owner check using ModularAccountV2 ABI
-    // For now, return true if addresses are different (indicating Smart Wallet exists)
-    // This is a safe assumption for Account Kit's ModularAccountV2
-    
-    return true; // Simplified: assume EOA is permitted if Smart Wallet exists
+    // Deployed SMA stores the owner as an immutable arg; undeployed counterfactual
+    // still matches prediction above.
+    const code = await publicClient.getCode({
+      address: getAddress(normalizedSmartWallet),
+    });
+    if (!code || code === "0x") {
+      return false;
+    }
+
+    return false;
   } catch (error) {
     logger.error("Error checking permitted signer:", error);
-    // On error, assume not permitted for security
     return false;
   }
 }
 
 /**
- * Get linked identity information
- * 
- * @param smartWalletAddress - The Smart Wallet address (primary identity)
- * @param eoaAddress - The EOA address (signing identity)
- * @returns Linked identity object with display information
+ * Verifies that `companionAddress` is linked to `verifiedAddress` (EOA↔SMA pair).
+ * Used server-side after wallet auth to safely include a second balance holder.
  */
+export async function isLinkedWalletCompanion(
+  verifiedAddress: string,
+  companionAddress: string,
+): Promise<boolean> {
+  try {
+    const verified = getAddress(verifiedAddress).toLowerCase();
+    const companion = getAddress(companionAddress).toLowerCase();
+    if (verified === companion) {
+      return false;
+    }
+
+    return (
+      (await isPermittedSigner(companion, verified)) ||
+      (await isPermittedSigner(verified, companion))
+    );
+  } catch (error) {
+    logger.error("Error checking linked wallet companion:", error);
+    return false;
+  }
+}
+
+/**
+ * Build the viewer address list for MeToken gate checks: always include the
+ * cryptographically verified address, plus a linked companion when provable.
+ */
+export async function resolveVerifiedViewerAddresses(
+  verifiedAddress: string,
+  companionAddress?: string | null,
+): Promise<string[]> {
+  const viewers = [getAddress(verifiedAddress).toLowerCase()];
+
+  if (!companionAddress) {
+    return viewers;
+  }
+
+  const companion = getAddress(companionAddress).toLowerCase();
+  if (companion === viewers[0]) {
+    return viewers;
+  }
+
+  if (await isLinkedWalletCompanion(verifiedAddress, companionAddress)) {
+    viewers.push(companion);
+  }
+
+  return viewers;
+}
+
 export interface LinkedIdentity {
-  primaryAddress: string; // Smart Wallet address
-  signingAddress: string; // EOA address
-  primaryName: string | null; // ENS/Basename if available
-  displayText: string; // Formatted display text
-  isLinked: boolean; // Whether addresses are linked (different)
+  primaryAddress: string;
+  signingAddress: string;
+  primaryName: string | null;
+  displayText: string;
+  isLinked: boolean;
 }
 
 export async function getLinkedIdentity(
@@ -109,9 +151,7 @@ export async function getLinkedIdentity(
     smartWalletAddress.toLowerCase() !== eoaAddress.toLowerCase()
   );
 
-  // TODO: Add ENS/Basename resolution when CCIP issues are resolved
-  // For now, we'll just use addresses
-  const primaryName = null; // ENS/Basename would go here
+  const primaryName = null;
 
   let displayText = "";
   if (isLinked) {
@@ -131,32 +171,19 @@ export async function getLinkedIdentity(
   };
 }
 
-/**
- * Format proposal author display with linked identity
- * 
- * @param smartWalletAddress - The Smart Wallet address (primary identity)
- * @param eoaAddress - The EOA address that signed (from Snapshot)
- * @param primaryName - Optional ENS/Basename for Smart Wallet
- * @returns Formatted author string
- */
 export function formatProposalAuthor(
   smartWalletAddress: string | null,
   eoaAddress: string,
   primaryName?: string | null
 ): string {
   if (!smartWalletAddress || smartWalletAddress.toLowerCase() === eoaAddress.toLowerCase()) {
-    // No Smart Wallet or they're the same - just show EOA
     return primaryName || shortenAddress(eoaAddress);
   }
 
-  // Linked identity - show Smart Wallet as primary, EOA as signer
   const primaryDisplay = primaryName || shortenAddress(smartWalletAddress);
   return `${primaryDisplay} (via ${shortenAddress(eoaAddress)})`;
 }
 
-/**
- * Helper to shorten address
- */
 function shortenAddress(address: string): string {
   if (!address) return "";
   return `${address.slice(0, 6)}...${address.slice(-4)}`;

--- a/lib/utils/linked-identity.ts
+++ b/lib/utils/linked-identity.ts
@@ -1,6 +1,6 @@
 import { predictModularAccountV2Address } from "@account-kit/smart-contracts";
-import { Address, createPublicClient, getAddress } from "viem";
-import { alchemy, base } from "@account-kit/infra";
+import { Address, getAddress } from "viem";
+import { base } from "@account-kit/infra";
 import {
   modularAccountFactoryAddresses,
   smaBytecodeImplementationAddresses,
@@ -14,13 +14,6 @@ import { logger } from '@/lib/utils/logger';
  * - Primary Display: Smart Wallet address (or ENS/Basename if available)
  * - Background: EOA address for signing operations (Snapshot, approvals, etc.)
  */
-
-const publicClient = createPublicClient({
-  chain: base,
-  transport: alchemy({
-    apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY as string,
-  }),
-});
 
 function predictSmaAddress(ownerAddress: string): string | null {
   const factory = modularAccountFactoryAddresses[base.id];
@@ -59,20 +52,7 @@ export async function isPermittedSigner(
     }
 
     const predicted = predictSmaAddress(normalizedEOA);
-    if (predicted && predicted === normalizedSmartWallet) {
-      return true;
-    }
-
-    // Deployed SMA stores the owner as an immutable arg; undeployed counterfactual
-    // still matches prediction above.
-    const code = await publicClient.getCode({
-      address: getAddress(normalizedSmartWallet),
-    });
-    if (!code || code === "0x") {
-      return false;
-    }
-
-    return false;
+    return Boolean(predicted && predicted === normalizedSmartWallet);
   } catch (error) {
     logger.error("Error checking permitted signer:", error);
     return false;

--- a/lib/utils/modularAccount.ts
+++ b/lib/utils/modularAccount.ts
@@ -7,3 +7,9 @@ export const modularAccountFactoryAddresses: Record<number, string> = {
   // Base
   [base.id]: "0x00000000000017c61b5bEe81050EC8eFc9c6fecd",
 };
+
+/** Semi-modular bytecode implementation used for SMA address prediction (Account Kit defaults). */
+export const smaBytecodeImplementationAddresses: Record<number, string> = {
+  [baseSepolia.id]: "0x000000000000c5A9089039570Dd36455b5C07383",
+  [base.id]: "0x000000000000c5A9089039570Dd36455b5C07383",
+};


### PR DESCRIPTION
## Summary
- Require wallet signatures for MeToken-gated live stream JWTs and verify linked EOA↔SCA companion addresses via SMA prediction before max-balance checks.
- Fix silent signing failures in the watch flow with a dedicated gate state and shared wallet auth error messaging.
- Wire creator profile upsert/update mutations through `useWalletAuth` and remove noisy `stream!` assertions in `sign-jwt`.

## Test plan
- [ ] MeToken-gated stream: connect wallet, approve signature, sufficient balance on SCA → playback JWT issued
- [ ] MeToken-gated stream: tokens on linked EOA only, auth signs as SCA → gate passes via companion balance check
- [ ] Reject wallet signature while connected → gate shows "Approve Signature", not "Connect Wallet"
- [ ] Ungated stream → JWT issued without wallet auth headers
- [ ] Spoofed `companionAddress` in request body → ignored unless linked to verified address
- [ ] Creator profile save prompts for signature and surfaces cancellation errors clearly


Made with [Cursor](https://cursor.com)