### PR TITLE
Fix Halliday console errors and polish Song Cup hero

### DIFF
--- a/app/api/livepeer/livepeer-proxy/route.test.ts
+++ b/app/api/livepeer/livepeer-proxy/route.test.ts
@@ -9,7 +9,7 @@ const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
 
 const mockRequireHumanOrVerifiedBot = vi.fn();
 const mockRequireWalletAuthFor = vi.fn();
-const mockGetStreamByCreator = vi.fn();
+const mockResolveStreamForCreator = vi.fn();
 const mockCreateStreamRecord = vi.fn();
 const mockFetch = vi.fn();
 
@@ -36,7 +36,7 @@ vi.mock("@/lib/auth/require-wallet", () => ({
 }));
 
 vi.mock("@/services/streams", () => ({
-  getStreamByCreator: (...args: unknown[]) => mockGetStreamByCreator(...args),
+  resolveStreamForCreator: (...args: unknown[]) => mockResolveStreamForCreator(...args),
   createStreamRecord: (...args: unknown[]) => mockCreateStreamRecord(...args),
 }));
 
@@ -79,7 +79,7 @@ describe("POST /api/livepeer/livepeer-proxy", () => {
     vi.clearAllMocks();
     mockRequireHumanOrVerifiedBot.mockResolvedValue({ allowed: true });
     mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
-    mockGetStreamByCreator.mockResolvedValue(null);
+    mockResolveStreamForCreator.mockResolvedValue(null);
     mockCreateStreamRecord.mockResolvedValue({ id: "db-1" });
     process.env.LIVEPEER_FULL_API_KEY = "test-full-key";
     global.fetch = mockFetch as typeof fetch;

--- a/components/Videos/Upload/NFTMintingStep.tsx
+++ b/components/Videos/Upload/NFTMintingStep.tsx
@@ -67,10 +67,7 @@ export function NFTMintingStep({
     (process.env.NEXT_PUBLIC_STORY_POLICY_ID ?? "").replace(/^["']|["']$/g, "").trim()
   );
 
-  const hallidayApiKey =
-    process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() ||
-    process.env.HALLIDAY_API_KEY?.trim() ||
-    null;
+  const hallidayApiKey = process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() || null;
   const hallidayOutputAsset = buildHallidayStoryOutputAsset();
   const hallidayInputAssets = buildHallidayInputAssets();
   const hallidaySandbox = isHallidaySandboxEnabled();

--- a/components/Videos/Upload/NFTMintingStep.tsx
+++ b/components/Videos/Upload/NFTMintingStep.tsx
@@ -7,6 +7,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, InfoIcon, XCircle, CheckCircle, ExternalLink, FuelIcon } from "lucide-react";
 import { CrossChainSwap } from "./CrossChainSwap";
+import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+import {
+  buildHallidayInputAssets,
+  buildHallidayStoryOutputAsset,
+  isHallidaySandboxEnabled,
+} from "@/lib/songchain/halliday";
 import { createStoryPublicClient } from "@/lib/sdk/story/client";
 import { getNFTContractAddress, mintVideoNFT } from "@/lib/sdk/nft/minting-service";
 import { formatEther, type Address } from "viem";
@@ -60,6 +66,14 @@ export function NFTMintingStep({
   const hasStoryPolicy = Boolean(
     (process.env.NEXT_PUBLIC_STORY_POLICY_ID ?? "").replace(/^["']|["']$/g, "").trim()
   );
+
+  const hallidayApiKey =
+    process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() ||
+    process.env.HALLIDAY_API_KEY?.trim() ||
+    null;
+  const hallidayOutputAsset = buildHallidayStoryOutputAsset();
+  const hallidayInputAssets = buildHallidayInputAssets();
+  const hallidaySandbox = isHallidaySandboxEnabled();
 
   useEffect(() => {
     const address = getNFTContractAddress();
@@ -265,6 +279,18 @@ export function NFTMintingStep({
                 }, 3000);
               }}
             />
+
+            {hallidayApiKey && (
+              <HallidayOnramp
+                variant="story"
+                hallidayApiKey={hallidayApiKey}
+                hallidayOutputAsset={hallidayOutputAsset}
+                hallidayInputAssets={hallidayInputAssets}
+                hallidaySandbox={hallidaySandbox}
+                destinationAddressOverride={fundingWalletAddress}
+                lazyInit
+              />
+            )}
           </div>
             )}
           </>

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   initializeClient,
   openHallidayPayments,
@@ -170,6 +170,12 @@ export function HallidayOnramp({
     setInitialized(true);
   }, [hallidayApiKey, initialized, baseParams]);
 
+  useEffect(() => {
+    if (!lazyInit && hallidayApiKey && !lensOnrampBlocked) {
+      void ensureInitialized();
+    }
+  }, [lazyInit, hallidayApiKey, lensOnrampBlocked, ensureInitialized]);
+
   const requireWallet = useCallback((): boolean => {
     if (destinationAddress) return true;
     setError(copy.connectMessage);
@@ -181,21 +187,18 @@ export function HallidayOnramp({
     if (!hallidayApiKey || !requireWallet()) return;
     setError(null);
     try {
-      if (lazyInit) {
-        await ensureInitialized();
-      }
+      await ensureInitialized();
       openHallidayPayments(baseParams);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not open Halliday.");
     }
-  }, [hallidayApiKey, requireWallet, lazyInit, ensureInitialized, baseParams]);
+  }, [hallidayApiKey, requireWallet, ensureInitialized, baseParams]);
 
   if (!hallidayApiKey) {
     return (
       <p className="text-sm text-muted-foreground">
         {copy.missingKeyMessage} — set{" "}
-        <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> (or{" "}
-        <code className="text-xs">HALLIDAY_API_KEY</code> on the server) to enable.
+        <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> to enable.
       </p>
     );
   }

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
-  destroyClient,
   initializeClient,
   openHallidayPayments,
 } from "@halliday-sdk/payments";
@@ -15,14 +14,56 @@ import { Wallet } from "lucide-react";
 
 /** Above app modals (e.g. z-50 nav, z-[99999] selects) so Halliday header stays visible. */
 const HALLIDAY_WIDGET_Z_INDEX = 1_000_000;
-const HALLIDAY_HEADER_TITLE = "Buy GHO";
+
+export type HallidayOnrampVariant = "lens" | "story";
 
 export type HallidayOnrampProps = {
   hallidayApiKey: string | null;
   hallidayOutputAsset: string;
-  /** Fiat or token ids for the pay side, e.g. `["USD"]` for card onramp. */
+  /** Fiat or token ids for the pay side, e.g. `["usd"]` for card onramp. */
   hallidayInputAssets: string[];
   hallidaySandbox: boolean;
+  /** Lens GHO onramp vs Story $IP gas funding. */
+  variant?: HallidayOnrampVariant;
+  /** Override destination (e.g. Story funding wallet). */
+  destinationAddressOverride?: string | null;
+  /** When true, skip mount-time preload; init on button click only. */
+  lazyInit?: boolean;
+};
+
+const VARIANT_COPY: Record<
+  HallidayOnrampVariant,
+  {
+    headerTitle: string;
+    buttonLabel: string;
+    title: string;
+    description: string;
+    connectMessage: string;
+    footer: string;
+    missingKeyMessage: string;
+  }
+> = {
+  lens: {
+    headerTitle: "Buy GHO",
+    buttonLabel: "Get GHO",
+    title: "Fund on Lens Chain",
+    description: "Buy GHO on Lens with debit/credit via Halliday — destination",
+    connectMessage:
+      "Sign in and connect a wallet so funds arrive at your Lens destination address.",
+    footer:
+      "Opens Halliday checkout. Pay by card or bank in the widget to receive GHO at your Lens destination.",
+    missingKeyMessage: "Fund your Lens wallet with GHO via Halliday",
+  },
+  story: {
+    headerTitle: "Buy $IP",
+    buttonLabel: "Buy $IP",
+    title: "Fund Story Protocol Gas",
+    description: "Buy $IP with debit/credit via Halliday — destination",
+    connectMessage: "Connect your wallet so Halliday knows where to send $IP.",
+    footer:
+      "Opens Halliday checkout. Pay by card or bank to top up Story Protocol gas.",
+    missingKeyMessage: "Fund Story Protocol gas with $IP via Halliday",
+  },
 };
 
 export function HallidayOnramp({
@@ -30,7 +71,11 @@ export function HallidayOnramp({
   hallidayOutputAsset,
   hallidayInputAssets,
   hallidaySandbox,
+  variant = "lens",
+  destinationAddressOverride,
+  lazyInit = true,
 }: HallidayOnrampProps) {
+  const copy = VARIANT_COPY[variant];
   const { openAuthModal } = useAuthModal();
   const user = useUser();
   const { client: smartAccountClient, address: smartAccountAddress } =
@@ -38,8 +83,18 @@ export function HallidayOnramp({
   const { lensAccount } = useLensOrbWrite();
 
   const [error, setError] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
 
   const destinationAddress = useMemo(() => {
+    if (destinationAddressOverride) return destinationAddressOverride;
+    if (variant === "story") {
+      return (
+        smartAccountClient?.account?.address ??
+        smartAccountAddress ??
+        user?.address ??
+        null
+      );
+    }
     return (
       lensAccount ??
       smartAccountClient?.account?.address ??
@@ -48,6 +103,8 @@ export function HallidayOnramp({
       null
     );
   }, [
+    destinationAddressOverride,
+    variant,
     lensAccount,
     smartAccountClient?.account?.address,
     smartAccountAddress,
@@ -69,10 +126,9 @@ export function HallidayOnramp({
       outputs: [hallidayOutputAsset],
       sandbox: hallidaySandbox,
       windowType: "MODAL" as const,
-      /** Fiat onramp tab; matches Halliday widget `sessionType` for card/bank pay-in. */
       sessionType: "cash" as const,
       destinationAddress: destinationAddress ?? undefined,
-      headerTitle: HALLIDAY_HEADER_TITLE,
+      headerTitle: copy.headerTitle,
       customStyles: {
         zIndex: HALLIDAY_WIDGET_Z_INDEX,
         backgroundStyle: "BLUR" as const,
@@ -91,45 +147,45 @@ export function HallidayOnramp({
       destinationAddress,
       userWallet,
       openAuthModal,
+      copy.headerTitle,
     ],
   );
 
-  useEffect(() => {
-    if (!hallidayApiKey) return;
-
-    initializeClient({
+  const ensureInitialized = useCallback(async () => {
+    if (!hallidayApiKey || initialized) return;
+    await initializeClient({
       ...baseParams,
       onError: (err) => {
         setError(err.message || "Halliday failed to preload.");
       },
     });
-
-    return () => {
-      destroyClient();
-    };
-  }, [hallidayApiKey, baseParams]);
+    setInitialized(true);
+  }, [hallidayApiKey, initialized, baseParams]);
 
   const requireWallet = useCallback((): boolean => {
     if (destinationAddress) return true;
-    setError("Connect your wallet (or link Orb) so Halliday knows where to send GHO.");
+    setError(copy.connectMessage);
     openAuthModal();
     return false;
-  }, [destinationAddress, openAuthModal]);
+  }, [destinationAddress, openAuthModal, copy.connectMessage]);
 
-  const openOnramp = useCallback(() => {
+  const openOnramp = useCallback(async () => {
     if (!hallidayApiKey || !requireWallet()) return;
     setError(null);
     try {
+      if (lazyInit) {
+        await ensureInitialized();
+      }
       openHallidayPayments(baseParams);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not open Halliday.");
     }
-  }, [hallidayApiKey, requireWallet, baseParams]);
+  }, [hallidayApiKey, requireWallet, lazyInit, ensureInitialized, baseParams]);
 
   if (!hallidayApiKey) {
     return (
       <p className="text-sm text-muted-foreground">
-        Fund your Lens wallet with GHO via Halliday — set{" "}
+        {copy.missingKeyMessage} — set{" "}
         <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> (or{" "}
         <code className="text-xs">HALLIDAY_API_KEY</code> on the server) to enable.
       </p>
@@ -142,39 +198,34 @@ export function HallidayOnramp({
         <div>
           <h3 className="font-semibold flex items-center gap-2">
             <Wallet className="h-4 w-4 text-violet-400" aria-hidden />
-            Fund on Lens Chain
+            {copy.title}
           </h3>
           <p className="text-sm text-muted-foreground">
-            Buy GHO on Lens with debit/credit via Halliday — destination{" "}
+            {copy.description}{" "}
             {destinationAddress
               ? `${destinationAddress.slice(0, 6)}…${destinationAddress.slice(-4)}`
               : "connect wallet"}
           </p>
         </div>
-        <Button type="button" variant="secondary" size="sm" onClick={openOnramp}>
-          Get GHO
+        <Button type="button" variant="secondary" size="sm" onClick={() => void openOnramp()}>
+          {copy.buttonLabel}
         </Button>
       </div>
 
       {error && (
         <p className="mt-3 text-sm text-destructive" role="alert">
           {error}{" "}
-          <button type="button" className="underline" onClick={openOnramp}>
+          <button type="button" className="underline" onClick={() => void openOnramp()}>
             Try again
           </button>
         </p>
       )}
 
       {!destinationAddress && (
-        <p className="mt-3 text-sm text-amber-200/90">
-          Sign in and connect a wallet so funds arrive at your Lens destination address.
-        </p>
+        <p className="mt-3 text-sm text-amber-200/90">{copy.connectMessage}</p>
       )}
 
-      <p className="mt-3 text-xs text-muted-foreground">
-        Opens Halliday checkout. Pay by card or bank in the widget to receive GHO at
-        your Lens destination.
-      </p>
+      <p className="mt-3 text-xs text-muted-foreground">{copy.footer}</p>
     </div>
   );
 }

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -11,6 +11,10 @@ import type { WalletClient } from "viem";
 import { Button } from "@/components/ui/button";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { Wallet } from "lucide-react";
+import {
+  isHallidayLensChainAsset,
+  isHallidayLensOnrampSupported,
+} from "@/lib/songchain/halliday";
 
 /** Above app modals (e.g. z-50 nav, z-[99999] selects) so Halliday header stays visible. */
 const HALLIDAY_WIDGET_Z_INDEX = 1_000_000;
@@ -71,10 +75,14 @@ export function HallidayOnramp({
   hallidayOutputAsset,
   hallidayInputAssets,
   hallidaySandbox,
-  variant = "lens",
+  variant = "story",
   destinationAddressOverride,
   lazyInit = true,
 }: HallidayOnrampProps) {
+  const lensOnrampBlocked =
+    (variant === "lens" || isHallidayLensChainAsset(hallidayOutputAsset)) &&
+    !isHallidayLensOnrampSupported();
+
   const copy = VARIANT_COPY[variant];
   const { openAuthModal } = useAuthModal();
   const user = useUser();
@@ -188,6 +196,18 @@ export function HallidayOnramp({
         {copy.missingKeyMessage} — set{" "}
         <code className="text-xs">NEXT_PUBLIC_HALLIDAY_API_KEY</code> (or{" "}
         <code className="text-xs">HALLIDAY_API_KEY</code> on the server) to enable.
+      </p>
+    );
+  }
+
+  if (lensOnrampBlocked) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Lens GHO onramp via Halliday is temporarily unavailable — Halliday
+        production does not support the Lens chain yet. Bridge or swap GHO on Lens
+        manually, or set{" "}
+        <code className="text-xs">NEXT_PUBLIC_HALLIDAY_LENS_ENABLED=true</code>{" "}
+        after Halliday enables Lens.
       </p>
     );
   }

--- a/components/songchain/SongchainFeedExperience.tsx
+++ b/components/songchain/SongchainFeedExperience.tsx
@@ -8,7 +8,7 @@ import { SongchainGroupPanel } from "@/components/songchain/SongchainGroupPanel"
 import { SongchainGraphPanel } from "@/components/songchain/SongchainGraphPanel";
 import { SongchainComposePost } from "@/components/songchain/SongchainComposePost";
 import { SongchainBookmarksSection } from "@/components/songchain/SongchainBookmarksSection";
-import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+// import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
 import type { SongchainConfig } from "@/lib/songchain/config";
 import type { SongchainFeedHandle } from "@/components/songchain/SongchainFeedSection";
 
@@ -31,12 +31,14 @@ export function SongchainFeedExperience({
       {showWallet && (
         <div className="space-y-6">
           <SongchainOrbConnect />
+          {/* TODO: Re-enable when Halliday supports Lens GHO on production
           <HallidayOnramp
             hallidayApiKey={config.hallidayApiKey}
             hallidayOutputAsset={config.hallidayOutputAsset}
             hallidayInputAssets={config.hallidayInputAssets}
             hallidaySandbox={config.hallidaySandbox}
           />
+          */}
         </div>
       )}
 

--- a/components/songchain/SongchainPageClient.tsx
+++ b/components/songchain/SongchainPageClient.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect";
 import { SongchainLensAdvancedTooltip } from "@/components/songchain/SongchainLensAdvancedTooltip";
-import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+// import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
 import type { SongchainConfig } from "@/lib/songchain/config";
 import { SONGCHAIN_EVENTS } from "@/lib/songchain/events";
 import { Music2, Trophy } from "lucide-react";
@@ -45,12 +45,14 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
 
       <div className="mb-10 space-y-6">
         <SongchainOrbConnect />
+        {/* TODO: Re-enable when Halliday supports Lens GHO on production
         <HallidayOnramp
           hallidayApiKey={config.hallidayApiKey}
           hallidayOutputAsset={config.hallidayOutputAsset}
           hallidayInputAssets={config.hallidayInputAssets}
           hallidaySandbox={config.hallidaySandbox}
         />
+        */}
       </div>
 
       <section aria-labelledby="songchain-events-heading">
@@ -63,8 +65,6 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
         </h2>
         <ul className="grid gap-4 sm:grid-cols-2">
           {SONGCHAIN_EVENTS.map((event) => {
-            const isActive = event.status === "active" && event.href;
-
             const cardContent = (
               <>
                 <span className="text-xs font-semibold uppercase tracking-wider text-violet-400">
@@ -74,7 +74,7 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
                 {event.description && (
                   <span className="mt-1 block text-sm text-violet-200/70">{event.description}</span>
                 )}
-                {isActive && (
+                {event.status === "active" && (
                   <span className="mt-3 inline-block rounded-md bg-gradient-to-r from-[#E82594] to-[#FF66CC] px-3 py-1.5 text-sm font-semibold text-white">
                     Enter event
                   </span>
@@ -82,11 +82,11 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
               </>
             );
 
-            return (
-              <li key={event.slug}>
-                {isActive ? (
+            if (event.status === "active") {
+              return (
+                <li key={event.slug}>
                   <Link
-                    href={event.href!}
+                    href={event.href}
                     className={cn(
                       "block rounded-xl border border-violet-500/30 bg-gradient-to-br from-violet-950/80 to-fuchsia-950/60 p-6",
                       "transition hover:border-violet-400/50 hover:shadow-md",
@@ -94,14 +94,18 @@ export function SongchainPageClient({ config }: SongchainPageClientProps) {
                   >
                     {cardContent}
                   </Link>
-                ) : (
-                  <div
-                    className="block cursor-not-allowed rounded-xl border border-violet-500/15 bg-violet-950/30 p-6 opacity-70"
-                    aria-disabled="true"
-                  >
-                    {cardContent}
-                  </div>
-                )}
+                </li>
+              );
+            }
+
+            return (
+              <li key={event.slug}>
+                <div
+                  className="block cursor-not-allowed rounded-xl border border-violet-500/15 bg-violet-950/30 p-6 opacity-70"
+                  aria-disabled="true"
+                >
+                  {cardContent}
+                </div>
               </li>
             );
           })}

--- a/components/songchain/song-cup/CirclingTextRings.tsx
+++ b/components/songchain/song-cup/CirclingTextRings.tsx
@@ -1,0 +1,39 @@
+import type { CSSProperties } from "react";
+
+const RING_PHRASES = [
+  "Music",
+  "Predict your Winner",
+  "Technology",
+  "Guess the Song",
+  "Fun",
+  "Community",
+  "Art",
+  "2026 Song Cup",
+] as const;
+
+const N_DATA = RING_PHRASES.length;
+
+export function CirclingTextRings() {
+  return (
+    <div className="song-cup-hero-rings" style={{ "--n-data": N_DATA } as CSSProperties}>
+      {RING_PHRASES.map((phrase, p) => (
+        <div
+          key={phrase}
+          className="stage"
+          style={
+            {
+              "--p": p,
+              "--n-char": phrase.length,
+            } as CSSProperties
+          }
+        >
+          {[...phrase].map((char, idx) => (
+            <span key={`${p}-${idx}`} style={{ "--idx": idx } as CSSProperties}>
+              {char}
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/songchain/song-cup/SongCupHero.tsx
+++ b/components/songchain/song-cup/SongCupHero.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "./song-cup-hero.css";
+import { CirclingTextRings } from "./CirclingTextRings";
 import { SongCupLogo } from "./SongCupLogo";
 
 type SongCupHeroProps = {
@@ -46,7 +47,10 @@ export function SongCupHero({ onLetsGoalClick }: SongCupHeroProps) {
         </button>
       </div>
 
-      <PolyhedronFaces />
+      <div className="song-cup-hero-animation" aria-hidden="true">
+        <CirclingTextRings />
+        <PolyhedronFaces />
+      </div>
     </section>
   );
 }

--- a/components/songchain/song-cup/SongCupHero.tsx
+++ b/components/songchain/song-cup/SongCupHero.tsx
@@ -26,14 +26,14 @@ function PolyhedronFaces() {
 export function SongCupHero({ onLetsGoalClick }: SongCupHeroProps) {
   return (
     <section className="song-cup-hero-scene relative min-h-[85vh] w-full overflow-hidden bg-black">
-      <header className="site-header">
-        <div className="site-logo">
+      <div className="site-header">
+        <div className="site-logo" aria-label="Song Cup Contest">
           <SongCupLogo />
         </div>
-      </header>
+      </div>
 
       <div className="song-cup-hero-copy">
-        <p className="song-cup-hero-line">BE OUR TOP ARTIST</p>
+        <h1 className="song-cup-hero-line">BE OUR TOP ARTIST</h1>
         <p className="song-cup-hero-line song-cup-hero-line-sub">
           CREATE YOUR 30 SEC. WORLD CUP MUSIC VIDEO
         </p>

--- a/components/songchain/song-cup/SongCupLogo.tsx
+++ b/components/songchain/song-cup/SongCupLogo.tsx
@@ -3,8 +3,8 @@ export function SongCupLogo() {
     <div className="logo-container">
       <div className="top-row text-glow">
         <span className="letter-s">s</span>
-        <div className="ball-container" aria-label="O" role="text">
-          <svg className="soccer-ball" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <div className="ball-container" aria-hidden="true">
+          <svg className="soccer-ball" viewBox="0 0 100 100" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <radialGradient id="ballGradient" cx="30%" cy="30%" r="70%">
                 <stop offset="0%" stopColor="#ffffff" />

--- a/components/songchain/song-cup/SongCupPlayModal.tsx
+++ b/components/songchain/song-cup/SongCupPlayModal.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -75,6 +76,9 @@ export function SongCupPlayModal({ open, onOpenChange }: SongCupPlayModalProps) 
           <DialogTitle className="text-center text-lg font-bold uppercase tracking-wide text-white">
             Choose how to play
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Pick predict your winner on Orb or guess your artist on Beat Me.
+          </DialogDescription>
         </DialogHeader>
         <div className="mt-6 grid grid-cols-1 gap-10 sm:grid-cols-2 sm:gap-8">
           <PlayCard

--- a/components/songchain/song-cup/SongCupPlayModal.tsx
+++ b/components/songchain/song-cup/SongCupPlayModal.tsx
@@ -77,7 +77,7 @@ export function SongCupPlayModal({ open, onOpenChange }: SongCupPlayModalProps) 
             Choose how to play
           </DialogTitle>
           <DialogDescription className="sr-only">
-            Pick predict your winner on Orb or guess your artist on Beat Me.
+            Predict your winner on Orb or guess your artist on Beat Me.
           </DialogDescription>
         </DialogHeader>
         <div className="mt-6 grid grid-cols-1 gap-10 sm:grid-cols-2 sm:gap-8">

--- a/components/songchain/song-cup/song-cup-hero.css
+++ b/components/songchain/song-cup/song-cup-hero.css
@@ -1,9 +1,13 @@
 
-.s3gon:nth-child(n + 23), .s4gon:nth-child(n + 48), .s5gon:nth-child(n + 7) {
+.song-cup-hero-scene .s3gon:nth-child(n + 23),
+.song-cup-hero-scene .s4gon:nth-child(n + 48),
+.song-cup-hero-scene .s5gon:nth-child(n + 7) {
   --sup: 1;
 }
 
-.s3gon:nth-child(n + 18):nth-child(-n + 27), .s4gon:nth-child(n + 38):nth-last-child(n + 6), .s5gon:nth-child(n + 2):nth-child(-n + 11) {
+.song-cup-hero-scene .s3gon:nth-child(n + 18):nth-child(-n + 27),
+.song-cup-hero-scene .s4gon:nth-child(n + 38):nth-last-child(n + 6),
+.song-cup-hero-scene .s5gon:nth-child(n + 2):nth-child(-n + 11) {
   --mid: 1;
 }
 
@@ -24,14 +28,8 @@
   place-self: center;
 }
 
-.stage {
-  color: #ffffff;
-  text-shadow: 0 0 0.25ch rgba(0,0,0,0.6);
-  font: 700 2.25ch/ 1.5 ubuntu mono, consolas, monaco, monospace;
-  animation: text-move 48s linear calc(((var(--p) - .25)/var(--n-data) - 1)*48s) infinite;
-}
 
-.site-header {
+.song-cup-hero-scene .site-header {
   position: absolute;
   top: 0;
   left: 0;
@@ -43,7 +41,7 @@
   pointer-events: none;
 }
 
-.site-logo {
+.song-cup-hero-scene .site-logo {
   width: min(90vw, 560px);
   max-width: 100%;
   display: block;
@@ -53,7 +51,7 @@
   pointer-events: auto;
 }
 
-.song-cup-hero-copy {
+.song-cup-hero-scene .song-cup-hero-copy {
   position: relative;
   z-index: 20;
   margin-top: clamp(140px, 24vh, 200px);
@@ -66,7 +64,7 @@
   pointer-events: none;
 }
 
-.song-cup-hero-line {
+.song-cup-hero-scene .song-cup-hero-line {
   margin: 0;
   font-size: clamp(1rem, 3.5vw, 1.75rem);
   font-weight: 800;
@@ -76,14 +74,14 @@
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.8);
 }
 
-.song-cup-hero-line-sub {
+.song-cup-hero-scene .song-cup-hero-line-sub {
   font-size: clamp(0.75rem, 2.5vw, 1.125rem);
   font-weight: 600;
   letter-spacing: 0.06em;
   max-width: 36rem;
 }
 
-.song-cup-lets-goal-btn {
+.song-cup-hero-scene .song-cup-lets-goal-btn {
   pointer-events: auto;
   margin-top: 0.75rem;
   border: none;
@@ -99,18 +97,18 @@
   transition: filter 0.2s, box-shadow 0.2s;
 }
 
-.song-cup-lets-goal-btn:hover {
+.song-cup-hero-scene .song-cup-lets-goal-btn:hover {
   filter: brightness(1.1);
   box-shadow: 0 6px 24px rgba(232, 37, 148, 0.55);
 }
 
-.song-cup-lets-goal-btn:focus-visible {
+.song-cup-hero-scene .song-cup-lets-goal-btn:focus-visible {
   outline: 2px solid #ff66cc;
   outline-offset: 3px;
 }
 
 /* Logo typography */
-.logo-container {
+.song-cup-hero-scene .logo-container {
   display: inline-flex;
   flex-direction: column;
   align-items: stretch;
@@ -122,7 +120,7 @@
   font-weight: bold;
 }
 
-.top-row {
+.song-cup-hero-scene .top-row {
   display: flex;
   align-items: baseline;
   position: relative;
@@ -130,16 +128,16 @@
   white-space: nowrap;
 }
 
-.top-row > * {
+.song-cup-hero-scene .top-row > * {
   flex-shrink: 0;
 }
 
-.letter-s {
+.song-cup-hero-scene .letter-s {
   font-size: 65px;
   margin-right: 4px;
 }
 
-.ball-container {
+.song-cup-hero-scene .ball-container {
   position: relative;
   display: inline-flex;
   flex-direction: column;
@@ -149,14 +147,14 @@
   top: 5px;
 }
 
-.soccer-ball {
+.song-cup-hero-scene .soccer-ball {
   width: 75px;
   height: 75px;
   position: relative;
   z-index: 2;
 }
 
-.ball-shadow {
+.song-cup-hero-scene .ball-shadow {
   position: absolute;
   bottom: -6px;
   width: 60px;
@@ -168,16 +166,16 @@
   z-index: 1;
 }
 
-.letter-ng {
+.song-cup-hero-scene .letter-ng {
   font-size: 95px;
 }
 
-.word-cup {
+.song-cup-hero-scene .word-cup {
   font-size: 95px;
   margin-left: 35px;
 }
 
-.bottom-row {
+.song-cup-hero-scene .bottom-row {
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -189,87 +187,72 @@
   white-space: nowrap;
 }
 
-.bottom-row span {
+.song-cup-hero-scene .bottom-row span {
   flex-shrink: 0;
   display: inline;
   grid-area: unset;
   place-self: unset;
 }
 
-.bottom-row span:last-child {
+.song-cup-hero-scene .bottom-row span:last-child {
   padding-right: 8px;
 }
 
-.text-glow {
+.song-cup-hero-scene .text-glow {
   text-shadow: 0px 2px 4px rgba(0, 0, 0, 0.8), 0 0 2px rgba(255, 255, 255, 0.3);
 }
 
 @media (max-width: 600px) {
-  .logo-container {
+  .song-cup-hero-scene .logo-container {
     padding: 12px 18px 12px 12px;
   }
-  .letter-s {
+  .song-cup-hero-scene .letter-s {
     font-size: 40px;
     margin-right: 2px;
   }
-  .letter-ng {
+  .song-cup-hero-scene .letter-ng {
     font-size: 60px;
   }
-  .word-cup {
+  .song-cup-hero-scene .word-cup {
     font-size: 60px;
     margin-left: 15px;
   }
-  .bottom-row {
+  .song-cup-hero-scene .bottom-row {
     font-size: 68px;
     margin-top: -22px;
   }
-  .ball-container {
+  .song-cup-hero-scene .ball-container {
     top: 3px;
     margin-right: 4px;
   }
-  .soccer-ball {
+  .song-cup-hero-scene .soccer-ball {
     width: 50px;
     height: 50px;
   }
-  .ball-shadow {
+  .song-cup-hero-scene .ball-shadow {
     width: 40px;
     height: 6px;
     bottom: -4px;
   }
-  .song-cup-hero-copy {
+  .song-cup-hero-scene .song-cup-hero-copy {
     margin-top: clamp(100px, 18vh, 140px);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .a3d,
-  .s2d {
+  .song-cup-hero-scene .a3d,
+  .song-cup-hero-scene .s2d {
     animation: none !important;
   }
 }
 
-@keyframes text-move {
-  0% {
-    transform: rotate(1turn);
-  }
-}
-span {
-  --pos: rotate(calc((var(--idx) - .5*(var(--n-char) - 1))*2.33635deg)) translatey(-30.63759ch);
-  transform: var(--pos) scale(1.375);
-  animation: text-fade 48s ease-in-out infinite;
-  animation-delay: calc(((var(--p) + var(--idx)/var(--n-char) - .75)/var(--n-data) - 1)*48s);
 }
 
-@keyframes text-fade {
-  15%, 85% {
-    transform: var(--pos) scale(0.625);
-    filter: grayscale(1);
-  }
   50% {
     opacity: 0.15;
   }
 }
-.a3d {
+.song-cup-hero-scene .a3d {
   transform-style: preserve-3d;
   animation: roty 12s linear infinite, size 48s cubic-bezier(0.25, 1, 0.5, 1) infinite;
 }
@@ -286,7 +269,7 @@ span {
 }
 
 /* 3D shape faces - brighter material and rim light so they pop on black */
-.s2d {
+.song-cup-hero-scene .s2d {
   --sup: 0;
   --not-sup: calc(1 - var(--sup));
   --sgn-sup: calc(2*var(--sup) - 1);
@@ -311,7 +294,7 @@ span {
 }
 
 /* White hexagon/triangle faces */
-.s3gon {
+.song-cup-hero-scene .s3gon {
   --i: calc(var(--sgn-sup)*(var(--not-mid)*0.29235 + var(--mid)*0.06007));
   --k: var(--not-xor);
   --hs: 0deg, 0%;
@@ -323,19 +306,19 @@ span {
   border-color: rgba(0,0,0,0.35);
   box-shadow: inset 0 0 1.5ch rgba(0,0,0,0.12), 0 0 0.8ch rgba(255,255,255,0.35);
 }
-.s3gon:nth-child(5n + 13) {
+.song-cup-hero-scene .s3gon:nth-child(5n + 13) {
   --j: calc((0 + .5*var(--sup))/5);
 }
-.s3gon:nth-child(5n + 14) {
+.song-cup-hero-scene .s3gon:nth-child(5n + 14) {
   --j: calc((1 + .5*var(--sup))/5);
 }
-.s3gon:nth-child(5n + 15) {
+.song-cup-hero-scene .s3gon:nth-child(5n + 15) {
   --j: calc((2 + .5*var(--sup))/5);
 }
-.s3gon:nth-child(5n + 16) {
+.song-cup-hero-scene .s3gon:nth-child(5n + 16) {
   --j: calc((3 + .5*var(--sup))/5);
 }
-.s3gon:nth-child(5n + 17) {
+.song-cup-hero-scene .s3gon:nth-child(5n + 17) {
   --j: calc((4 + .5*var(--sup))/5);
 }
 
@@ -357,7 +340,7 @@ span {
 }
 
 /* White square faces */
-.s4gon {
+.song-cup-hero-scene .s4gon {
   --ver: 0;
   --not-ver: calc(1 - var(--ver));
   --i: calc(var(--not-ver)*var(--sgn-sup)*(var(--not-mid)*0.32379 + var(--mid)*0.17621));
@@ -371,22 +354,22 @@ span {
   border-color: rgba(0,0,0,0.35);
   box-shadow: inset 0 0 1.5ch rgba(0,0,0,0.12), 0 0 0.8ch rgba(255,255,255,0.35);
 }
-.s4gon:nth-last-child(n + 11):nth-last-child(-n + 20) {
+.song-cup-hero-scene .s4gon:nth-last-child(n + 11):nth-last-child(-n + 20) {
   --ver: 1;
 }
-.s4gon:nth-child(5n + 33) {
+.song-cup-hero-scene .s4gon:nth-child(5n + 33) {
   --j: calc((0 + var(--not-ver)*var(--not-xor)*.5 + var(--ver)*var(--sgn-sup)*.25)/5);
 }
-.s4gon:nth-child(5n + 34) {
+.song-cup-hero-scene .s4gon:nth-child(5n + 34) {
   --j: calc((1 + var(--not-ver)*var(--not-xor)*.5 + var(--ver)*var(--sgn-sup)*.25)/5);
 }
-.s4gon:nth-child(5n + 35) {
+.song-cup-hero-scene .s4gon:nth-child(5n + 35) {
   --j: calc((2 + var(--not-ver)*var(--not-xor)*.5 + var(--ver)*var(--sgn-sup)*.25)/5);
 }
-.s4gon:nth-child(5n + 36) {
+.song-cup-hero-scene .s4gon:nth-child(5n + 36) {
   --j: calc((3 + var(--not-ver)*var(--not-xor)*.5 + var(--ver)*var(--sgn-sup)*.25)/5);
 }
-.s4gon:nth-child(5n + 37) {
+.song-cup-hero-scene .s4gon:nth-child(5n + 37) {
   --j: calc((4 + var(--not-ver)*var(--not-xor)*.5 + var(--ver)*var(--sgn-sup)*.25)/5);
 }
 
@@ -403,7 +386,7 @@ span {
 }
 
 /* Black pentagon faces */
-.s5gon {
+.song-cup-hero-scene .s5gon {
   --hs: 0deg, 0%;
   --lum: 22%;
   --i: calc(var(--sgn-sup)*(var(--not-mid)*.5 + var(--mid)*0.14758));
@@ -422,23 +405,23 @@ span {
   }
 }
 
-.s5gon:nth-child(1), .s5gon:nth-child(12) {
+.song-cup-hero-scene .s5gon:nth-child(1), .song-cup-hero-scene .s5gon:nth-child(12) {
   filter: brightness(calc(1 - .5*var(--not-sup)));
   animation-name: nos, var(--morph);
 }
-.s5gon:nth-child(5n + 2) {
+.song-cup-hero-scene .s5gon:nth-child(5n + 2) {
   --j: calc((0 + .5*var(--not-sup))/5);
 }
-.s5gon:nth-child(5n + 3) {
+.song-cup-hero-scene .s5gon:nth-child(5n + 3) {
   --j: calc((1 + .5*var(--not-sup))/5);
 }
-.s5gon:nth-child(5n + 4) {
+.song-cup-hero-scene .s5gon:nth-child(5n + 4) {
   --j: calc((2 + .5*var(--not-sup))/5);
 }
-.s5gon:nth-child(5n + 5) {
+.song-cup-hero-scene .s5gon:nth-child(5n + 5) {
   --j: calc((3 + .5*var(--not-sup))/5);
 }
-.s5gon:nth-child(5n + 6) {
+.song-cup-hero-scene .s5gon:nth-child(5n + 6) {
   --j: calc((4 + .5*var(--not-sup))/5);
 }
 

--- a/components/songchain/song-cup/song-cup-hero.css
+++ b/components/songchain/song-cup/song-cup-hero.css
@@ -19,15 +19,73 @@
   perspective-origin: 50% calc(50% - 8rem);
   perspective: 35em;
   background: #000000;
+  isolation: isolate;
 }
 
-.song-cup-hero-scene div:not(.logo-container):not(.top-row):not(.bottom-row):not(.ball-container):not(.ball-shadow),
-.song-cup-hero-scene .a3d span {
+/* 3D rings + polyhedron — stacked in one cell; filters stay inside this subtree */
+.song-cup-hero-scene .song-cup-hero-animation {
+  grid-area: 1 / 1;
+  place-self: center;
   display: grid;
-  grid-area: 1/ 1;
+  width: 100%;
+  min-height: min(70vh, 560px);
+  margin-top: clamp(80px, 14vh, 120px);
+  z-index: 1;
+  pointer-events: none;
+  contain: paint;
+}
+
+.song-cup-hero-scene .song-cup-hero-animation > div {
+  display: grid;
+  grid-area: 1 / 1;
   place-self: center;
 }
 
+.song-cup-hero-scene .song-cup-hero-rings {
+  --n-data: 8;
+  z-index: 1;
+}
+
+.song-cup-hero-scene .stage {
+  display: grid;
+  grid-area: 1 / 1;
+  place-self: center;
+  color: #ffffff;
+  text-shadow: 0 0 0.25ch rgba(0, 0, 0, 0.6);
+  font: 700 2.25ch / 1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  animation: song-cup-text-move 48s linear calc(((var(--p) - 0.25) / var(--n-data) - 1) * 48s)
+    infinite;
+}
+
+.song-cup-hero-scene .stage span {
+  --pos: rotate(calc((var(--idx) - 0.5 * (var(--n-char) - 1)) * 2.33635deg))
+    translatey(-30.63759ch);
+  display: grid;
+  grid-area: 1 / 1;
+  place-self: center;
+  transform: var(--pos) scale(1.375);
+  animation: song-cup-text-fade 48s ease-in-out infinite;
+  animation-delay: calc(
+    ((var(--p) + var(--idx) / var(--n-char) - 0.75) / var(--n-data) - 1) * 48s
+  );
+}
+
+@keyframes song-cup-text-move {
+  0% {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes song-cup-text-fade {
+  15%,
+  85% {
+    transform: var(--pos) scale(0.625);
+    filter: grayscale(1);
+  }
+  50% {
+    opacity: 0.15;
+  }
+}
 
 .song-cup-hero-scene .site-header {
   position: absolute;
@@ -241,18 +299,16 @@
 
 @media (prefers-reduced-motion: reduce) {
   .song-cup-hero-scene .a3d,
-  .song-cup-hero-scene .s2d {
+  .song-cup-hero-scene .s2d,
+  .song-cup-hero-scene .stage,
+  .song-cup-hero-scene .stage span {
     animation: none !important;
   }
 }
 
-}
-
-  50% {
-    opacity: 0.15;
-  }
-}
 .song-cup-hero-scene .a3d {
+  z-index: 2;
+  display: grid;
   transform-style: preserve-3d;
   animation: roty 12s linear infinite, size 48s cubic-bezier(0.25, 1, 0.5, 1) infinite;
 }
@@ -270,6 +326,9 @@
 
 /* 3D shape faces - brighter material and rim light so they pop on black */
 .song-cup-hero-scene .s2d {
+  display: grid;
+  grid-area: 1 / 1;
+  place-self: center;
   --sup: 0;
   --not-sup: calc(1 - var(--sup));
   --sgn-sup: calc(2*var(--sup) - 1);

--- a/lib/songchain/events.ts
+++ b/lib/songchain/events.ts
@@ -1,12 +1,14 @@
 export type SongchainEventStatus = "active" | "upcoming";
 
-export type SongchainEvent = {
+type SongchainEventBase = {
   slug: string;
   title: string;
   description?: string;
-  status: SongchainEventStatus;
-  href?: string;
 };
+
+export type SongchainEvent =
+  | (SongchainEventBase & { status: "active"; href: string })
+  | (SongchainEventBase & { status: "upcoming" });
 
 export const SONGCHAIN_EVENTS: SongchainEvent[] = [
   {

--- a/lib/songchain/halliday.test.ts
+++ b/lib/songchain/halliday.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildHallidayInputAssets,
   buildHallidayOutputAsset,
+  buildHallidayStoryOutputAsset,
   HALLIDAY_DEFAULT_INPUT_ASSETS,
   isHallidaySandboxEnabled,
   LENS_GHO_TOKEN_ADDRESS,
@@ -45,6 +46,27 @@ describe('buildHallidayOutputAsset', () => {
   it('respects full output asset override and normalizes casing', () => {
     process.env.NEXT_PUBLIC_HALLIDAY_OUTPUT_ASSET = 'Lens:0xAbC';
     expect(buildHallidayOutputAsset('mainnet')).toBe('lens:0xabc');
+  });
+});
+
+describe('buildHallidayStoryOutputAsset', () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it('builds story testnet native IP output by default', () => {
+    delete process.env.NEXT_PUBLIC_HALLIDAY_STORY_OUTPUT_ASSET;
+    delete process.env.NEXT_PUBLIC_HALLIDAY_STORY_CHAIN_SLUG;
+    delete process.env.NEXT_PUBLIC_STORY_NETWORK;
+
+    expect(buildHallidayStoryOutputAsset('testnet')).toBe('story-testnet:0x');
+  });
+
+  it('builds story mainnet native IP output', () => {
+    delete process.env.NEXT_PUBLIC_HALLIDAY_STORY_OUTPUT_ASSET;
+    expect(buildHallidayStoryOutputAsset('mainnet')).toBe('story:0x');
   });
 });
 

--- a/lib/songchain/halliday.test.ts
+++ b/lib/songchain/halliday.test.ts
@@ -4,6 +4,8 @@ import {
   buildHallidayOutputAsset,
   buildHallidayStoryOutputAsset,
   HALLIDAY_DEFAULT_INPUT_ASSETS,
+  isHallidayLensChainAsset,
+  isHallidayLensOnrampSupported,
   isHallidaySandboxEnabled,
   LENS_GHO_TOKEN_ADDRESS,
   normalizeHallidayAssetId,
@@ -90,6 +92,30 @@ describe('buildHallidayInputAssets', () => {
   it('falls back to defaults when override is only whitespace or commas', () => {
     process.env.NEXT_PUBLIC_HALLIDAY_INPUT_ASSET = ' , , ';
     expect(buildHallidayInputAssets()).toEqual([...HALLIDAY_DEFAULT_INPUT_ASSETS]);
+  });
+});
+
+describe('isHallidayLensChainAsset', () => {
+  it('detects lens mainnet and testnet assets', () => {
+    expect(isHallidayLensChainAsset(`lens:${LENS_GHO_TOKEN_ADDRESS}`)).toBe(true);
+    expect(isHallidayLensChainAsset('lens-testnet:0xabc')).toBe(true);
+    expect(isHallidayLensChainAsset('story:0x')).toBe(false);
+  });
+});
+
+describe('isHallidayLensOnrampSupported', () => {
+  const env = process.env;
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it('is disabled unless explicitly enabled', () => {
+    delete process.env.NEXT_PUBLIC_HALLIDAY_LENS_ENABLED;
+    expect(isHallidayLensOnrampSupported()).toBe(false);
+
+    process.env.NEXT_PUBLIC_HALLIDAY_LENS_ENABLED = 'true';
+    expect(isHallidayLensOnrampSupported()).toBe(true);
   });
 });
 

--- a/lib/songchain/halliday.ts
+++ b/lib/songchain/halliday.ts
@@ -9,6 +9,15 @@ const DEFAULT_CHAIN_SLUG: Record<LensNetwork, string> = {
   testnet: 'lens-testnet',
 };
 
+const DEFAULT_STORY_CHAIN_SLUG: Record<'mainnet' | 'testnet', string> = {
+  mainnet: 'story',
+  testnet: 'story-testnet',
+};
+
+function getStoryNetwork(): 'mainnet' | 'testnet' {
+  return process.env.NEXT_PUBLIC_STORY_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
+}
+
 function readEnv(...keys: string[]): string | null {
   for (const key of keys) {
     const value = process.env[key]?.trim();
@@ -57,6 +66,26 @@ export function buildHallidayOutputAsset(
 
   const token = (tokenAddress ?? LENS_GHO_TOKEN_ADDRESS).toLowerCase();
   return normalizeHallidayAssetId(`${chainSlug}:${token}`);
+}
+
+/**
+ * Halliday output asset for native $IP on Story Protocol (gas funding).
+ * @see https://docs.halliday.xyz/pages/payments-sdk-docs
+ */
+export function buildHallidayStoryOutputAsset(
+  network: 'mainnet' | 'testnet' = getStoryNetwork(),
+): string {
+  const assetOverride = readEnv(
+    'NEXT_PUBLIC_HALLIDAY_STORY_OUTPUT_ASSET',
+    'HALLIDAY_STORY_OUTPUT_ASSET',
+  );
+  if (assetOverride) return normalizeHallidayAssetId(assetOverride);
+
+  const chainSlug =
+    readEnv('NEXT_PUBLIC_HALLIDAY_STORY_CHAIN_SLUG', 'HALLIDAY_STORY_CHAIN_SLUG') ??
+    DEFAULT_STORY_CHAIN_SLUG[network];
+
+  return normalizeHallidayAssetId(`${chainSlug}:0x`);
 }
 
 export function isHallidaySandboxEnabled(): boolean {

--- a/lib/songchain/halliday.ts
+++ b/lib/songchain/halliday.ts
@@ -93,6 +93,24 @@ export function isHallidaySandboxEnabled(): boolean {
   return value === '1' || value?.toLowerCase() === 'true';
 }
 
+/** True when the Halliday asset id targets Lens mainnet or testnet. */
+export function isHallidayLensChainAsset(asset: string): boolean {
+  const chain = normalizeHallidayAssetId(asset).split(':')[0];
+  return chain === 'lens' || chain === 'lens-testnet';
+}
+
+/**
+ * Halliday production rejects `lens:*` outputs (`Unknown Chain: 'lens'`).
+ * Opt in with NEXT_PUBLIC_HALLIDAY_LENS_ENABLED=true once Halliday ships support.
+ */
+export function isHallidayLensOnrampSupported(): boolean {
+  const value = readEnv(
+    'NEXT_PUBLIC_HALLIDAY_LENS_ENABLED',
+    'HALLIDAY_LENS_ENABLED',
+  );
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
 /**
  * Default fiat input for Halliday onramp (debit/credit → crypto).
  * Single `usd` pre-selects pay currency in the widget; add `eur` via env if needed.


### PR DESCRIPTION
## Summary
- Disable Lens GHO Halliday on Songchain pages until Halliday supports the `lens` chain on production, stopping repeated `available-inputs` 400 console errors.
- Add a Story `$IP` Halliday variant with lazy init in the NFT mint flow so creators can fund Story Protocol gas via card/bank when the funding wallet is low.
- Polish Song Cup hero accessibility (semantic heading, dialog description, scoped CSS) and tighten Songchain event types so active events require `href`.
- Update livepeer-proxy tests to mock `resolveStreamForCreator` after the stream identity migration.

## Test plan
- [ ] Visit `/songchain` and confirm no Halliday `Unknown Chain: 'lens'` errors in the console
- [ ] Upload flow → NFT mint step with low Story gas wallet shows Halliday "Buy $IP" and CrossChainSwap still works
- [ ] Visit `/songchain/song-cup` and verify hero layout, logo animation, and play modal accessibility
- [ ] Run `npx vitest run app/api/livepeer/livepeer-proxy/route.test.ts lib/songchain/halliday.test.ts`


Made with [Cursor](https://cursor.com)