### PR TITLE
fix: resolve botIdGuard TypeScript build error on Vercel

### DIFF
--- a/lib/middleware/botIdGuard.ts
+++ b/lib/middleware/botIdGuard.ts
@@ -19,8 +19,8 @@ export async function requireHumanOrVerifiedBot(
   if (verification.isBot && !verification.isVerifiedBot) {
     serverLogger.warn("[botIdGuard] access denied", {
       context,
+      isBot: verification.isBot,
       isVerifiedBot: verification.isVerifiedBot,
-      verifiedBotName: verification.verifiedBotName,
     });
 
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Vercel build failure caused by accessing `verification.verifiedBotName` in `lib/middleware/botIdGuard.ts`.

`checkBotId()` from `botid/server` returns a union type. The simpler variant only includes `isHuman`, `isBot`, `isVerifiedBot`, and `bypassed`. `verifiedBotName` exists only on the extended response variant, so unconditional access fails TypeScript during `next build`.

## Changes

- Removed `verifiedBotName` from the denied-access log payload
- Added `isBot` to the log for clearer diagnostics when blocking unverified bots

## Testing

- `yarn vitest run lib/middleware/botIdGuard.test.ts` — all 3 tests pass
- `next build` TypeScript phase completes without the previous type error
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef18c396-0210-4597-85de-d215bb86b72d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef18c396-0210-4597-85de-d215bb86b72d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

