### PR TITLE
Align MeTokens subgraph and pipelines with 1.0.3

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -98,7 +98,8 @@ The application supports Goldsky and Graph Studio for blockchain indexing:
 #### MeTokens Subgraphs (Existing Project)
 No configuration is required as these are public endpoints:
 
-- **MeTokens Subgraph (Primary - Goldsky)**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.2/gn`
+- **MeTokens Subgraph (Goldsky fallback)**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.3/gn`
+- **MeTokens Subgraph (Primary - Graph Studio)**: set `GRAPH_STUDIO_CREATIVE_PLATFORM_URL` (deploy tag `1.0.3`)
   - Deployment ID: `QmVaWYhk4HKhk9rNQi11RKujTVS4KHF1uHGNVUF4f7xJ53`
 
 - **Creative TV Subgraph**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/creative_tv/0.1/gn`

--- a/METOKENS_SETUP.md
+++ b/METOKENS_SETUP.md
@@ -10,10 +10,10 @@ The MeTokens subgraph endpoint has CORS restrictions that prevent direct access 
 
 ### 1. Subgraph Configuration
 
-The application now uses **Goldsky** for subgraph indexing, which provides public endpoints that don't require authentication keys.
+The app uses **Graph Studio** as the primary subgraph (`GRAPH_STUDIO_CREATIVE_PLATFORM_URL`, deploy tag **1.0.3**). **Goldsky** `metokens/1.0.3` is the fallback when `SUBGRAPH_PROVIDER_MODE=goldsky` or Studio is unset.
 
-**Primary Subgraph Endpoints (Goldsky):**
-- **MeTokens**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.2/gn`
+**Goldsky fallback endpoint:**
+- **MeTokens**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.3/gn`
   - Deployment ID: `QmVaWYhk4HKhk9rNQi11RKujTVS4KHF1uHGNVUF4f7xJ53`
 - **Creative TV**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/creative_tv/0.1/gn`
   - Deployment ID: `QmbDp8Wfy82g8L7Mv6RCAZHRcYUQB4prQfqchvexfZR8yZ`
@@ -47,7 +47,7 @@ The subgraph endpoints are now using **Goldsky** public APIs:
 
 **MeTokens Subgraph:**
 ```
-https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.2/gn
+https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.3/gn
 ```
 
 **Creative TV Subgraph:**

--- a/SUBGRAPH_PRODUCTION_VERIFICATION.md
+++ b/SUBGRAPH_PRODUCTION_VERIFICATION.md
@@ -7,8 +7,8 @@
 
 ### ✅ API Proxy Configuration
 - **File**: [`app/api/metokens-subgraph/route.ts`](app/api/metokens-subgraph/route.ts)
-- **Subgraph Version**: `1.0.2` ✅ (correctly configured)
-- **Public Endpoint**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.2/gn`
+- **Subgraph Version**: `1.0.3` ✅ (Studio primary; Goldsky fallback in proxy)
+- **Public Endpoint**: `https://api.goldsky.com/api/public/project_cmh0iv6s500dbw2p22vsxcfo6/subgraphs/metokens/1.0.3/gn`
 - **Private Endpoint**: Falls back to public if private is not enabled
 - **CORS**: Handled via API proxy (no client-side CORS issues)
 
@@ -119,7 +119,7 @@ The Market API has its own fallback:
 ## Production Readiness Checklist
 
 ### ✅ Configuration
-- [x] API proxy uses correct subgraph version (`1.0.2`)
+- [x] API proxy uses correct subgraph version (`1.0.3` Goldsky fallback)
 - [x] Public endpoint is accessible
 - [x] No environment variables required (uses defaults)
 - [x] CORS handled via API proxy
@@ -210,7 +210,7 @@ If subgraph has issues and you need the Supabase fallback:
 ✅ **Production Ready**: The subgraph integration is fully functional and production-ready.
 
 **Key Points**:
-- ✅ API proxy correctly configured with version `1.0.2`
+- ✅ API proxy correctly configured with Goldsky fallback version `1.0.3`
 - ✅ All integration points working correctly
 - ✅ Error handling and fallbacks in place
 - ✅ No environment variables required
@@ -225,5 +225,5 @@ If subgraph has issues and you need the Supabase fallback:
 ---
 
 **Last Updated**: 2025-01-22  
-**Subgraph Version**: `1.0.2`  
+**Subgraph Version**: `1.0.3`  
 **Status**: ✅ Production Ready

--- a/docs/METOKENS_CONTRACTS.md
+++ b/docs/METOKENS_CONTRACTS.md
@@ -53,6 +53,12 @@ HUB_SYMBOL=USDC VAULT_ADDRESS=0x... DIAMOND_OWNER_PRIVATE_KEY=0x... \
 
 See [`USDC_HUB_SETUP.md`](USDC_HUB_SETUP.md).
 
+## Subgraph
+
+- **Graph Studio (primary)**: `GRAPH_STUDIO_CREATIVE_PLATFORM_URL` — deploy tag **1.0.3** (`Hub`, `MeTokenBalance`, P2P `Transfer` indexing)
+- **Goldsky (fallback)**: `metokens/1.0.3` — see `METOKENS_GOLDSKY_VERSION` in `lib/subgraph/creative-platform-proxy.ts`
+- **Turbo**: `pipeline-metokens-balances.yaml`, `pipeline-metokens-hubs.yaml`, `pipeline-metokens-all.yaml`
+
 ## Upgrade vs register
 
 - **Upgrade (ERC-2535):** replace facet logic on the existing Diamond via `diamondCut` — see [`METOKENS_UPGRADE_RUNBOOK.md`](METOKENS_UPGRADE_RUNBOOK.md).

--- a/docs/USDC_HUB_SETUP.md
+++ b/docs/USDC_HUB_SETUP.md
@@ -47,20 +47,20 @@ Or call `register(owner, asset, vault, refundRatio, baseY, reserveWeight, encode
 
 USDC on Base: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 
-### 3. Redeploy subgraph (v1.0.3+)
+### 3. Sync Turbo pipelines (subgraph 1.0.3 on Studio)
 
-The subgraph now indexes `Hub` and `MeTokenBalance` entities. After deploy, sync the Turbo pipeline:
+Graph Studio deploy **1.0.3** indexes `Hub` and `MeTokenBalance`. Mirror to Goldsky at the same version, then apply pipelines:
 
 ```bash
-cd subgraphs/creative-platform
-yarn codegen && yarn build
-# Deploy to Graph Studio / Goldsky as metokens 1.0.3
 turbo pipeline apply pipeline-metokens-balances.yaml
+turbo pipeline apply pipeline-metokens-hubs.yaml
+# or sync all MeToken entities:
+turbo pipeline apply pipeline-metokens-all.yaml
 ```
 
 ### 4. Verify in the app
 
-- Open **Create MeToken** — Hub selector should show **Hub 2 — USDC**
+- Open **Create MeToken** — Hub selector should show **Hub 3 — USDC** once registered on-chain
 - Portfolio uses `meTokenBalances(where: { user })` instead of scanning all tokens
 
 ## Subgraph balance index

--- a/lib/subgraph/creative-platform-proxy.ts
+++ b/lib/subgraph/creative-platform-proxy.ts
@@ -6,6 +6,9 @@ export type SubgraphProviderMode = 'goldsky' | 'studio' | 'dual';
 
 const DEFAULT_GOLDSKY_PROJECT_ID = 'project_cmh0iv6s500dbw2p22vsxcfo6';
 
+/** Goldsky MeTokens subgraph version (Studio deploy tag should match). */
+export const METOKENS_GOLDSKY_VERSION = '1.0.3';
+
 export function getSubgraphProviderMode(): SubgraphProviderMode {
   const rawMode = process.env.SUBGRAPH_PROVIDER_MODE?.toLowerCase();
   if (rawMode === 'studio' || rawMode === 'dual' || rawMode === 'goldsky') return rawMode;
@@ -45,12 +48,12 @@ export function resolveSubgraphEndpoints(target: SubgraphProxyTarget): string[] 
   const goldskyPrimary =
     target === 'reality-eth'
       ? getGoldskyUrl('reality-eth', '1.0.0', true, isPrivate ? 'private' : 'public')
-      : getGoldskyUrl('metokens', '1.0.2', false, isPrivate ? 'private' : 'public');
+      : getGoldskyUrl('metokens', METOKENS_GOLDSKY_VERSION, false, isPrivate ? 'private' : 'public');
 
   const goldskyPublicFallback =
     target === 'reality-eth'
       ? getGoldskyUrl('reality-eth', '1.0.0', true, 'public')
-      : getGoldskyUrl('metokens', '1.0.2', false, 'public');
+      : getGoldskyUrl('metokens', METOKENS_GOLDSKY_VERSION, false, 'public');
 
   const endpoints: string[] = [];
 

--- a/pipeline-from-metokens.yaml
+++ b/pipeline-from-metokens.yaml
@@ -6,7 +6,7 @@ sources:
     name: burn
     subgraphs:
       - name: metokens
-        version: v0.0.1
+        version: 1.0.3
     type: subgraph_entity
 transforms: {}
 sinks:

--- a/pipeline-metokens-all.yaml
+++ b/pipeline-metokens-all.yaml
@@ -6,25 +6,37 @@ sources:
     name: subscribe
     subgraphs:
       - name: metokens
-        version: 1.0.2
+        version: 1.0.3
     type: subgraph_entity
   metoken_mints_source:
     name: mint
     subgraphs:
       - name: metokens
-        version: 1.0.2
+        version: 1.0.3
     type: subgraph_entity
   metoken_burns_source:
     name: burn
     subgraphs:
       - name: metokens
-        version: 1.0.2
+        version: 1.0.3
     type: subgraph_entity
   metoken_registers_source:
     name: register
     subgraphs:
       - name: metokens
-        version: 1.0.2
+        version: 1.0.3
+    type: subgraph_entity
+  metoken_hubs_source:
+    name: hub
+    subgraphs:
+      - name: metokens
+        version: 1.0.3
+    type: subgraph_entity
+  metoken_balances_source:
+    name: me_token_balance
+    subgraphs:
+      - name: metokens
+        version: 1.0.3
     type: subgraph_entity
 transforms:
   metoken_subscribes_transform:
@@ -59,6 +71,14 @@ transforms:
         *,
         `timestamp` AS block_timestamp
       FROM metoken_registers_source
+  metoken_hubs_transform:
+    type: sql
+    primary_key: id
+    sql: SELECT * FROM metoken_hubs_source
+  metoken_balances_transform:
+    type: sql
+    primary_key: id
+    sql: SELECT * FROM metoken_balances_source
 sinks:
   postgres_metoken_subscribes:
     from: metoken_subscribes_transform
@@ -83,4 +103,18 @@ sinks:
     schema: public
     secret_name: POSTGRES_SECRET_CMJIQCIFZ0
     table: metoken_registers
+    type: postgres
+  postgres_metoken_hubs:
+    from: metoken_hubs_transform
+    schema: public
+    secret_name: POSTGRES_SECRET_CMJIQCIFZ0
+    table: metoken_hubs
+    primary_key: id
+    type: postgres
+  postgres_metoken_subgraph_balances:
+    from: metoken_balances_transform
+    schema: public
+    secret_name: POSTGRES_SECRET_CMJIQCIFZ0
+    table: metoken_subgraph_balances
+    primary_key: id
     type: postgres

--- a/pipeline-metokens-balances.yaml
+++ b/pipeline-metokens-balances.yaml
@@ -3,28 +3,17 @@ resource_size: s
 apiVersion: 3
 sources:
   metoken_balances_source:
-    name: meTokenBalance
+    name: me_token_balance
     subgraphs:
       - name: metokens
         version: 1.0.3
     type: subgraph_entity
-transforms:
-  metoken_balances_transform:
-    type: sql
-    primary_key: id
-    sql: >-
-      SELECT
-        id,
-        user AS user_address,
-        meToken AS metoken_address,
-        CAST(balance AS DOUBLE) / 1e18 AS balance,
-        updatedAt AS updated_at
-      FROM metoken_balances_source
-      WHERE CAST(balance AS DOUBLE) > 0
+transforms: {}
 sinks:
-  postgres_metoken_balances_sync:
-    from: metoken_balances_transform
+  postgres_metoken_subgraph_balances:
+    from: metoken_balances_source
     schema: public
     secret_name: POSTGRES_SECRET_CMJIQCIFZ0
-    table: metoken_balances
+    table: metoken_subgraph_balances
+    primary_key: id
     type: postgres

--- a/pipeline-metokens-hubs.yaml
+++ b/pipeline-metokens-hubs.yaml
@@ -1,18 +1,19 @@
-name: pipeline-metokens-registers
+name: pipeline-metokens-hubs
 resource_size: s
 apiVersion: 3
 sources:
-  metoken_registers_source:
-    name: register
+  metoken_hubs_source:
+    name: hub
     subgraphs:
       - name: metokens
-        version: v0.0.1
+        version: 1.0.3
     type: subgraph_entity
 transforms: {}
 sinks:
-  postgres_metoken_registers:
-    from: metoken_registers_source
+  postgres_metoken_hubs:
+    from: metoken_hubs_source
     schema: public
     secret_name: POSTGRES_SECRET_CMJIQCIFZ0
-    table: metoken_registers
+    table: metoken_hubs
+    primary_key: id
     type: postgres

--- a/pipeline-metokens-mints.yaml
+++ b/pipeline-metokens-mints.yaml
@@ -6,7 +6,7 @@ sources:
     name: mint
     subgraphs:
       - name: metokens
-        version: v0.0.1
+        version: 1.0.3
     type: subgraph_entity
 transforms: {}
 sinks:

--- a/pipeline-metokens-subscribes.yaml
+++ b/pipeline-metokens-subscribes.yaml
@@ -6,7 +6,7 @@ sources:
     name: subscribe
     subgraphs:
       - name: metokens
-        version: v0.0.1
+        version: 1.0.3
     type: subgraph_entity
 transforms: {}
 sinks:

--- a/scripts/graph-studio/parity-check.ts
+++ b/scripts/graph-studio/parity-check.ts
@@ -28,6 +28,8 @@ async function main() {
     subscribes(first: 20) { id }
     mints(first: 20) { id }
     burns(first: 20) { id }
+    hubs(first: 20) { id }
+    meTokenBalances(first: 20) { id }
   }`;
 
   const realityQuery = `{
@@ -36,8 +38,8 @@ async function main() {
   }`;
 
   const [goldskyMeTokens, studioMeTokens, goldskyReality, studioReality] = await Promise.all([
-    query<{ subscribes: Array<{ id: string }>; mints: Array<{ id: string }>; burns: Array<{ id: string }> }>(goldskyMeTokensUrl, meTokenQuery),
-    query<{ subscribes: Array<{ id: string }>; mints: Array<{ id: string }>; burns: Array<{ id: string }> }>(studioUrl, meTokenQuery),
+    query<{ subscribes: Array<{ id: string }>; mints: Array<{ id: string }>; burns: Array<{ id: string }>; hubs: Array<{ id: string }>; meTokenBalances: Array<{ id: string }> }>(goldskyMeTokensUrl, meTokenQuery),
+    query<{ subscribes: Array<{ id: string }>; mints: Array<{ id: string }>; burns: Array<{ id: string }>; hubs: Array<{ id: string }>; meTokenBalances: Array<{ id: string }> }>(studioUrl, meTokenQuery),
     query<{ questions: Array<{ id: string }>; answers: Array<{ id: string }> }>(goldskyRealityUrl, realityQuery),
     query<{ questions: Array<{ id: string }>; answers: Array<{ id: string }> }>(studioUrl, realityQuery)
   ]);
@@ -55,6 +57,12 @@ async function main() {
   compareCounts("subscribes", goldskyMeTokens.data?.subscribes.length ?? 0, studioMeTokens.data?.subscribes.length ?? 0);
   compareCounts("mints", goldskyMeTokens.data?.mints.length ?? 0, studioMeTokens.data?.mints.length ?? 0);
   compareCounts("burns", goldskyMeTokens.data?.burns.length ?? 0, studioMeTokens.data?.burns.length ?? 0);
+  compareCounts("hubs", goldskyMeTokens.data?.hubs.length ?? 0, studioMeTokens.data?.hubs.length ?? 0);
+  compareCounts(
+    "meTokenBalances",
+    goldskyMeTokens.data?.meTokenBalances.length ?? 0,
+    studioMeTokens.data?.meTokenBalances.length ?? 0
+  );
   compareCounts("questions", goldskyReality.data?.questions.length ?? 0, studioReality.data?.questions.length ?? 0);
   compareCounts("answers", goldskyReality.data?.answers.length ?? 0, studioReality.data?.answers.length ?? 0);
 }

--- a/scripts/graph-studio/parity-check.ts
+++ b/scripts/graph-studio/parity-check.ts
@@ -57,11 +57,11 @@ async function main() {
   compareCounts("subscribes", goldskyMeTokens.data?.subscribes.length ?? 0, studioMeTokens.data?.subscribes.length ?? 0);
   compareCounts("mints", goldskyMeTokens.data?.mints.length ?? 0, studioMeTokens.data?.mints.length ?? 0);
   compareCounts("burns", goldskyMeTokens.data?.burns.length ?? 0, studioMeTokens.data?.burns.length ?? 0);
-  compareCounts("hubs", goldskyMeTokens.data?.hubs.length ?? 0, studioMeTokens.data?.hubs.length ?? 0);
+  compareCounts("hubs", goldskyMeTokens.data?.hubs?.length ?? 0, studioMeTokens.data?.hubs?.length ?? 0);
   compareCounts(
     "meTokenBalances",
-    goldskyMeTokens.data?.meTokenBalances.length ?? 0,
-    studioMeTokens.data?.meTokenBalances.length ?? 0
+    goldskyMeTokens.data?.meTokenBalances?.length ?? 0,
+    studioMeTokens.data?.meTokenBalances?.length ?? 0
   );
   compareCounts("questions", goldskyReality.data?.questions.length ?? 0, studioReality.data?.questions.length ?? 0);
   compareCounts("answers", goldskyReality.data?.answers.length ?? 0, studioReality.data?.answers.length ?? 0);

--- a/subgraphs/creative-platform/README.md
+++ b/subgraphs/creative-platform/README.md
@@ -1,7 +1,7 @@
 # Creative Platform Subgraph
 
 Merged Graph Studio subgraph for the Creative Platform on Base:
-- MeTokens entities: `Subscribe`, `Mint`, `Burn`, `Register` (GraphQL field names match Goldsky `metokens/1.0.2`: `timestamp_`, `block_number`, `transactionHash_`, `contractId_`, etc.)
+- MeTokens entities: `Subscribe`, `Mint`, `Burn`, `Register`, `Hub`, `MeTokenBalance` (GraphQL field names match Goldsky `metokens/1.0.3`: `timestamp_`, `block_number`, `transactionHash_`, `contractId_`, etc.)
 - Reality.eth entities: `Question`, `Answer`
 
 ## MeTokens data source


### PR DESCRIPTION
## Summary
- Bump Goldsky MeTokens fallback from `1.0.2` → `1.0.3` via `METOKENS_GOLDSKY_VERSION` in `lib/subgraph/creative-platform-proxy.ts`
- Update all Turbo pipeline YAMLs to subgraph version `1.0.3`
- Add `pipeline-metokens-balances.yaml` (`me_token_balance` → `metoken_subgraph_balances`)
- Repurpose `pipeline-metokens-hubs.yaml` for `hub` → `metoken_hubs` (was stale `v0.0.1` register-only config)
- Extend `pipeline-metokens-all.yaml` with hub + balance sources/sinks
- Refresh operational docs (`METOKENS_SETUP`, `ENVIRONMENT_SETUP`, `USDC_HUB_SETUP`, etc.)
- Extend Graph Studio parity check to compare `hubs` and `meTokenBalances`

## Not in this PR (manual / on-chain)
- Deploy `metokens/1.0.3` to Goldsky (if using Goldsky fallback or Turbo)
- Apply Turbo pipelines: `turbo pipeline apply pipeline-metokens-balances.yaml` (and/or `pipeline-metokens-all.yaml`)
- Register USDC/USDS/GHO hubs on the Base Diamond

## Test plan
- [ ] Merge and verify `/api/metokens-subgraph` returns `meTokenBalances` / `hubs` against Studio URL
- [ ] After Goldsky 1.0.3 deploy, set `SUBGRAPH_PROVIDER_MODE=goldsky` and smoke-test portfolio holdings
- [ ] Apply updated Turbo pipelines once Goldsky mirrors 1.0.3


Made with [Cursor](https://cursor.com)