### PR TITLE
Harden API routes with wallet auth and on-chain verification

### DIFF
--- a/app/api/livepeer/livepeer-proxy/route.test.ts
+++ b/app/api/livepeer/livepeer-proxy/route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("viem", () => ({
+  isAddress: (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value),
+}));
+
+const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockGetStreamByCreator = vi.fn();
+const mockCreateStreamRecord = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { standard: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/services/streams", () => ({
+  getStreamByCreator: (...args: unknown[]) => mockGetStreamByCreator(...args),
+  createStreamRecord: (...args: unknown[]) => mockCreateStreamRecord(...args),
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+const validBody = {
+  creatorAddress: CREATOR,
+  name: "Test Stream",
+  profiles: [
+    {
+      name: "720p",
+      width: 1280,
+      height: 720,
+      bitrate: 2_500_000,
+      fps: 30,
+      fpsDen: 1,
+      quality: 23,
+      gop: "2",
+      profile: "H264Baseline",
+    },
+  ],
+  record: true,
+  playbackPolicy: { type: "jwt" },
+};
+
+function streamRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/livepeer/livepeer-proxy", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("livepeer-proxy POST security", () => {
+  beforeEach(() => {
+    process.env.LIVEPEER_FULL_API_KEY = "test-key";
+    mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
+    mockGetStreamByCreator.mockResolvedValue(null);
+    mockCreateStreamRecord.mockResolvedValue({ id: "db-1" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: "stream-1",
+          playbackId: "playback-1",
+          streamKey: "secret-key",
+        }),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(streamRequest(validBody));
+    expect(res.status).toBe(401);
+    expect(mockCreateStreamRecord).not.toHaveBeenCalled();
+  });
+
+  it("creates stream and persists record for authenticated creator", async () => {
+    const res = await POST(streamRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.streamId).toBe("stream-1");
+    expect(json.playbackId).toBe("playback-1");
+    expect(json.streamKey).toBe("secret-key");
+    expect(mockCreateStreamRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creator_id: CREATOR,
+        stream_key: "secret-key",
+      }),
+    );
+  });
+});

--- a/app/api/livepeer/livepeer-proxy/route.ts
+++ b/app/api/livepeer/livepeer-proxy/route.ts
@@ -1,6 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkBotId } from "botid/server";
+import { z } from "zod";
+import { isAddress } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
+import { createStreamRecord, getStreamByCreator } from "@/services/streams";
+import { serverLogger } from "@/lib/utils/logger";
+
+const streamProfileSchema = z.object({
+  name: z.string(),
+  width: z.number(),
+  height: z.number(),
+  bitrate: z.number(),
+  fps: z.number(),
+  fpsDen: z.number(),
+  quality: z.number(),
+  gop: z.string(),
+  profile: z.string(),
+});
+
+const bodySchema = z.object({
+  creatorAddress: z.string().refine(isAddress, "Invalid creatorAddress"),
+  name: z.string().min(1),
+  profiles: z.array(streamProfileSchema).min(1),
+  record: z.boolean(),
+  playbackPolicy: z.record(z.unknown()),
+});
 
 export async function POST(req: NextRequest) {
   const verification = await checkBotId();
@@ -10,16 +35,99 @@ export async function POST(req: NextRequest) {
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 
-  const body = await req.json();
-  const livepeerRes = await fetch("https://livepeer.studio/api/stream", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${process.env.LIVEPEER_FULL_API_KEY}`,
-    },
-    body: JSON.stringify(body),
-  });
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
 
-  const data = await livepeerRes.json();
-  return NextResponse.json(data, { status: livepeerRes.status });
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+
+  const { creatorAddress, name, profiles, record, playbackPolicy } = parsed.data;
+  const normalizedCreator = creatorAddress.toLowerCase();
+
+  try {
+    await requireWalletAuthFor(req, normalizedCreator);
+  } catch (authErr) {
+    if (authErr instanceof WalletAuthError) {
+      return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+    }
+    throw authErr;
+  }
+
+  const existing = await getStreamByCreator(normalizedCreator);
+  if (existing) {
+    return NextResponse.json(
+      {
+        error: "Stream already exists for this creator",
+        streamId: existing.stream_id,
+        playbackId: existing.playback_id,
+      },
+      { status: 409 },
+    );
+  }
+
+  const apiKey = process.env.LIVEPEER_FULL_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Livepeer API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const livepeerRes = await fetch("https://livepeer.studio/api/stream", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ name, profiles, record, playbackPolicy }),
+    });
+
+    const data = await livepeerRes.json();
+    if (!livepeerRes.ok) {
+      return NextResponse.json(data, { status: livepeerRes.status });
+    }
+
+    const streamKeyValue = data.streamKey || data.stream?.streamKey;
+    const streamIdValue = data.id || data.stream?.id;
+    const playbackIdValue = data.playbackId || data.stream?.playbackId;
+
+    if (!streamKeyValue || !streamIdValue || !playbackIdValue) {
+      serverLogger.error("Livepeer create stream missing fields:", data);
+      return NextResponse.json(
+        { error: "Livepeer response missing stream identifiers" },
+        { status: 502 },
+      );
+    }
+
+    await createStreamRecord({
+      creator_id: normalizedCreator,
+      stream_key: streamKeyValue,
+      stream_id: streamIdValue,
+      playback_id: playbackIdValue,
+      name: name || `Channel-${normalizedCreator.slice(0, 6)}`,
+      is_live: false,
+    });
+
+    return NextResponse.json({
+      streamId: streamIdValue,
+      playbackId: playbackIdValue,
+      streamKey: streamKeyValue,
+    });
+  } catch (error) {
+    serverLogger.error("Livepeer stream creation error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to create stream" },
+      { status: 500 },
+    );
+  }
 }

--- a/app/api/livepeer/stream-key/route.ts
+++ b/app/api/livepeer/stream-key/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkBotId } from "botid/server";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
+import { getStreamByCreator } from "@/services/streams";
+
+/**
+ * Owner-only: return RTMP/WHIP stream key for the authenticated creator's channel.
+ */
+export async function GET(req: NextRequest) {
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  const creatorAddress = req.nextUrl.searchParams.get("creatorAddress")?.trim();
+  if (!creatorAddress || !/^0x[a-fA-F0-9]{40}$/.test(creatorAddress)) {
+    return NextResponse.json({ error: "Valid creatorAddress query param required" }, { status: 400 });
+  }
+
+  const normalizedCreator = creatorAddress.toLowerCase();
+
+  try {
+    await requireWalletAuthFor(req, normalizedCreator);
+  } catch (authErr) {
+    if (authErr instanceof WalletAuthError) {
+      return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+    }
+    throw authErr;
+  }
+
+  const stream = await getStreamByCreator(normalizedCreator);
+  if (!stream) {
+    return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    streamId: stream.stream_id,
+    playbackId: stream.playback_id,
+    streamKey: stream.stream_key,
+  });
+}

--- a/app/api/metokens/[address]/balance/route.test.ts
+++ b/app/api/metokens/[address]/balance/route.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const METOKEN = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const USER = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockVerifyMeTokenBalance = vi.fn();
+const mockUpdateUserBalance = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { standard: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/lib/metokens/verifyMeTokenBalance", () => ({
+  verifyMeTokenBalance: (...args: unknown[]) => mockVerifyMeTokenBalance(...args),
+}));
+
+vi.mock("@/lib/chain/verifyTransactionReceipt", () => ({
+  TransactionVerificationError: class TransactionVerificationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "TransactionVerificationError";
+    }
+  },
+}));
+
+vi.mock("@/lib/sdk/supabase/metokens", () => ({
+  meTokenSupabaseService: {
+    updateUserBalance: (...args: unknown[]) => mockUpdateUserBalance(...args),
+  },
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { PUT } from "./route";
+
+function balanceRequest(body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost/api/metokens/${METOKEN}/balance`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("metokens balance PUT security", () => {
+  beforeEach(() => {
+    mockRequireWalletAuthFor.mockResolvedValue({ address: USER });
+    mockVerifyMeTokenBalance.mockResolvedValue(2.5);
+    mockUpdateUserBalance.mockResolvedValue({ user_address: USER, balance: 2.5 });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await PUT(
+      balanceRequest({ user_address: USER, balance: 2.5 }),
+      { params: Promise.resolve({ address: METOKEN }) },
+    );
+    expect(res.status).toBe(401);
+    expect(mockUpdateUserBalance).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when on-chain balance verification fails", async () => {
+    const { TransactionVerificationError } = await import("@/lib/chain/verifyTransactionReceipt");
+    mockVerifyMeTokenBalance.mockRejectedValue(
+      new TransactionVerificationError("Claimed balance does not match on-chain balanceOf"),
+    );
+
+    const res = await PUT(
+      balanceRequest({ user_address: USER, balance: 99 }),
+      { params: Promise.resolve({ address: METOKEN }) },
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("balanceOf");
+    expect(mockUpdateUserBalance).not.toHaveBeenCalled();
+  });
+
+  it("updates balance with verified on-chain value", async () => {
+    const res = await PUT(
+      balanceRequest({ user_address: USER, balance: 2.5 }),
+      { params: Promise.resolve({ address: METOKEN }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateUserBalance).toHaveBeenCalledWith(METOKEN, USER, 2.5);
+  });
+});

--- a/app/api/metokens/[address]/balance/route.ts
+++ b/app/api/metokens/[address]/balance/route.ts
@@ -4,6 +4,7 @@ import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
+import { isValidEthAddress } from '@/lib/auth/validate-address';
 import { verifyMeTokenBalance } from '@/lib/metokens/verifyMeTokenBalance';
 import { TransactionVerificationError } from '@/lib/chain/verifyTransactionReceipt';
 
@@ -43,6 +44,13 @@ export async function PUT(
       );
     }
 
+    if (!isValidEthAddress(address)) {
+      return NextResponse.json(
+        { error: 'Invalid MeToken address format' },
+        { status: 400 }
+      );
+    }
+
     const {
       user_address,
       balance,
@@ -75,10 +83,10 @@ export async function PUT(
         { status: 400 }
       );
     }
-    
-    // Validate user_address format
-    const addressRegex = /^0x[a-fA-F0-9]{40}$/;
-    if (!addressRegex.test(user_address)) {
+
+    const normalizedUserAddress = user_address.trim().toLowerCase();
+
+    if (!isValidEthAddress(normalizedUserAddress)) {
       return NextResponse.json(
         { 
           error: 'Invalid user_address format',
@@ -87,8 +95,6 @@ export async function PUT(
         { status: 400 }
       );
     }
-
-    const normalizedUserAddress = user_address.toLowerCase();
 
     try {
       await requireWalletAuthFor(request, normalizedUserAddress);

--- a/app/api/metokens/[address]/balance/route.ts
+++ b/app/api/metokens/[address]/balance/route.ts
@@ -3,6 +3,9 @@ import { checkBotId } from 'botid/server';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
+import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
+import { verifyMeTokenBalance } from '@/lib/metokens/verifyMeTokenBalance';
+import { TransactionVerificationError } from '@/lib/chain/verifyTransactionReceipt';
 
 // PUT /api/metokens/[address]/balance - Update user's MeToken balance
 export async function PUT(
@@ -85,10 +88,35 @@ export async function PUT(
       );
     }
 
+    const normalizedUserAddress = user_address.toLowerCase();
+
+    try {
+      await requireWalletAuthFor(request, normalizedUserAddress);
+    } catch (authErr) {
+      if (authErr instanceof WalletAuthError) {
+        return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+      }
+      throw authErr;
+    }
+
+    let verifiedBalance: number;
+    try {
+      verifiedBalance = await verifyMeTokenBalance({
+        meTokenAddress: address,
+        userAddress: normalizedUserAddress,
+        claimedBalance: balanceNum,
+      });
+    } catch (verifyErr) {
+      if (verifyErr instanceof TransactionVerificationError) {
+        return NextResponse.json({ error: verifyErr.message }, { status: 400 });
+      }
+      throw verifyErr;
+    }
+
     const result = await meTokenSupabaseService.updateUserBalance(
       address,
-      user_address,
-      balance
+      normalizedUserAddress,
+      verifiedBalance
     );
     
     return NextResponse.json({ data: result }, { status: 200 });

--- a/app/api/metokens/[address]/transactions/route.test.ts
+++ b/app/api/metokens/[address]/transactions/route.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const METOKEN = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const USER = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockVerifyMeTokenTransaction = vi.fn();
+const mockGetMeTokenByAddress = vi.fn();
+const mockRecordTransaction = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { standard: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/lib/metokens/verifyMeTokenTransaction", () => ({
+  verifyMeTokenTransaction: (...args: unknown[]) => mockVerifyMeTokenTransaction(...args),
+}));
+
+vi.mock("@/lib/chain/verifyTransactionReceipt", () => ({
+  TransactionVerificationError: class TransactionVerificationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "TransactionVerificationError";
+    }
+  },
+}));
+
+vi.mock("@/lib/sdk/supabase/metokens", () => ({
+  meTokenSupabaseService: {
+    getMeTokenByAddress: (...args: unknown[]) => mockGetMeTokenByAddress(...args),
+    recordTransaction: (...args: unknown[]) => mockRecordTransaction(...args),
+  },
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function txRequest(body: Record<string, unknown>) {
+  return new NextRequest(`http://localhost/api/metokens/${METOKEN}/transactions`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("metokens transactions POST security", () => {
+  beforeEach(() => {
+    mockRequireWalletAuthFor.mockResolvedValue({ address: USER });
+    mockGetMeTokenByAddress.mockResolvedValue({ id: 1, address: METOKEN });
+    mockVerifyMeTokenTransaction.mockResolvedValue({
+      transactionHash: "0x" + "a".repeat(64),
+      blockNumber: 123n,
+      amount: 1.5,
+      userAddress: USER,
+      meTokenAddress: METOKEN,
+      transactionType: "mint",
+    });
+    mockRecordTransaction.mockResolvedValue({ id: 99 });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(txRequest({
+      user_address: USER,
+      transaction_type: "mint",
+      amount: 1,
+      transaction_hash: "0x" + "a".repeat(64),
+    }), { params: Promise.resolve({ address: METOKEN }) });
+
+    expect(res.status).toBe(401);
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when transaction_hash is missing", async () => {
+    const res = await POST(txRequest({
+      user_address: USER,
+      transaction_type: "mint",
+      amount: 1,
+    }), { params: Promise.resolve({ address: METOKEN }) });
+
+    expect(res.status).toBe(400);
+    expect(mockVerifyMeTokenTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when on-chain verification fails", async () => {
+    const { TransactionVerificationError } = await import("@/lib/chain/verifyTransactionReceipt");
+    mockVerifyMeTokenTransaction.mockRejectedValue(
+      new TransactionVerificationError("No MeToken Transfer events found in transaction"),
+    );
+
+    const res = await POST(txRequest({
+      user_address: USER,
+      transaction_type: "mint",
+      amount: 1,
+      transaction_hash: "0x" + "a".repeat(64),
+    }), { params: Promise.resolve({ address: METOKEN }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("Transfer");
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+  });
+
+  it("records verified transaction on success", async () => {
+    const res = await POST(txRequest({
+      user_address: USER,
+      transaction_type: "mint",
+      amount: 1.5,
+      transaction_hash: "0x" + "a".repeat(64),
+    }), { params: Promise.resolve({ address: METOKEN }) });
+
+    expect(res.status).toBe(201);
+    expect(mockRecordTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_address: USER,
+        amount: 1.5,
+      }),
+    );
+  });
+});

--- a/app/api/metokens/[address]/transactions/route.ts
+++ b/app/api/metokens/[address]/transactions/route.ts
@@ -4,6 +4,7 @@ import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
+import { isValidEthAddress } from '@/lib/auth/validate-address';
 import { verifyMeTokenTransaction } from '@/lib/metokens/verifyMeTokenTransaction';
 import { TransactionVerificationError } from '@/lib/chain/verifyTransactionReceipt';
 
@@ -97,6 +98,13 @@ export async function POST(
       );
     }
 
+    if (!isValidEthAddress(address)) {
+      return NextResponse.json(
+        { error: 'Invalid MeToken address format' },
+        { status: 400 }
+      );
+    }
+
     const {
       user_address,
       transaction_type,
@@ -126,7 +134,24 @@ export async function POST(
       );
     }
 
-    const normalizedUserAddress = user_address.toLowerCase();
+    const normalizedUserAddress = user_address.trim().toLowerCase();
+
+    if (!isValidEthAddress(normalizedUserAddress)) {
+      return NextResponse.json(
+        {
+          error: 'Invalid user_address format',
+          details: 'user_address must be a valid Ethereum address (0x followed by 40 hex characters)'
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!/^0x[a-fA-F0-9]{64}$/.test(String(transaction_hash).trim())) {
+      return NextResponse.json(
+        { error: 'Invalid transaction_hash format' },
+        { status: 400 }
+      );
+    }
 
     try {
       await requireWalletAuthFor(request, normalizedUserAddress);
@@ -157,18 +182,6 @@ export async function POST(
         {
           error: 'Invalid amount',
           details: 'amount must be a non-negative number'
-        },
-        { status: 400 }
-      );
-    }
-
-    // Validate user_address format
-    const addressRegex = /^0x[a-fA-F0-9]{40}$/;
-    if (!addressRegex.test(normalizedUserAddress)) {
-      return NextResponse.json(
-        {
-          error: 'Invalid user_address format',
-          details: 'user_address must be a valid Ethereum address (0x followed by 40 hex characters)'
         },
         { status: 400 }
       );

--- a/app/api/metokens/[address]/transactions/route.ts
+++ b/app/api/metokens/[address]/transactions/route.ts
@@ -3,6 +3,9 @@ import { checkBotId } from 'botid/server';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
+import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
+import { verifyMeTokenTransaction } from '@/lib/metokens/verifyMeTokenTransaction';
+import { TransactionVerificationError } from '@/lib/chain/verifyTransactionReceipt';
 
 // GET /api/metokens/[address]/transactions - Get MeToken transactions
 export async function GET(
@@ -106,20 +109,32 @@ export async function POST(
     } = body;
 
     // Validate required fields
-    if (!user_address || !transaction_type || amount === undefined) {
+    if (!user_address || !transaction_type || amount === undefined || !transaction_hash) {
       const missingFields = [];
       if (!user_address) missingFields.push('user_address');
       if (!transaction_type) missingFields.push('transaction_type');
       if (amount === undefined) missingFields.push('amount');
+      if (!transaction_hash) missingFields.push('transaction_hash');
 
       return NextResponse.json(
         {
           error: 'Missing required fields',
           missingFields,
-          hint: 'All of the following fields are required: user_address, transaction_type, amount'
+          hint: 'All of the following fields are required: user_address, transaction_type, amount, transaction_hash'
         },
         { status: 400 }
       );
+    }
+
+    const normalizedUserAddress = user_address.toLowerCase();
+
+    try {
+      await requireWalletAuthFor(request, normalizedUserAddress);
+    } catch (authErr) {
+      if (authErr instanceof WalletAuthError) {
+        return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+      }
+      throw authErr;
     }
 
     // Validate transaction_type is valid
@@ -149,7 +164,7 @@ export async function POST(
 
     // Validate user_address format
     const addressRegex = /^0x[a-fA-F0-9]{40}$/;
-    if (!addressRegex.test(user_address)) {
+    if (!addressRegex.test(normalizedUserAddress)) {
       return NextResponse.json(
         {
           error: 'Invalid user_address format',
@@ -168,14 +183,33 @@ export async function POST(
       );
     }
 
+    let verified;
+    try {
+      verified = await verifyMeTokenTransaction({
+        meTokenAddress: address,
+        userAddress: normalizedUserAddress,
+        transactionHash: transaction_hash,
+        transactionType: transaction_type,
+        claimedAmount: amount,
+      });
+    } catch (verifyErr) {
+      if (verifyErr instanceof TransactionVerificationError) {
+        return NextResponse.json(
+          { error: verifyErr.message },
+          { status: 400 },
+        );
+      }
+      throw verifyErr;
+    }
+
     const transactionData = {
       metoken_id: meToken.id,
-      user_address,
+      user_address: normalizedUserAddress,
       transaction_type,
-      amount,
+      amount: verified.amount,
       collateral_amount,
-      transaction_hash,
-      block_number,
+      transaction_hash: verified.transactionHash,
+      block_number: Number(verified.blockNumber),
       video_id,
       playback_id,
     };

--- a/app/api/predictions/record/route.test.ts
+++ b/app/api/predictions/record/route.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("viem", () => ({
+  isAddress: (value: string) => /^0x[a-fA-F0-9]{40}$/.test(value),
+  getAddress: (value: string) => value.toLowerCase(),
+}));
+
+const USER = "0x1111111111111111111111111111111111111111";
+const TX = "0x" + "b".repeat(64);
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockVerifyPredictionCreationTx = vi.fn();
+const mockGetAllMemberships = vi.fn();
+const mockCountPredictionMarketsThisMonthUtc = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { generous: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/lib/chain/verifyTransactionReceipt", () => ({
+  TransactionVerificationError: class TransactionVerificationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "TransactionVerificationError";
+    }
+  },
+}));
+
+vi.mock("@/lib/predictions/verifyPredictionCreationTx", () => ({
+  verifyPredictionCreationTx: (...args: unknown[]) => mockVerifyPredictionCreationTx(...args),
+}));
+
+vi.mock("@/lib/sdk/unlock/services", () => ({
+  unlockService: {
+    getAllMemberships: (...args: unknown[]) => mockGetAllMemberships(...args),
+  },
+}));
+
+vi.mock("@/lib/predictions/prediction-quota", () => ({
+  countPredictionMarketsThisMonthUtc: (...args: unknown[]) =>
+    mockCountPredictionMarketsThisMonthUtc(...args),
+  getPremiumPredictionAccess: () => ({ unlimited: false, premiumTier: null }),
+  normalizeCreatorAddress: (address: string) => address.toLowerCase(),
+  PREDICTION_MARKETS_MONTHLY_LIMIT: 3,
+}));
+
+vi.mock("@/lib/access/platform-admin", () => ({
+  isPlatformAdmin: () => false,
+}));
+
+vi.mock("@/lib/access/creator-membership", () => ({
+  hasValidCreatorPass: () => false,
+}));
+
+vi.mock("@/lib/sdk/supabase/service", () => ({
+  supabaseService: {
+    from: () => ({
+      insert: mockInsert,
+    }),
+  },
+}));
+
+import { POST } from "./route";
+
+function recordRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/predictions/record", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("predictions/record POST security", () => {
+  beforeEach(() => {
+    mockRequireWalletAuthFor.mockResolvedValue({ address: USER });
+    mockVerifyPredictionCreationTx.mockResolvedValue({
+      questionId: "0x" + "c".repeat(64),
+      creatorAddress: USER,
+      transactionHash: TX,
+    });
+    mockGetAllMemberships.mockResolvedValue([]);
+    mockCountPredictionMarketsThisMonthUtc.mockResolvedValue(0);
+    mockInsert.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(recordRequest({ address: USER, transactionHash: TX }));
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when tx verification fails", async () => {
+    const { TransactionVerificationError } = await import("@/lib/chain/verifyTransactionReceipt");
+    mockVerifyPredictionCreationTx.mockRejectedValue(
+      new TransactionVerificationError("No valid Reality.eth question creation found in transaction"),
+    );
+
+    const res = await POST(recordRequest({ address: USER, transactionHash: TX }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("Reality.eth");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("records quota usage when verification succeeds", async () => {
+    const res = await POST(recordRequest({
+      address: USER,
+      transactionHash: TX,
+      title: "Test market",
+    }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.recorded).toBe(true);
+    expect(mockInsert).toHaveBeenCalled();
+  });
+});

--- a/app/api/predictions/record/route.ts
+++ b/app/api/predictions/record/route.ts
@@ -4,6 +4,9 @@ import { z } from "zod";
 import { isAddress } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { supabaseService } from "@/lib/sdk/supabase/service";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
+import { verifyPredictionCreationTx } from "@/lib/predictions/verifyPredictionCreationTx";
+import { TransactionVerificationError } from "@/lib/chain/verifyTransactionReceipt";
 import {
   countPredictionMarketsThisMonthUtc,
   getPremiumPredictionAccess,
@@ -61,6 +64,33 @@ export async function POST(request: NextRequest) {
 
   try {
     const normalized = normalizeCreatorAddress(address);
+
+    try {
+      await requireWalletAuthFor(request, normalized);
+    } catch (authErr) {
+      if (authErr instanceof WalletAuthError) {
+        return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+      }
+      throw authErr;
+    }
+
+    let verifiedQuestionId: string | undefined;
+    try {
+      const verified = await verifyPredictionCreationTx(transactionHash, normalized);
+      verifiedQuestionId = verified.questionId;
+      if (questionId && questionId.toLowerCase() !== verified.questionId.toLowerCase()) {
+        return NextResponse.json(
+          { error: "questionId does not match on-chain transaction" },
+          { status: 400 },
+        );
+      }
+    } catch (verifyErr) {
+      if (verifyErr instanceof TransactionVerificationError) {
+        return NextResponse.json({ error: verifyErr.message }, { status: 400 });
+      }
+      throw verifyErr;
+    }
+
     const memberships = await unlockService.getAllMemberships(normalized);
 
     if (!isPlatformAdmin(normalized) && hasValidCreatorPass(memberships)) {
@@ -97,7 +127,7 @@ export async function POST(request: NextRequest) {
       .insert({
         creator_address: normalized,
         transaction_hash: transactionHash.toLowerCase(),
-        question_id: questionId ?? null,
+        question_id: questionId ?? verifiedQuestionId ?? null,
         title: title ?? null,
         category: category ?? null,
         question_type: questionType ?? null,

--- a/app/api/story/factory/deploy-collection/route.test.ts
+++ b/app/api/story/factory/deploy-collection/route.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("viem", () => ({
+  createWalletClient: vi.fn(() => ({})),
+  http: vi.fn(),
+  privateKeyToAccount: vi.fn(() => ({ address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" })),
+}));
+
+const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockDeployCreatorCollection = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { strict: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/lib/sdk/story/factory-contract-service", () => ({
+  deployCreatorCollection: (...args: unknown[]) => mockDeployCreatorCollection(...args),
+  getCollectionBytecode: () => "0x1234",
+  getFactoryContractAddress: () => "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+}));
+
+vi.mock("@/lib/sdk/story/client", () => ({
+  getStoryRpcUrl: () => "https://rpc.story.test",
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function deployRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/story/factory/deploy-collection", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("deploy-collection POST security", () => {
+  beforeEach(() => {
+    process.env.FACTORY_OWNER_PRIVATE_KEY =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
+    mockDeployCreatorCollection.mockResolvedValue({
+      collectionAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+      txHash: "0xabc",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when wallet auth fails", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(
+      deployRequest({
+        creatorAddress: CREATOR,
+        collectionName: "Test",
+        collectionSymbol: "TST",
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toContain("Missing wallet auth");
+    expect(mockDeployCreatorCollection).not.toHaveBeenCalled();
+  });
+
+  it("deploys when wallet auth succeeds", async () => {
+    const res = await POST(
+      deployRequest({
+        creatorAddress: CREATOR,
+        collectionName: "Test",
+        collectionSymbol: "TST",
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockRequireWalletAuthFor).toHaveBeenCalledWith(expect.any(NextRequest), CREATOR);
+    expect(mockDeployCreatorCollection).toHaveBeenCalled();
+  });
+});

--- a/app/api/story/factory/deploy-collection/route.ts
+++ b/app/api/story/factory/deploy-collection/route.ts
@@ -18,6 +18,7 @@ import { deployCreatorCollection, getCollectionBytecode, getFactoryContractAddre
 import type { Address } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 
 /**
  * Story Protocol chain configuration
@@ -49,6 +50,17 @@ export async function POST(request: NextRequest) {
         { error: "Missing required fields: creatorAddress, collectionName, collectionSymbol" },
         { status: 400 }
       );
+    }
+
+    const normalizedCreator = String(creatorAddress).toLowerCase();
+
+    try {
+      await requireWalletAuthFor(request, normalizedCreator);
+    } catch (authErr) {
+      if (authErr instanceof WalletAuthError) {
+        return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+      }
+      throw authErr;
     }
 
     // Check factory configuration
@@ -104,7 +116,7 @@ export async function POST(request: NextRequest) {
     // Deploy collection via factory
     const result = await deployCreatorCollection(
       walletClient,
-      creatorAddress as Address,
+      normalizedCreator as Address,
       collectionName,
       collectionSymbol,
       bytecode

--- a/app/api/story/factory/deploy-collection/route.ts
+++ b/app/api/story/factory/deploy-collection/route.ts
@@ -19,6 +19,7 @@ import type { Address } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
+import { isValidEthAddress, normalizeEthAddress } from "@/lib/auth/validate-address";
 
 /**
  * Story Protocol chain configuration
@@ -52,7 +53,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const normalizedCreator = String(creatorAddress).toLowerCase();
+    const normalizedCreator = normalizeEthAddress(String(creatorAddress));
+
+    if (!isValidEthAddress(normalizedCreator)) {
+      return NextResponse.json({ error: "Invalid creatorAddress format" }, { status: 400 });
+    }
 
     try {
       await requireWalletAuthFor(request, normalizedCreator);

--- a/app/api/story/mint-derivative/route.test.ts
+++ b/app/api/story/mint-derivative/route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const RECIPIENT = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockGetVideoAssetById = vi.fn();
+const mockGetOrCreateCreatorCollection = vi.fn();
+const mockMintAndRegisterDerivative = vi.fn();
+const mockUpdateVideoAsset = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { strict: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/services/video-assets", () => ({
+  getVideoAssetById: (...args: unknown[]) => mockGetVideoAssetById(...args),
+  updateVideoAsset: (...args: unknown[]) => mockUpdateVideoAsset(...args),
+}));
+
+vi.mock("@/services/streams", () => ({
+  getStreamByPlaybackId: vi.fn(async () => ({
+    story_license_terms_id: "lt-1",
+  })),
+}));
+
+vi.mock("@/lib/sdk/story/collection-service", () => ({
+  getOrCreateCreatorCollection: (...args: unknown[]) => mockGetOrCreateCreatorCollection(...args),
+}));
+
+vi.mock("@/lib/sdk/story/spg-service", () => ({
+  mintAndRegisterDerivative: (...args: unknown[]) => mockMintAndRegisterDerivative(...args),
+}));
+
+vi.mock("@/lib/sdk/story/client", () => ({
+  createStoryClient: () => ({}),
+}));
+
+vi.mock("@/lib/sdk/grove/service", () => ({
+  groveService: {
+    uploadJson: vi.fn(async () => ({ success: true, url: "ipfs://meta" })),
+  },
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function mintRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/story/mint-derivative", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("mint-derivative POST security", () => {
+  beforeEach(() => {
+    process.env.STORY_PROTOCOL_PRIVATE_KEY =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    mockRequireWalletAuthFor.mockResolvedValue({ address: RECIPIENT });
+    mockGetVideoAssetById.mockResolvedValue({
+      id: 1,
+      source_type: "Clip",
+      is_minted: false,
+      clipper_address: RECIPIENT,
+      parent_story_ip_id: "ip-parent",
+      parent_playback_id: "playback-parent",
+      title: "Clip",
+      clip_start_ms: 0,
+      clip_end_ms: 1000,
+    });
+    mockGetOrCreateCreatorCollection.mockResolvedValue(RECIPIENT);
+    mockMintAndRegisterDerivative.mockResolvedValue({
+      ipId: "ip-clip",
+      tokenId: "2",
+      txHash: "0xabc",
+    });
+    mockUpdateVideoAsset.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(
+      mintRequest({ clipVideoAssetId: 1, recipient: RECIPIENT }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockGetOrCreateCreatorCollection).not.toHaveBeenCalled();
+  });
+
+  it("mints derivative when auth succeeds", async () => {
+    const res = await POST(
+      mintRequest({ clipVideoAssetId: 1, recipient: RECIPIENT }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockRequireWalletAuthFor).toHaveBeenCalledWith(expect.any(NextRequest), RECIPIENT);
+    expect(mockMintAndRegisterDerivative).toHaveBeenCalled();
+  });
+});

--- a/app/api/story/mint-derivative/route.ts
+++ b/app/api/story/mint-derivative/route.ts
@@ -14,6 +14,7 @@ import { getStreamByPlaybackId } from "@/services/streams";
 import { groveService } from "@/lib/sdk/grove/service";
 import type { Address } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
@@ -43,6 +44,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid recipient format" }, { status: 400 });
   }
 
+  const normalizedRecipient = recipient.toLowerCase();
+
+  try {
+    await requireWalletAuthFor(request, normalizedRecipient);
+  } catch (authErr) {
+    if (authErr instanceof WalletAuthError) {
+      return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+    }
+    throw authErr;
+  }
+
   const clip = await getVideoAssetById(Number(clipVideoAssetId));
   if (!clip) {
     return NextResponse.json({ error: "Clip not found" }, { status: 404 });
@@ -55,7 +67,7 @@ export async function POST(request: NextRequest) {
   }
   if (
     clip.clipper_address &&
-    clip.clipper_address.toLowerCase() !== recipient.toLowerCase()
+    clip.clipper_address.toLowerCase() !== normalizedRecipient
   ) {
     return NextResponse.json(
       { error: "Only the clipper can mint their own clip" },
@@ -130,7 +142,7 @@ export async function POST(request: NextRequest) {
     }
 
     const client = createStoryClient(fundingAddress, privateKey);
-    const clipperAddress = (clip.clipper_address || recipient) as Address;
+    const clipperAddress = (clip.clipper_address || normalizedRecipient) as Address;
     const collectionAddress = await getOrCreateCreatorCollection(
       client,
       clipperAddress,
@@ -140,7 +152,7 @@ export async function POST(request: NextRequest) {
 
     const result = await mintAndRegisterDerivative(client, {
       collectionAddress,
-      recipient: recipient as Address,
+      recipient: normalizedRecipient as Address,
       parentIpIds: [parentStoryIpId as Address],
       licenseTermsIds: [parentLicenseTermsId],
       metadataURI: metadataUpload.url,

--- a/app/api/story/prepare-mint/route.test.ts
+++ b/app/api/story/prepare-mint/route.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockGetOrCreateCreatorCollection = vi.fn();
+const mockMintAndRegisterIp = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { strict: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/lib/sdk/story/collection-service", () => ({
+  getOrCreateCreatorCollection: (...args: unknown[]) => mockGetOrCreateCreatorCollection(...args),
+}));
+
+vi.mock("@/lib/sdk/story/spg-service", () => ({
+  mintAndRegisterIp: (...args: unknown[]) => mockMintAndRegisterIp(...args),
+}));
+
+vi.mock("@/lib/sdk/story/capture-transport", () => ({
+  createCaptureTransport: () => ({}),
+  getCapturedTxs: () => [
+    { to: CREATOR, data: "0x1234", value: 0n, gas: 100n, gasPrice: 1n, chainId: 1315 },
+  ],
+}));
+
+vi.mock("@/lib/sdk/story/client", () => ({
+  createStoryClient: () => ({}),
+  getStoryRpcUrl: () => "https://rpc.story.test",
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function prepareRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/story/prepare-mint", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("prepare-mint POST security", () => {
+  beforeEach(() => {
+    process.env.STORY_PROTOCOL_PRIVATE_KEY =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
+    mockGetOrCreateCreatorCollection.mockResolvedValue(CREATOR);
+    mockMintAndRegisterIp.mockRejectedValue(new Error("capture"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not create collection when wallet auth fails", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Invalid wallet signature"));
+
+    const res = await POST(
+      prepareRequest({
+        creatorAddress: CREATOR,
+        recipient: CREATOR,
+        metadataURI: "ipfs://test",
+        collectionName: "Test",
+        collectionSymbol: "TST",
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockGetOrCreateCreatorCollection).not.toHaveBeenCalled();
+  });
+
+  it("rejects recipient mismatch", async () => {
+    const res = await POST(
+      prepareRequest({
+        creatorAddress: CREATOR,
+        recipient: "0x1111111111111111111111111111111111111111",
+        metadataURI: "ipfs://test",
+        collectionName: "Test",
+        collectionSymbol: "TST",
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("recipient must match");
+    expect(mockGetOrCreateCreatorCollection).not.toHaveBeenCalled();
+  });
+
+  it("prepares mint when auth succeeds", async () => {
+    const res = await POST(
+      prepareRequest({
+        creatorAddress: CREATOR,
+        recipient: CREATOR,
+        metadataURI: "ipfs://test",
+        collectionName: "Test",
+        collectionSymbol: "TST",
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockGetOrCreateCreatorCollection).toHaveBeenCalled();
+  });
+});

--- a/app/api/story/prepare-mint/route.ts
+++ b/app/api/story/prepare-mint/route.ts
@@ -12,6 +12,7 @@ import { createCaptureTransport, getCapturedTxs } from "@/lib/sdk/story/capture-
 import type { Address } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 
 function serializeTx(tx: { to: Address; data: `0x${string}`; value?: bigint; gas?: bigint; gasPrice?: bigint; chainId?: number }) {
   return {
@@ -48,6 +49,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid address format" }, { status: 400 });
     }
 
+    const normalizedCreator = creatorAddress.toLowerCase();
+    const normalizedRecipient = recipient.toLowerCase();
+
+    try {
+      await requireWalletAuthFor(request, normalizedCreator);
+    } catch (authErr) {
+      if (authErr instanceof WalletAuthError) {
+        return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+      }
+      throw authErr;
+    }
+
+    if (normalizedRecipient !== normalizedCreator) {
+      return NextResponse.json(
+        { error: "recipient must match creatorAddress for prepare-mint" },
+        { status: 400 },
+      );
+    }
+
     const privateKey = process.env.STORY_PROTOCOL_PRIVATE_KEY;
     if (!privateKey) {
       return NextResponse.json(
@@ -67,19 +87,19 @@ export async function POST(request: NextRequest) {
     const fundingClient = createStoryClient(fundingAddress, privateKey);
     const collectionAddress = await getOrCreateCreatorCollection(
       fundingClient,
-      creatorAddress as Address,
+      normalizedCreator as Address,
       collectionName,
       collectionSymbol
     );
 
     const captureKey = `prepare-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const captureTransport = createCaptureTransport(rpcUrl, captureKey);
-    const captureClient = createStoryClient(creatorAddress as Address, undefined, captureTransport);
+    const captureClient = createStoryClient(normalizedCreator as Address, undefined, captureTransport);
 
     try {
       await mintAndRegisterIp(captureClient, {
         collectionAddress,
-        recipient: recipient as Address,
+        recipient: normalizedRecipient as Address,
         metadataURI,
         allowDuplicates: false,
       });

--- a/app/api/story/register-stream/route.test.ts
+++ b/app/api/story/register-stream/route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("viem", () => ({
+  parseEther: (value: string) => BigInt(value),
+}));
+
+const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+const mockRequireWalletAuthFor = vi.fn();
+const mockGetStreamByCreator = vi.fn();
+const mockGetOrCreateCreatorCollection = vi.fn();
+const mockMintAndRegisterIpAndAttachPilTerms = vi.fn();
+const mockUpdateStreamStoryIp = vi.fn();
+
+vi.mock("botid/server", () => ({
+  checkBotId: vi.fn(async () => ({ isBot: false })),
+}));
+
+vi.mock("@/lib/middleware/rateLimit", () => ({
+  rateLimiters: { strict: vi.fn(async () => null) },
+}));
+
+vi.mock("@/lib/auth/require-wallet", () => ({
+  requireWalletAuthFor: (...args: unknown[]) => mockRequireWalletAuthFor(...args),
+  WalletAuthError: class WalletAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "WalletAuthError";
+    }
+  },
+}));
+
+vi.mock("@/services/streams", () => ({
+  getStreamByCreator: (...args: unknown[]) => mockGetStreamByCreator(...args),
+  updateStreamStoryIp: (...args: unknown[]) => mockUpdateStreamStoryIp(...args),
+}));
+
+vi.mock("@/lib/sdk/story/collection-service", () => ({
+  getOrCreateCreatorCollection: (...args: unknown[]) => mockGetOrCreateCreatorCollection(...args),
+}));
+
+vi.mock("@/lib/sdk/story/spg-service", () => ({
+  mintAndRegisterIpAndAttachPilTerms: (...args: unknown[]) =>
+    mockMintAndRegisterIpAndAttachPilTerms(...args),
+}));
+
+vi.mock("@/lib/sdk/story/client", () => ({
+  createStoryClient: () => ({}),
+}));
+
+vi.mock("@/lib/sdk/grove/service", () => ({
+  groveService: {
+    uploadJson: vi.fn(async () => ({ success: true, url: "ipfs://meta" })),
+  },
+}));
+
+vi.mock("@/lib/sdk/story/constants", () => ({
+  WIP_TOKEN_ADDRESS: "0x1111111111111111111111111111111111111111",
+}));
+
+vi.mock("@story-protocol/core-sdk", () => ({
+  PILFlavor: {
+    commercialRemix: () => ({}),
+  },
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  serverLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "./route";
+
+function registerRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/story/register-stream", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("register-stream POST security", () => {
+  beforeEach(() => {
+    process.env.STORY_PROTOCOL_PRIVATE_KEY =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+    mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
+    mockGetStreamByCreator.mockResolvedValue({
+      playback_id: "playback-1",
+      name: "My Stream",
+      story_ip_id: null,
+    });
+    mockGetOrCreateCreatorCollection.mockResolvedValue(CREATOR);
+    mockMintAndRegisterIpAndAttachPilTerms.mockResolvedValue({
+      ipId: "ip-1",
+      tokenId: "1",
+      txHash: "0xabc",
+      licenseTermsIds: ["lt-1"],
+    });
+    mockUpdateStreamStoryIp.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without wallet auth", async () => {
+    const { WalletAuthError } = await import("@/lib/auth/require-wallet");
+    mockRequireWalletAuthFor.mockRejectedValue(new WalletAuthError(401, "Missing wallet auth"));
+
+    const res = await POST(registerRequest({ creatorAddress: CREATOR }));
+    expect(res.status).toBe(401);
+    expect(mockGetOrCreateCreatorCollection).not.toHaveBeenCalled();
+  });
+
+  it("registers stream IP when auth succeeds", async () => {
+    const res = await POST(registerRequest({ creatorAddress: CREATOR }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockRequireWalletAuthFor).toHaveBeenCalledWith(expect.any(NextRequest), CREATOR);
+    expect(mockGetOrCreateCreatorCollection).toHaveBeenCalled();
+  });
+});

--- a/app/api/story/register-stream/route.ts
+++ b/app/api/story/register-stream/route.ts
@@ -15,6 +15,7 @@ import { getStreamByCreator, updateStreamStoryIp } from "@/services/streams";
 import { groveService } from "@/lib/sdk/grove/service";
 import { WIP_TOKEN_ADDRESS } from "@/lib/sdk/story/constants";
 import { serverLogger } from "@/lib/utils/logger";
+import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 const DEFAULT_REV_SHARE = 10;
@@ -42,6 +43,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid creatorAddress format" }, { status: 400 });
   }
 
+  const normalizedCreator = creatorAddress.toLowerCase();
+
+  try {
+    await requireWalletAuthFor(request, normalizedCreator);
+  } catch (authErr) {
+    if (authErr instanceof WalletAuthError) {
+      return NextResponse.json({ error: authErr.message }, { status: authErr.status });
+    }
+    throw authErr;
+  }
+
   const revShare = commercialRevShare == null ? DEFAULT_REV_SHARE : Number(commercialRevShare);
   if (!Number.isFinite(revShare) || revShare < 0 || revShare > 100) {
     return NextResponse.json(
@@ -50,7 +62,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const stream = await getStreamByCreator(creatorAddress);
+  const stream = await getStreamByCreator(normalizedCreator);
   if (!stream) {
     return NextResponse.json({ error: "Stream not found for creator" }, { status: 404 });
   }
@@ -85,13 +97,13 @@ export async function POST(request: NextRequest) {
 
     const metadata = {
       name: resolvedName,
-      description: `Livestream channel by creator ${creatorAddress}. Viewers can create and mint derivative clip NFTs.`,
+      description: `Livestream channel by creator ${normalizedCreator}. Viewers can create and mint derivative clip NFTs.`,
       image: thumbnailUrl || stream.thumbnail_url || undefined,
       animation_url: streamPlaybackUrl,
       attributes: [
         { trait_type: "source_type", value: "Livestream" },
         { trait_type: "playback_id", value: stream.playback_id },
-        { trait_type: "creator", value: creatorAddress },
+        { trait_type: "creator", value: normalizedCreator },
         { trait_type: "commercial_rev_share", value: revShare },
       ],
     };
@@ -107,14 +119,14 @@ export async function POST(request: NextRequest) {
     const client = createStoryClient(fundingAddress, privateKey);
     const collectionAddress = await getOrCreateCreatorCollection(
       client,
-      creatorAddress as Address,
+      normalizedCreator as Address,
       `${resolvedName} Streams`,
       "STREAM"
     );
 
     const result = await mintAndRegisterIpAndAttachPilTerms(client, {
       collectionAddress,
-      recipient: creatorAddress as Address,
+      recipient: normalizedCreator as Address,
       metadataURI: metadataUpload.url,
       allowDuplicates: true,
       licenseTermsData: [
@@ -130,7 +142,7 @@ export async function POST(request: NextRequest) {
 
     const licenseTermsId = result.licenseTermsIds?.[0] ?? null;
 
-    await updateStreamStoryIp(creatorAddress, {
+    await updateStreamStoryIp(normalizedCreator, {
       story_ip_id: result.ipId,
       story_license_terms_id: licenseTermsId,
       story_ip_registration_tx: result.txHash,

--- a/app/api/streams/creator/[address]/route.ts
+++ b/app/api/streams/creator/[address]/route.ts
@@ -17,13 +17,18 @@ export async function GET(
     }
 
     return NextResponse.json({
+      stream_id: stream.stream_id,
       playback_id: stream.playback_id,
       name: stream.name,
       thumbnail_url: stream.thumbnail_url,
       is_live: stream.is_live,
       last_live_at: stream.last_live_at,
+      allow_clipping: stream.allow_clipping ?? true,
       requires_metoken: stream.requires_metoken ?? false,
       metoken_price: stream.metoken_price ?? null,
+      story_ip_id: stream.story_ip_id ?? null,
+      story_license_terms_id: stream.story_license_terms_id ?? null,
+      story_commercial_rev_share: stream.story_commercial_rev_share ?? null,
     });
   } catch (error) {
     return NextResponse.json(

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
-import { Broadcast, createStreamViaProxy } from "@/components/Live/Broadcast";
-import { getStreamByCreator, createStreamRecord, updateStream } from "@/services/streams";
+import { Broadcast, createStreamViaProxy, fetchStreamKeyForCreator } from "@/components/Live/Broadcast";
+import { updateStream } from "@/services/streams";
 import { useUser } from "@account-kit/react";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -44,6 +45,7 @@ import { logger } from '@/lib/utils/logger';
 
 export default function LivePage() {
   const user = useUser();
+  const { getAuthHeaders } = useWalletAuth();
   const isConnected = !!user?.address;
   const [multistreamTargets, setMultistreamTargets] = useState<
     MultistreamTarget[]
@@ -88,11 +90,16 @@ export default function LivePage() {
       if (!user?.address) return;
 
       try {
-        // 1. Fetch persistent stream
-        const stream = await getStreamByCreator(user.address);
+        const authHeaders = await getAuthHeaders();
+        const streamRes = await fetch(
+          `/api/streams/creator/${encodeURIComponent(user.address)}`,
+        );
 
-        if (stream) {
-          setStreamKey(stream.stream_key);
+        let currentStreamId: string | null = null;
+
+        if (streamRes.ok) {
+          const stream = await streamRes.json();
+          currentStreamId = stream.stream_id ?? null;
           setStreamId(stream.stream_id);
           setPlaybackId(stream.playback_id);
           setThumbnailUrl(stream.thumbnail_url || null);
@@ -104,17 +111,24 @@ export default function LivePage() {
           setStoryLicenseTermsId(stream.story_license_terms_id ?? null);
           setStoryRevShare(stream.story_commercial_rev_share ?? null);
 
-          // One-time migration: enable recording for channels created before auto-record.
-          if (!recordingEnableRequestedRef.current.has(stream.stream_id)) {
-            recordingEnableRequestedRef.current.add(stream.stream_id);
-            fetch(`/api/livepeer/stream/${encodeURIComponent(stream.stream_id)}/recording`, {
+          try {
+            const keyData = await fetchStreamKeyForCreator(user.address, authHeaders);
+            setStreamKey(keyData.streamKey);
+          } catch (keyErr) {
+            logger.error("Failed to fetch stream key:", keyErr);
+          }
+
+          if (currentStreamId && !recordingEnableRequestedRef.current.has(currentStreamId)) {
+            recordingEnableRequestedRef.current.add(currentStreamId);
+            fetch(`/api/livepeer/stream/${encodeURIComponent(currentStreamId)}/recording`, {
               method: "POST",
             }).catch((err) => logger.error("Failed to enable stream recording:", err));
           }
+        } else if (streamRes.status !== 404) {
+          logger.error("Error fetching stream metadata:", await streamRes.text());
         }
 
         // 2. Fetch multistream targets for the persisted stream
-        const currentStreamId = stream?.stream_id;
         if (!currentStreamId) {
           setMultistreamTargets([]);
           return;
@@ -206,10 +220,14 @@ export default function LivePage() {
   }
 
   async function handleCreateStream() {
+    if (!user?.address) return;
     setIsCreatingStream(true);
     setStreamCreateError(null);
     try {
+      const authHeaders = await getAuthHeaders();
       const result = await createStreamViaProxy({
+        creatorAddress: user.address,
+        authHeaders,
         name: `Broadcast-${Date.now()}`,
         profiles: [
           {
@@ -253,36 +271,15 @@ export default function LivePage() {
         multistream: undefined,
       });
 
-      // Extract stream key and stream ID from response
-      // Livepeer API can return data in different formats:
-      // 1. Direct property: result.streamKey, result.id
-      // 2. Nested in stream object: result.stream.streamKey, result.stream.id
-      const streamKeyValue = result.streamKey || result.stream?.streamKey;
-      const streamIdValue = result.id || result.stream?.id;
-      const playbackIdValue = result.playbackId || result.stream?.playbackId;
+      const streamKeyValue = result.streamKey;
+      const streamIdValue = result.streamId;
+      const playbackIdValue = result.playbackId;
 
       if (streamKeyValue) {
         setStreamKey(streamKeyValue);
         if (streamIdValue) {
           setStreamId(streamIdValue);
           if (playbackIdValue) setPlaybackId(playbackIdValue);
-
-          // Persist the stream to database
-          if (user?.address) {
-            try {
-              await createStreamRecord({
-                creator_id: user.address,
-                stream_key: streamKeyValue,
-                stream_id: streamIdValue,
-                playback_id: result.playbackId || result.stream?.playbackId,
-                name: `Channel-${user.address.slice(0, 6)}`,
-                is_live: false
-              });
-            } catch (persistErr) {
-              logger.error("Failed to persist stream record:", persistErr);
-              // Don't block UI, but warn
-            }
-          }
         }
       } else {
         setStreamCreateError("Stream key not found in response");

--- a/components/Live/Broadcast.tsx
+++ b/components/Live/Broadcast.tsx
@@ -53,31 +53,49 @@ export interface StreamProfile {
 }
 
 export interface CreateStreamProxyParams {
+  creatorAddress: string;
   name: string;
   profiles: StreamProfile[];
   record: boolean;
   playbackPolicy: any;
   multistream?: any;
+  authHeaders: Record<string, string>;
 }
 
 export async function createStreamViaProxy(params: CreateStreamProxyParams) {
-  const { name, profiles, record, playbackPolicy, multistream } = params;
-  const body: any = {
+  const { creatorAddress, name, profiles, record, playbackPolicy, authHeaders } = params;
+  const body = {
+    creatorAddress,
     name,
     profiles,
     record,
     playbackPolicy,
   };
-  if (multistream !== undefined) {
-    body.multistream = multistream;
-  }
   const res = await fetch("/api/livepeer/livepeer-proxy", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeaders },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error("Failed to create stream");
   return res.json();
+}
+
+export async function fetchStreamKeyForCreator(
+  creatorAddress: string,
+  authHeaders: Record<string, string>,
+) {
+  const res = await fetch(
+    `/api/livepeer/stream-key?creatorAddress=${encodeURIComponent(creatorAddress)}`,
+    { headers: authHeaders },
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch stream key");
+  }
+  return res.json() as Promise<{
+    streamId: string;
+    playbackId: string;
+    streamKey: string;
+  }>;
 }
 
 async function finalizeStreamRecordings(streamId: string) {

--- a/components/Live/ClipCreator.tsx
+++ b/components/Live/ClipCreator.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useState } from "react";
 import { useUser } from "@account-kit/react";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -35,6 +36,7 @@ export function ClipCreator({
   parentCommercialRevShare,
 }: ClipCreatorProps) {
   const user = useUser();
+  const { getAuthHeaders } = useWalletAuth();
   const clipperAddress = user?.address;
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -141,9 +143,10 @@ export function ClipCreator({
     setIsMinting(true);
     setError(null);
     try {
+      const authHeaders = await getAuthHeaders();
       const res = await fetch("/api/story/mint-derivative", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
           clipVideoAssetId: clip.clipVideoAssetId,
           recipient: clipperAddress,

--- a/components/Live/StreamIPRegistration.tsx
+++ b/components/Live/StreamIPRegistration.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,6 +36,7 @@ export function StreamIPRegistration({
   commercialRevShare,
   onRegistered,
 }: StreamIPRegistrationProps) {
+  const { getAuthHeaders } = useWalletAuth();
   const [revShare, setRevShare] = useState<string>("10");
   const [isRegistering, setIsRegistering] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -50,9 +52,10 @@ export function StreamIPRegistration({
     setIsRegistering(true);
     setError(null);
     try {
+      const authHeaders = await getAuthHeaders();
       const res = await fetch("/api/story/register-stream", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
           creatorAddress,
           commercialRevShare: share,

--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -22,6 +22,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Info, Loader2 } from "lucide-react";
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { toast } from "sonner";
 import {
   Select,
@@ -109,6 +110,7 @@ function CreatePrediction() {
     walletAddress,
     smartAccountAddress: address,
   } = useWalletStatus();
+  const { getAuthHeaders } = useWalletAuth();
 
   const { openAuthModal } = useAuthModal();
   const { client: accountKitClient } = useSmartAccountClient({});
@@ -388,9 +390,10 @@ function CreatePrediction() {
       logger.debug("✅ Transaction hash:", hash);
 
       try {
+        const authHeaders = await getAuthHeaders();
         const rec = await fetch("/api/predictions/record", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...authHeaders },
           body: JSON.stringify({
             address,
             transactionHash: hash,

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -37,6 +37,7 @@ initBotId({
     { path: '/api/livepeer/sign-jwt', method: 'POST' },
     { path: '/api/livepeer/token-gate', method: 'POST' },
     { path: '/api/livepeer/livepeer-proxy', method: 'POST' },
+    { path: '/api/livepeer/stream-key', method: 'GET' },
     { path: '/api/livepeer', method: 'POST' },
     { path: '/api/livepeer/attestation', method: 'POST' },
     { path: '/api/ai/upload-to-ipfs', method: 'POST' },

--- a/lib/auth/validate-address.ts
+++ b/lib/auth/validate-address.ts
@@ -1,0 +1,10 @@
+/** Lowercase hex Ethereum address (0x + 40 hex chars). */
+export const ETH_ADDRESS_REGEX = /^0x[a-f0-9]{40}$/;
+
+export function isValidEthAddress(address: string): boolean {
+  return ETH_ADDRESS_REGEX.test(address.trim().toLowerCase());
+}
+
+export function normalizeEthAddress(address: string): string {
+  return address.trim().toLowerCase();
+}

--- a/lib/chain/verifyTransactionReceipt.ts
+++ b/lib/chain/verifyTransactionReceipt.ts
@@ -1,5 +1,6 @@
-import type { Hash, TransactionReceipt } from "viem";
+import type { Hash, Transaction, TransactionReceipt } from "viem";
 import { publicClient } from "@/lib/viem";
+import { serverLogger } from "@/lib/utils/logger";
 
 export class TransactionVerificationError extends Error {
   constructor(message: string) {
@@ -18,6 +19,11 @@ export interface VerifyReceiptOptions {
   maxAgeSeconds?: number;
 }
 
+function wrapRpcError(context: string, err: unknown): TransactionVerificationError {
+  serverLogger.warn(`[verifyTransactionReceipt] ${context}:`, err);
+  return new TransactionVerificationError("Unable to verify transaction on-chain");
+}
+
 /**
  * Fetch a successful on-chain transaction receipt on Base.
  */
@@ -30,7 +36,13 @@ export async function getVerifiedTransactionReceipt(
     throw new TransactionVerificationError("Invalid transaction hash format");
   }
 
-  const receipt = await publicClient.getTransactionReceipt({ hash });
+  let receipt: TransactionReceipt | null;
+  try {
+    receipt = await publicClient.getTransactionReceipt({ hash });
+  } catch (err) {
+    throw wrapRpcError("getTransactionReceipt failed", err);
+  }
+
   if (!receipt) {
     throw new TransactionVerificationError("Transaction not found");
   }
@@ -39,12 +51,42 @@ export async function getVerifiedTransactionReceipt(
   }
 
   if (options.maxAgeSeconds != null && options.maxAgeSeconds > 0) {
-    const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
-    const ageSec = Math.floor(Date.now() / 1000) - Number(block.timestamp);
-    if (ageSec > options.maxAgeSeconds) {
-      throw new TransactionVerificationError("Transaction is too old");
+    try {
+      const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
+      const ageSec = Math.floor(Date.now() / 1000) - Number(block.timestamp);
+      if (ageSec > options.maxAgeSeconds) {
+        throw new TransactionVerificationError("Transaction is too old");
+      }
+    } catch (err) {
+      if (err instanceof TransactionVerificationError) {
+        throw err;
+      }
+      throw wrapRpcError("getBlock failed", err);
     }
   }
 
   return { receipt, blockNumber: receipt.blockNumber };
+}
+
+/**
+ * Fetch the original transaction (for `to` / input inspection).
+ */
+export async function getVerifiedTransaction(transactionHash: string): Promise<Transaction> {
+  const hash = transactionHash.trim().toLowerCase() as Hash;
+  if (!/^0x[a-f0-9]{64}$/.test(hash)) {
+    throw new TransactionVerificationError("Invalid transaction hash format");
+  }
+
+  try {
+    const tx = await publicClient.getTransaction({ hash });
+    if (!tx) {
+      throw new TransactionVerificationError("Transaction not found");
+    }
+    return tx;
+  } catch (err) {
+    if (err instanceof TransactionVerificationError) {
+      throw err;
+    }
+    throw wrapRpcError("getTransaction failed", err);
+  }
 }

--- a/lib/chain/verifyTransactionReceipt.ts
+++ b/lib/chain/verifyTransactionReceipt.ts
@@ -1,0 +1,50 @@
+import type { Hash, TransactionReceipt } from "viem";
+import { publicClient } from "@/lib/viem";
+
+export class TransactionVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransactionVerificationError";
+  }
+}
+
+export interface VerifiedReceipt {
+  receipt: TransactionReceipt;
+  blockNumber: bigint;
+}
+
+export interface VerifyReceiptOptions {
+  /** Reject receipts older than this many seconds (by block timestamp). */
+  maxAgeSeconds?: number;
+}
+
+/**
+ * Fetch a successful on-chain transaction receipt on Base.
+ */
+export async function getVerifiedTransactionReceipt(
+  transactionHash: string,
+  options: VerifyReceiptOptions = {},
+): Promise<VerifiedReceipt> {
+  const hash = transactionHash.trim().toLowerCase() as Hash;
+  if (!/^0x[a-f0-9]{64}$/.test(hash)) {
+    throw new TransactionVerificationError("Invalid transaction hash format");
+  }
+
+  const receipt = await publicClient.getTransactionReceipt({ hash });
+  if (!receipt) {
+    throw new TransactionVerificationError("Transaction not found");
+  }
+  if (receipt.status !== "success") {
+    throw new TransactionVerificationError("Transaction did not succeed");
+  }
+
+  if (options.maxAgeSeconds != null && options.maxAgeSeconds > 0) {
+    const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
+    const ageSec = Math.floor(Date.now() / 1000) - Number(block.timestamp);
+    if (ageSec > options.maxAgeSeconds) {
+      throw new TransactionVerificationError("Transaction is too old");
+    }
+  }
+
+  return { receipt, blockNumber: receipt.blockNumber };
+}

--- a/lib/hooks/metokens/useMeTokensSupabase.ts
+++ b/lib/hooks/metokens/useMeTokensSupabase.ts
@@ -8,6 +8,7 @@ import { METOKEN_ABI } from '@/lib/contracts/MeToken';
 import { DAI_TOKEN_ADDRESSES, getDaiTokenContract } from '@/lib/contracts/DAIToken';
 import { useToast } from '@/components/ui/use-toast';
 import { useGasSponsorship } from '@/lib/hooks/wallet/useGasSponsorship';
+import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { logger } from '@/lib/utils/logger';
 import { appendBuilderCode } from "@/lib/utils/builder-code";
 
@@ -101,6 +102,7 @@ export function useMeTokensSupabase(targetAddress?: string) {
   const { client } = useSmartAccountClient({});
   const { toast } = useToast();
   const { getGasContext, isMember } = useGasSponsorship();
+  const { getAuthHeaders } = useWalletAuth();
 
   // Use targetAddress if provided, otherwise use the smart account address from client
   const address = targetAddress || client?.account?.address || user?.address;
@@ -1572,9 +1574,10 @@ You can try creating your MeToken with 0 DAI deposit and add liquidity later.`;
       if (meToken) {
         // Record the transaction with video tracking if provided via API route
         try {
+          const authHeaders = await getAuthHeaders();
           const response = await fetch(`/api/metokens/${meTokenAddress}/transactions`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...authHeaders },
             body: JSON.stringify({
               user_address: address,
               transaction_type: 'mint',
@@ -1610,9 +1613,10 @@ You can try creating your MeToken with 0 DAI deposit and add liquidity later.`;
           const newBalance = parseFloat(formatEther(actualBalance));
           logger.debug(`📊 Syncing balance to Supabase: ${newBalance} (Chain balance: ${actualBalance.toString()})`);
 
+          const authHeaders = await getAuthHeaders();
           const balanceResponse = await fetch(`/api/metokens/${meTokenAddress}/balance`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...authHeaders },
             body: JSON.stringify({
               user_address: address,
               balance: newBalance,
@@ -2019,9 +2023,10 @@ You can try creating your MeToken with 0 DAI deposit and add liquidity later.`;
         // Record the transaction via API route
         // Note: collateralAmountReturned was calculated before the burn for accuracy
         try {
+          const authHeaders = await getAuthHeaders();
           const response = await fetch(`/api/metokens/${meTokenAddress}/transactions`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...authHeaders },
             body: JSON.stringify({
               user_address: address,
               transaction_type: 'burn',
@@ -2055,9 +2060,10 @@ You can try creating your MeToken with 0 DAI deposit and add liquidity later.`;
           const newBalance = parseFloat(formatEther(actualBalance));
           logger.debug(`📊 Syncing balance to Supabase: ${newBalance} (Chain balance: ${actualBalance.toString()})`);
 
+          const authHeaders = await getAuthHeaders();
           const balanceResponse = await fetch(`/api/metokens/${meTokenAddress}/balance`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...authHeaders },
             body: JSON.stringify({
               user_address: address,
               balance: newBalance,

--- a/lib/metokens/verifyMeTokenBalance.ts
+++ b/lib/metokens/verifyMeTokenBalance.ts
@@ -1,6 +1,7 @@
 import { formatEther, parseAbi } from "viem";
 import { publicClient } from "@/lib/viem";
 import { TransactionVerificationError } from "@/lib/chain/verifyTransactionReceipt";
+import { serverLogger } from "@/lib/utils/logger";
 
 const erc20BalanceAbi = parseAbi([
   "function balanceOf(address account) view returns (uint256)",
@@ -25,12 +26,18 @@ export async function verifyMeTokenBalance(
     throw new TransactionVerificationError("Invalid address format");
   }
 
-  const onChainBalance = await publicClient.readContract({
-    address: meTokenAddress as `0x${string}`,
-    abi: erc20BalanceAbi,
-    functionName: "balanceOf",
-    args: [userAddress as `0x${string}`],
-  });
+  let onChainBalance: bigint;
+  try {
+    onChainBalance = await publicClient.readContract({
+      address: meTokenAddress as `0x${string}`,
+      abi: erc20BalanceAbi,
+      functionName: "balanceOf",
+      args: [userAddress as `0x${string}`],
+    });
+  } catch (err) {
+    serverLogger.warn("[verifyMeTokenBalance] readContract failed:", err);
+    throw new TransactionVerificationError("Unable to verify balance on-chain");
+  }
 
   const verifiedBalance = parseFloat(formatEther(onChainBalance));
 

--- a/lib/metokens/verifyMeTokenBalance.ts
+++ b/lib/metokens/verifyMeTokenBalance.ts
@@ -1,0 +1,51 @@
+import { formatEther, parseAbi } from "viem";
+import { publicClient } from "@/lib/viem";
+import { TransactionVerificationError } from "@/lib/chain/verifyTransactionReceipt";
+
+const erc20BalanceAbi = parseAbi([
+  "function balanceOf(address account) view returns (uint256)",
+]);
+
+export interface VerifyMeTokenBalanceParams {
+  meTokenAddress: string;
+  userAddress: string;
+  claimedBalance?: number | string;
+}
+
+/**
+ * Read on-chain MeToken balance for a user. Optionally assert it matches a claimed value.
+ */
+export async function verifyMeTokenBalance(
+  params: VerifyMeTokenBalanceParams,
+): Promise<number> {
+  const meTokenAddress = params.meTokenAddress.trim().toLowerCase();
+  const userAddress = params.userAddress.trim().toLowerCase();
+
+  if (!/^0x[a-f0-9]{40}$/.test(meTokenAddress) || !/^0x[a-f0-9]{40}$/.test(userAddress)) {
+    throw new TransactionVerificationError("Invalid address format");
+  }
+
+  const onChainBalance = await publicClient.readContract({
+    address: meTokenAddress as `0x${string}`,
+    abi: erc20BalanceAbi,
+    functionName: "balanceOf",
+    args: [userAddress as `0x${string}`],
+  });
+
+  const verifiedBalance = parseFloat(formatEther(onChainBalance));
+
+  if (params.claimedBalance != null) {
+    const claimed = Number(params.claimedBalance);
+    if (!Number.isFinite(claimed) || claimed < 0) {
+      throw new TransactionVerificationError("Invalid claimed balance");
+    }
+    const tolerance = Math.max(claimed * 0.01, 1e-9);
+    if (Math.abs(verifiedBalance - claimed) > tolerance) {
+      throw new TransactionVerificationError(
+        "Claimed balance does not match on-chain balanceOf",
+      );
+    }
+  }
+
+  return verifiedBalance;
+}

--- a/lib/metokens/verifyMeTokenTransaction.ts
+++ b/lib/metokens/verifyMeTokenTransaction.ts
@@ -1,6 +1,7 @@
-import { decodeEventLog, formatEther, parseAbi, type Hash } from "viem";
+import { decodeEventLog, formatEther, parseAbi } from "viem";
 import {
   getVerifiedTransactionReceipt,
+  getVerifiedTransaction,
   TransactionVerificationError,
 } from "@/lib/chain/verifyTransactionReceipt";
 
@@ -69,9 +70,7 @@ export async function verifyMeTokenTransaction(
     { maxAgeSeconds: 60 * 60 * 24 * 7 },
   );
 
-  const tx = await import("@/lib/viem").then((m) =>
-    m.publicClient.getTransaction({ hash: params.transactionHash as Hash }),
-  );
+  const tx = await getVerifiedTransaction(params.transactionHash);
 
   const involvedAddresses = new Set(
     receipt.logs.map((log) => log.address.toLowerCase()),

--- a/lib/metokens/verifyMeTokenTransaction.ts
+++ b/lib/metokens/verifyMeTokenTransaction.ts
@@ -1,0 +1,203 @@
+import { decodeEventLog, formatEther, parseAbi, type Hash } from "viem";
+import {
+  getVerifiedTransactionReceipt,
+  TransactionVerificationError,
+} from "@/lib/chain/verifyTransactionReceipt";
+
+const DIAMOND_ADDRESS = "0xba5502db2aC2cBff189965e991C07109B14eB3f5";
+const METOKEN_FACTORY = "0xb31Ae2583d983faa7D8C8304e6A16E414e721A0B";
+
+const transferAbi = parseAbi([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
+
+const meTokenCreatedAbi = parseAbi([
+  "event MeTokenCreated(address indexed meToken, address indexed owner, string name, string symbol)",
+]);
+
+const CREDIT_TYPES = new Set([
+  "mint",
+  "buy",
+  "subscribe",
+  "contribute",
+  "create",
+]);
+
+const DEBIT_TYPES = new Set(["burn", "sell", "unsubscribe", "transfer"]);
+
+export interface VerifyMeTokenTransactionParams {
+  meTokenAddress: string;
+  userAddress: string;
+  transactionHash: string;
+  transactionType: string;
+  claimedAmount?: number | string;
+}
+
+export interface VerifiedMeTokenTransaction {
+  transactionHash: string;
+  blockNumber: bigint;
+  amount: number;
+  userAddress: string;
+  meTokenAddress: string;
+  transactionType: string;
+}
+
+function normalizeAddress(address: string): string {
+  return address.trim().toLowerCase();
+}
+
+function parseTransferAmount(value: bigint): number {
+  return parseFloat(formatEther(value));
+}
+
+/**
+ * Verify a Base-chain MeToken-related transaction involves the user and MeToken.
+ */
+export async function verifyMeTokenTransaction(
+  params: VerifyMeTokenTransactionParams,
+): Promise<VerifiedMeTokenTransaction> {
+  const meTokenAddress = normalizeAddress(params.meTokenAddress);
+  const userAddress = normalizeAddress(params.userAddress);
+  const transactionType = params.transactionType;
+
+  if (!/^0x[a-f0-9]{40}$/.test(meTokenAddress) || !/^0x[a-f0-9]{40}$/.test(userAddress)) {
+    throw new TransactionVerificationError("Invalid address format");
+  }
+
+  const { receipt, blockNumber } = await getVerifiedTransactionReceipt(
+    params.transactionHash,
+    { maxAgeSeconds: 60 * 60 * 24 * 7 },
+  );
+
+  const tx = await import("@/lib/viem").then((m) =>
+    m.publicClient.getTransaction({ hash: params.transactionHash as Hash }),
+  );
+
+  const involvedAddresses = new Set(
+    receipt.logs.map((log) => log.address.toLowerCase()),
+  );
+  const touchesMeToken =
+    involvedAddresses.has(meTokenAddress) ||
+    tx.to?.toLowerCase() === DIAMOND_ADDRESS.toLowerCase() ||
+    tx.to?.toLowerCase() === METOKEN_FACTORY.toLowerCase();
+
+  if (!touchesMeToken) {
+    throw new TransactionVerificationError(
+      "Transaction does not involve the specified MeToken",
+    );
+  }
+
+  if (transactionType === "create") {
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== METOKEN_FACTORY.toLowerCase()) {
+        continue;
+      }
+      try {
+        const decoded = decodeEventLog({
+          abi: meTokenCreatedAbi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName !== "MeTokenCreated") {
+          continue;
+        }
+        const args = decoded.args as { meToken: string; owner: string };
+        if (args.meToken.toLowerCase() !== meTokenAddress) {
+          throw new TransactionVerificationError("MeToken address mismatch in creation tx");
+        }
+        if (args.owner.toLowerCase() !== userAddress) {
+          throw new TransactionVerificationError(
+            "Transaction creator does not match authenticated address",
+          );
+        }
+        return {
+          transactionHash: params.transactionHash.toLowerCase(),
+          blockNumber,
+          amount: params.claimedAmount != null ? Number(params.claimedAmount) : 0,
+          userAddress,
+          meTokenAddress,
+          transactionType,
+        };
+      } catch (err) {
+        if (err instanceof TransactionVerificationError) {
+          throw err;
+        }
+      }
+    }
+    throw new TransactionVerificationError("No MeToken creation event found in transaction");
+  }
+
+  const transfers: { from: string; to: string; value: bigint }[] = [];
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== meTokenAddress) {
+      continue;
+    }
+    try {
+      const decoded = decodeEventLog({
+        abi: transferAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName !== "Transfer") {
+        continue;
+      }
+      const args = decoded.args as { from: string; to: string; value: bigint };
+      transfers.push({
+        from: args.from.toLowerCase(),
+        to: args.to.toLowerCase(),
+        value: args.value,
+      });
+    } catch {
+      // Not a Transfer log.
+    }
+  }
+
+  if (transfers.length === 0) {
+    throw new TransactionVerificationError(
+      "No MeToken Transfer events found in transaction",
+    );
+  }
+
+  let matchedAmount: bigint | null = null;
+
+  if (CREDIT_TYPES.has(transactionType)) {
+    const credit = transfers.find((t) => t.to === userAddress);
+    if (!credit) {
+      throw new TransactionVerificationError(
+        "User did not receive MeTokens in this transaction",
+      );
+    }
+    matchedAmount = credit.value;
+  } else if (DEBIT_TYPES.has(transactionType)) {
+    const debit = transfers.find((t) => t.from === userAddress);
+    if (!debit) {
+      throw new TransactionVerificationError(
+        "User did not send MeTokens in this transaction",
+      );
+    }
+    matchedAmount = debit.value;
+  } else {
+    throw new TransactionVerificationError(`Unsupported transaction_type: ${transactionType}`);
+  }
+
+  const verifiedAmount = parseTransferAmount(matchedAmount);
+  if (params.claimedAmount != null) {
+    const claimed = Number(params.claimedAmount);
+    if (!Number.isFinite(claimed) || claimed < 0) {
+      throw new TransactionVerificationError("Invalid claimed amount");
+    }
+    const tolerance = Math.max(claimed * 0.01, 1e-9);
+    if (Math.abs(verifiedAmount - claimed) > tolerance) {
+      throw new TransactionVerificationError("Claimed amount does not match on-chain transfer");
+    }
+  }
+
+  return {
+    transactionHash: params.transactionHash.toLowerCase(),
+    blockNumber,
+    amount: verifiedAmount,
+    userAddress,
+    meTokenAddress,
+    transactionType,
+  };
+}

--- a/lib/predictions/verifyPredictionCreationTx.ts
+++ b/lib/predictions/verifyPredictionCreationTx.ts
@@ -1,0 +1,70 @@
+import { decodeEventLog, parseAbi, type Hash } from "viem";
+import { getRealityEthContractAddress } from "@/lib/sdk/reality-eth/reality-eth-client";
+import {
+  getVerifiedTransactionReceipt,
+  TransactionVerificationError,
+} from "@/lib/chain/verifyTransactionReceipt";
+
+const logNewQuestionAbi = parseAbi([
+  "event LogNewQuestion(bytes32 indexed question_id, address indexed user, uint256 template_id, string question, bytes32 indexed content_hash, address arbitrator, uint32 timeout, uint32 opening_ts, uint256 nonce, uint256 created)",
+]);
+
+export interface VerifiedPredictionCreation {
+  questionId: Hash;
+  creatorAddress: string;
+  transactionHash: string;
+}
+
+/**
+ * Verify a Base-chain tx created a Reality.eth question for the given creator.
+ */
+export async function verifyPredictionCreationTx(
+  transactionHash: string,
+  creatorAddress: string,
+): Promise<VerifiedPredictionCreation> {
+  const normalizedCreator = creatorAddress.trim().toLowerCase();
+  const { receipt } = await getVerifiedTransactionReceipt(transactionHash, {
+    maxAgeSeconds: 60 * 60 * 24 * 30,
+  });
+
+  const realityAddress = getRealityEthContractAddress().toLowerCase();
+
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== realityAddress) {
+      continue;
+    }
+    try {
+      const decoded = decodeEventLog({
+        abi: logNewQuestionAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName !== "LogNewQuestion") {
+        continue;
+      }
+      const args = decoded.args as {
+        question_id: Hash;
+        user: string;
+      };
+      if (args.user.toLowerCase() !== normalizedCreator) {
+        throw new TransactionVerificationError(
+          "Transaction creator does not match authenticated address",
+        );
+      }
+      return {
+        questionId: args.question_id,
+        creatorAddress: normalizedCreator,
+        transactionHash: transactionHash.toLowerCase(),
+      };
+    } catch (err) {
+      if (err instanceof TransactionVerificationError) {
+        throw err;
+      }
+      // Not a LogNewQuestion log — try next.
+    }
+  }
+
+  throw new TransactionVerificationError(
+    "No valid Reality.eth question creation found in transaction",
+  );
+}

--- a/lib/predictions/verifyPredictionCreationTx.ts
+++ b/lib/predictions/verifyPredictionCreationTx.ts
@@ -28,6 +28,7 @@ export async function verifyPredictionCreationTx(
   });
 
   const realityAddress = getRealityEthContractAddress().toLowerCase();
+  let sawUserMismatch = false;
 
   for (const log of receipt.logs) {
     if (log.address.toLowerCase() !== realityAddress) {
@@ -47,21 +48,23 @@ export async function verifyPredictionCreationTx(
         user: string;
       };
       if (args.user.toLowerCase() !== normalizedCreator) {
-        throw new TransactionVerificationError(
-          "Transaction creator does not match authenticated address",
-        );
+        sawUserMismatch = true;
+        continue;
       }
       return {
         questionId: args.question_id,
         creatorAddress: normalizedCreator,
         transactionHash: transactionHash.toLowerCase(),
       };
-    } catch (err) {
-      if (err instanceof TransactionVerificationError) {
-        throw err;
-      }
+    } catch {
       // Not a LogNewQuestion log — try next.
     }
+  }
+
+  if (sawUserMismatch) {
+    throw new TransactionVerificationError(
+      "Transaction creator does not match authenticated address",
+    );
   }
 
   throw new TransactionVerificationError(


### PR DESCRIPTION
## Summary
- Require `requireWalletAuthFor` on Story, MeToken, Livepeer, and prediction mutation routes so callers must prove wallet ownership before state-changing operations.
- Add on-chain verification helpers for transaction receipts, MeToken activity/balances, and Reality.eth prediction creation before persisting to Supabase.
- Lock down Livepeer stream creation and stream-key access to authenticated owners; update live, MeToken, and prediction clients to send wallet auth headers.

## Test plan
- [ ] Run `npx vitest run app/api/story/**/route.test.ts app/api/metokens/**/route.test.ts app/api/livepeer/livepeer-proxy/route.test.ts app/api/predictions/record/route.test.ts`
- [ ] Create a live stream as an authenticated creator and confirm stream key is returned only after wallet auth
- [ ] Mint/burn a MeToken and confirm transaction + balance sync succeed with signed headers
- [ ] Create a prediction market and confirm quota record requires a valid on-chain `LogNewQuestion` tx
- [ ] Attempt unauthenticated POSTs to hardened routes and confirm 401/403 responses


Made with [Cursor](https://cursor.com)