### PR TITLE
Exclude MeTokens submodules from Next.js TypeScript check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "examples",
     "supabase/functions",
     "vitest.config.ts",
-    "subgraphs"
+    "subgraphs",
+    "packages/metokens"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `packages/metokens` to `tsconfig.json` exclude list
- Fixes Vercel build failure after #199 where Next.js typechecked Hardhat submodule configs (`hardhat/config` not installed at app root)

## Test plan
- [ ] Vercel preview build passes on this branch
- [ ] `yarn build` completes locally


Made with [Cursor](https://cursor.com)