### PR TITLE
Fix live stream BotID 403s and enable Deep Analysis

### DIFF
--- a/app/actions/story-actions.ts
+++ b/app/actions/story-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { createServiceClient } from '@/lib/sdk/supabase/service';
 import type { Address } from 'viem';
 import { serverLogger } from '@/lib/utils/logger';
@@ -30,7 +30,7 @@ export async function saveCreatorCollectionAction(
     collectionName: string,
     collectionSymbol: string
 ) {
-    const verification = await checkBotId();
+    const verification = await checkBotIdDeep();
     if (verification.isBot) {
         throw new Error('Access denied');
     }

--- a/app/api/ai/generate-thumbnail/route.ts
+++ b/app/api/ai/generate-thumbnail/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { generateText } from 'ai';
 import { decodeEventLog } from 'viem';
@@ -115,7 +115,7 @@ async function verifyPaymentProof(
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/ai/upload-to-ipfs/route.ts
+++ b/app/api/ai/upload-to-ipfs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { ipfsService } from '@/lib/sdk/ipfs/service';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
@@ -51,7 +51,7 @@ async function urlToFile(url: string, filename: string): Promise<File | null> {
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/coinbase/session-token/route.ts
+++ b/app/api/coinbase/session-token/route.ts
@@ -1,6 +1,6 @@
 "use server";
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { generateJwt } from "@coinbase/cdp-sdk/auth";
 import { verifyMessage } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
@@ -321,7 +321,7 @@ function getClientIp(request: NextRequest): string {
 }
 
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/creator-profiles/link-orb/route.ts
+++ b/app/api/creator-profiles/link-orb/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { getOrbLogin } from '@/lib/sdk/orb/login';
 import { supabaseService } from '@/lib/sdk/supabase/service';
 import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
@@ -7,7 +7,7 @@ import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/creator-profiles/route.ts
+++ b/app/api/creator-profiles/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { supabaseService } from '@/lib/sdk/supabase/service';
 import { createClient } from '@/lib/sdk/supabase/server';
 import { serverLogger } from '@/lib/utils/logger';
@@ -130,7 +130,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
@@ -308,7 +308,7 @@ export async function PUT(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/creator-profiles/upsert/route.ts
+++ b/app/api/creator-profiles/upsert/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { supabaseService } from '@/lib/sdk/supabase/service';
 import { createClient } from '@/lib/sdk/supabase/server';
 import { serverLogger } from '@/lib/utils/logger';
@@ -7,7 +7,7 @@ import { rateLimiters } from '@/lib/middleware/rateLimit';
 import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet';
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/ipfs/upload/route.ts
+++ b/app/api/ipfs/upload/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { groveService } from '@/lib/sdk/grove/service';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 
 export async function POST(request: NextRequest) {
-    const verification = await checkBotId();
+    const verification = await checkBotIdDeep();
     if (verification.isBot) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
     }

--- a/app/api/livepeer/attestation/route.ts
+++ b/app/api/livepeer/attestation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 
 const LIVEPEER_ATTESTATION_BASE = "https://livepeer.studio/api/experiment/-/attestation";
 
@@ -8,7 +8,7 @@ const LIVEPEER_ATTESTATION_BASE = "https://livepeer.studio/api/experiment/-/atte
  * Body: { primaryType, domain, message, signature } (message.timestamp as number for JSON).
  */
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/livepeer/livepeer-proxy/route.test.ts
+++ b/app/api/livepeer/livepeer-proxy/route.test.ts
@@ -7,16 +7,10 @@ vi.mock("viem", () => ({
 
 const CREATOR = "0xcccccccccccccccccccccccccccccccccccccccc";
 
-const mockRequireHumanOrVerifiedBot = vi.fn();
 const mockRequireWalletAuthFor = vi.fn();
 const mockResolveStreamForCreator = vi.fn();
 const mockCreateStreamRecord = vi.fn();
 const mockFetch = vi.fn();
-
-vi.mock("@/lib/middleware/botIdGuard", () => ({
-  requireHumanOrVerifiedBot: (...args: unknown[]) =>
-    mockRequireHumanOrVerifiedBot(...args),
-}));
 
 vi.mock("@/lib/middleware/rateLimit", () => ({
   rateLimiters: { standard: vi.fn(async () => null) },
@@ -77,7 +71,6 @@ function streamRequest(body: Record<string, unknown>) {
 describe("POST /api/livepeer/livepeer-proxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireHumanOrVerifiedBot.mockResolvedValue({ allowed: true });
     mockRequireWalletAuthFor.mockResolvedValue({ address: CREATOR });
     mockResolveStreamForCreator.mockResolvedValue(null);
     mockCreateStreamRecord.mockResolvedValue({ id: "db-1" });

--- a/app/api/livepeer/livepeer-proxy/route.ts
+++ b/app/api/livepeer/livepeer-proxy/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isAddress } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
-import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
 import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 import { createStreamRecord, resolveStreamForCreator } from "@/services/streams";
 import {
@@ -33,11 +32,6 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
-  const botCheck = await requireHumanOrVerifiedBot("livepeer-proxy");
-  if (!botCheck.allowed) {
-    return botCheck.response;
-  }
-
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 

--- a/app/api/livepeer/route.ts
+++ b/app/api/livepeer/route.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 
 export async function GET(request: NextRequest) {
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -1,6 +1,6 @@
 import { signAccessJwt } from "@livepeer/core/crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { getStreamByPlaybackId } from "@/services/streams";
 import {
@@ -14,7 +14,7 @@ import {
 import { resolveVerifiedViewerAddresses } from "@/lib/utils/linked-identity";
 
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/livepeer/stream-key/route.ts
+++ b/app/api/livepeer/stream-key/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 import { resolveStreamForCreator } from "@/services/streams";
@@ -8,10 +7,6 @@ import { resolveStreamForCreator } from "@/services/streams";
  * Owner-only: return RTMP/WHIP stream key for the authenticated creator's channel.
  */
 export async function GET(req: NextRequest) {
-  const botCheck = await requireHumanOrVerifiedBot("livepeer-stream-key");
-  if (!botCheck.allowed) {
-    return botCheck.response;
-  }
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 

--- a/app/api/livepeer/token-gate/route.ts
+++ b/app/api/livepeer/token-gate/route.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { createPublicClient, Address } from "viem";
 import { alchemy, base } from "@account-kit/infra";
 import type { Chain } from "viem";
@@ -43,7 +43,7 @@ export interface WebhookContext {
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/membership/route.ts
+++ b/app/api/membership/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { unlockService } from "@/lib/sdk/unlock/services";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 
 // POST /api/membership
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/metokens/[address]/balance/route.ts
+++ b/app/api/metokens/[address]/balance/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
@@ -13,7 +13,7 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ address: string }> }
 ) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/metokens/[address]/route.ts
+++ b/app/api/metokens/[address]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
@@ -61,7 +61,7 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ address: string }> }
 ) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/metokens/[address]/transactions/route.ts
+++ b/app/api/metokens/[address]/transactions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
@@ -67,7 +67,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ address: string }> }
 ) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/metokens/alchemy/route.ts
+++ b/app/api/metokens/alchemy/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { createClient } from '@/lib/sdk/supabase/server';
 import { MeTokenCreationParams } from '@/lib/sdk/alchemy/metoken-service';
 import { serverLogger } from '@/lib/utils/logger';
@@ -15,7 +15,7 @@ async function getAllchemyService() {
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/metokens/route.ts
+++ b/app/api/metokens/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { createClient } from '@/lib/sdk/supabase/server';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { serverLogger } from '@/lib/utils/logger';
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
 
 // POST /api/metokens - Create a new MeToken
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/metokens/sync/route.ts
+++ b/app/api/metokens/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { meTokensSubgraph } from '@/lib/sdk/metokens/subgraph';
 import { createServiceClient } from '@/lib/sdk/supabase/service';
@@ -13,7 +13,7 @@ import { rateLimiters } from '@/lib/middleware/rateLimit';
 
 // POST /api/metokens/sync - Sync a MeToken from blockchain to database
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/poap-proxy/route.ts
+++ b/app/api/poap-proxy/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { getCachedPoapAccessToken } from "@/lib/utils/poap-auth";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/poap/create-event/route.ts
+++ b/app/api/poap/create-event/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { getCachedPoapAccessToken } from "@/lib/utils/poap-auth";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -9,7 +9,7 @@ import { rateLimiters } from "@/lib/middleware/rateLimit";
  * Creates a POAP event for a Snapshot proposal
  */
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/claim-status/route.ts
+++ b/app/api/predictions/claim-status/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { isAddress, createPublicClient, http, fallback } from "viem";
 import { base } from "@account-kit/infra";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -11,7 +11,7 @@ import { enrichPredictionDisplaySync } from "@/lib/predictions/enrich-prediction
 import { getUserClaimStatus } from "@/lib/predictions/claim-status";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/metadata/route.ts
+++ b/app/api/predictions/metadata/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { supabaseService } from "@/lib/sdk/supabase/service";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/precog/route.ts
+++ b/app/api/predictions/precog/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { fetchPrecogMarket } from "@/lib/predictions/precog-markets";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/quota/route.ts
+++ b/app/api/predictions/quota/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { isAddress } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { supabaseService } from "@/lib/sdk/supabase/service";
@@ -13,7 +13,7 @@ import { unlockService } from "@/lib/sdk/unlock/services";
 import { isPlatformAdmin } from "@/lib/access/platform-admin";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/record/route.ts
+++ b/app/api/predictions/record/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { z } from "zod";
 import { isAddress } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -30,7 +30,7 @@ const bodySchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/predictions/stake-stats/route.ts
+++ b/app/api/predictions/stake-stats/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { serverLogger } from "@/lib/utils/logger";
 import {
@@ -34,7 +34,7 @@ type SubgraphQuestion = {
 };
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/reality-eth-subgraph/route.ts
+++ b/app/api/reality-eth-subgraph/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 import {
@@ -15,7 +15,7 @@ import {
 } from '@/lib/subgraph/creative-platform-proxy';
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/search/market/route.ts
+++ b/app/api/search/market/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { meTokenSupabaseService } from "@/lib/sdk/supabase/metokens";
 
 import { sanitizeAutocompleteQuery } from "@/lib/search/sanitize-autocomplete-query";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/search/predictions/route.ts
+++ b/app/api/search/predictions/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { supabaseService } from "@/lib/sdk/supabase/service";
 
 import { sanitizeAutocompleteQuery } from "@/lib/search/sanitize-autocomplete-query";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/search/videos/route.ts
+++ b/app/api/search/videos/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { supabaseService } from "@/lib/sdk/supabase/service";
 
 import { sanitizeAutocompleteQuery } from "@/lib/search/sanitize-autocomplete-query";
 
 export async function GET(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/factory/deploy-collection/route.ts
+++ b/app/api/story/factory/deploy-collection/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { getStoryRpcUrl } from "@/lib/sdk/story/client";
@@ -30,7 +30,7 @@ const STORY_MAINNET_CHAIN_ID = 1514; // Story mainnet
 const CHAIN_ID = STORY_NETWORK === "mainnet" ? STORY_MAINNET_CHAIN_ID : STORY_TESTNET_CHAIN_ID;
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/mint-derivative/route.ts
+++ b/app/api/story/mint-derivative/route.ts
@@ -4,7 +4,7 @@
  * via the parent's attached PIL license terms.
  */
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { createStoryClient } from "@/lib/sdk/story/client";
 import { getOrCreateCreatorCollection } from "@/lib/sdk/story/collection-service";
@@ -19,7 +19,7 @@ import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/mint/route.ts
+++ b/app/api/story/mint/route.ts
@@ -9,14 +9,14 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { createCollectionAndMintVideoNFTOnStory } from "@/lib/sdk/nft/minting-service";
 import type { Address } from "viem";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/prepare-mint/route.ts
+++ b/app/api/story/prepare-mint/route.ts
@@ -4,7 +4,7 @@
  * and submit via eth_sendRawTransaction (e.g. through /api/story/rpc-proxy).
  */
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { createStoryClient, getStoryRpcUrl } from "@/lib/sdk/story/client";
 import { getOrCreateCreatorCollection } from "@/lib/sdk/story/collection-service";
 import { mintAndRegisterIp } from "@/lib/sdk/story/spg-service";
@@ -26,7 +26,7 @@ function serializeTx(tx: { to: Address; data: `0x${string}`; value?: bigint; gas
 }
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/register-stream/route.ts
+++ b/app/api/story/register-stream/route.ts
@@ -4,7 +4,7 @@
  * minted as derivative IPs with automatic royalty routing to the broadcaster.
  */
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { PILFlavor } from "@story-protocol/core-sdk";
 import { parseEther, type Address } from "viem";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -21,7 +21,7 @@ const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 const DEFAULT_REV_SHARE = 10;
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/story/transfer/route.ts
+++ b/app/api/story/transfer/route.ts
@@ -9,7 +9,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { createStoryPublicClient } from "@/lib/sdk/story/client";
 import { createWalletClient, http, formatEther, type Address } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -17,7 +17,7 @@ import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/swap/execute/route.ts
+++ b/app/api/swap/execute/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import { executeSwap } from '@/lib/sdk/alchemy/swap-client';
 import { BASE_TOKENS, type TokenSymbol } from '@/lib/sdk/alchemy/swap-service';
 import { serverLogger } from '@/lib/utils/logger';
 import { rateLimiters } from '@/lib/middleware/rateLimit';
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/api/unlock-nft/route.ts
+++ b/app/api/unlock-nft/route.ts
@@ -1,10 +1,10 @@
 import { fetchLockAndKey } from "@/lib/sdk/unlock/services";
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 
 export async function POST(req: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/video-assets/[id]/regenerate-thumbnail/route.ts
+++ b/app/api/video-assets/[id]/regenerate-thumbnail/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { getVideoAssetById, updateVideoAsset } from "@/services/video-assets";
 import { regenerateThumbnailFromLivepeer } from "@/lib/utils/thumbnail-regeneration";
 import { serverLogger } from "@/lib/utils/logger";
@@ -8,7 +8,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/video-assets/clips/route.ts
+++ b/app/api/video-assets/clips/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { createClipVideoAsset } from "@/services/video-assets";
 import { getClipThumbnailUrl } from "@/services/livepeer-clips";
@@ -9,7 +9,7 @@ import { serverLogger } from "@/lib/utils/logger";
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
 export async function POST(request: NextRequest) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: "Access denied" }, { status: 403 });
   }

--- a/app/api/video-assets/sync-views/[playbackId]/route.ts
+++ b/app/api/video-assets/sync-views/[playbackId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkBotId } from 'botid/server';
+import { checkBotIdDeep } from '@/lib/middleware/botIdGuard';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createServiceClient } from '@/lib/sdk/supabase/service';
 import { fetchAllViews } from '@/app/api/livepeer/views';
@@ -119,7 +119,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> },
 ) {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
   if (verification.isBot) {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -10,7 +10,7 @@ import { useCreatorWalletAddress } from "@/lib/hooks/accountkit/useCreatorWallet
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { walletAuthHeadersToArgs } from "@/lib/auth/require-wallet";
 import { LivePageClient } from "./LivePageClient";
-import { userMessageForStreamProxyError } from "@/lib/livepeer/stream-proxy-errors";
+import { userMessageForStreamProxyError, StreamProxyError } from "@/lib/livepeer/stream-proxy-errors";
 import { formatWalletAuthError } from "@/lib/auth/format-wallet-auth-error";
 import {
   Breadcrumb,
@@ -49,6 +49,30 @@ import { ShareDialog } from "@/components/Videos/ShareDialog";
 import { ModeratorsDialog } from "@/components/Live/ModeratorsDialog";
 import { DigitalTwinOverlay } from "@/components/Live/DigitalTwinOverlay";
 import { logger } from '@/lib/utils/logger';
+
+async function fetchStreamKeyWithRetry(
+  creatorAddress: string,
+  authHeaders: Record<string, string>,
+  legacyCreatorAddress?: string | null,
+) {
+  try {
+    return await fetchStreamKeyForCreator(
+      creatorAddress,
+      authHeaders,
+      legacyCreatorAddress,
+    );
+  } catch (err) {
+    if (err instanceof StreamProxyError && err.code === "BOTID_DENIED") {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return fetchStreamKeyForCreator(
+        creatorAddress,
+        authHeaders,
+        legacyCreatorAddress,
+      );
+    }
+    throw err;
+  }
+}
 
 
 export default function LivePage() {
@@ -127,7 +151,7 @@ export default function LivePage() {
         const legacy = signerAddress ?? undefined;
 
         try {
-          const keyData = await fetchStreamKeyForCreator(
+          const keyData = await fetchStreamKeyWithRetry(
             creatorAddress,
             authHeaders,
             legacy,

--- a/components/Live/Broadcast.tsx
+++ b/components/Live/Broadcast.tsx
@@ -120,7 +120,7 @@ export async function fetchStreamKeyForCreator(
     headers: authHeaders,
   });
   if (!res.ok) {
-    throw new Error("Failed to fetch stream key");
+    throw await parseStreamProxyFailure(res);
   }
   return res.json() as Promise<{
     streamId: string;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,60 +6,76 @@ import { initBotId } from 'botid/client/core';
  *
  * Orb QR sign-in (/api/auth/orb/qr/init, /api/auth/orb/qr/poll) is intentionally
  * omitted — poll loops every ~1–2s and Kasada/BotID flags that as bot traffic.
+ *
+ * livepeer/stream-key and livepeer/livepeer-proxy omitted: wallet-auth + rate
+ * limits are sufficient; BotID 403 broke Create Stream for legitimate creators.
+ *
+ * checkLevel must match Vercel Firewall → BotID → Deep Analysis and
+ * BOTID_DEEP_ANALYSIS_OPTIONS in lib/middleware/botIdGuard.ts.
  */
-initBotId({
-  protect: [
-    { path: '/api/swap/execute', method: 'POST' },
-    { path: '/api/ipfs/upload', method: 'POST' },
-    { path: '/api/creator-profiles/upsert', method: 'POST' },
-    { path: '/api/creator-profiles/link-orb', method: 'POST' },
-    // Orb QR init/poll omitted: high-frequency polling; rate-limited server routes instead.
-    { path: '/api/creator-profiles', method: 'POST' },
-    { path: '/api/creator-profiles', method: 'PUT' },
-    { path: '/api/creator-profiles', method: 'DELETE' },
-    { path: '/api/story/transfer', method: 'POST' },
-    { path: '/api/story/mint', method: 'POST' },
-    { path: '/api/story/register-stream', method: 'POST' },
-    { path: '/api/story/mint-derivative', method: 'POST' },
-    { path: '/api/story/prepare-mint', method: 'POST' },
-    // rpc-proxy omitted: BotID blocks legitimate client RPC (e.g. eth_getBalance for funding wallet).
-    // metokens-subgraph omitted: read-only GraphQL proxy; BotID 403 breaks portfolio balance queries.
-    { path: '/api/story/factory/deploy-collection', method: 'POST' },
-    { path: '/api/poap/create-event', method: 'POST' },
-    { path: '/api/poap-proxy', method: 'POST' },
-    { path: '/api/metokens/sync', method: 'POST' },
-    { path: '/api/metokens/alchemy', method: 'POST' },
-    { path: '/api/metokens', method: 'POST' },
-    { path: '/api/metokens/*', method: 'PUT' },
-    { path: '/api/metokens/*/balance', method: 'PUT' },
-    // metokens-subgraph: read-only GraphQL proxy — excluded from BotID (see rpc-proxy note above).
-    { path: '/api/membership', method: 'POST' },
-    { path: '/api/livepeer/sign-jwt', method: 'POST' },
-    { path: '/api/livepeer/token-gate', method: 'POST' },
-    { path: '/api/livepeer/livepeer-proxy', method: 'POST' },
-    { path: '/api/livepeer/stream/*/recording', method: 'POST' },
-    { path: '/api/streams/recordings/finalize', method: 'POST' },
-    { path: '/api/livepeer/clips', method: 'POST' },
-    { path: '/api/livepeer/stream-key', method: 'GET' },
-    { path: '/api/livepeer', method: 'POST' },
-    { path: '/api/livepeer/attestation', method: 'POST' },
-    { path: '/api/ai/upload-to-ipfs', method: 'POST' },
-    { path: '/api/ai/generate-thumbnail', method: 'POST' },
-    { path: '/api/unlock-nft', method: 'POST' },
-    { path: '/api/video-assets/sync-views/*', method: 'POST' },
-    { path: '/api/video-assets/*/regenerate-thumbnail', method: 'POST' },
-    { path: '/api/coinbase/session-token', method: 'POST' },
-    { path: '/api/reality-eth-subgraph', method: 'POST' },
-    { path: '/api/metokens/*/transactions', method: 'POST' },
-    { path: '/api/predictions/quota', method: 'GET' },
-    { path: '/api/predictions/record', method: 'POST' },
-    { path: '/api/predictions/metadata', method: 'GET' },
-    { path: '/api/search/videos', method: 'GET' },
-    { path: '/api/search/market', method: 'GET' },
-    { path: '/api/search/predictions', method: 'GET' },
-    // Server actions: pages that invoke saveCreatorCollectionAction (Next.js POSTs to page URL)
-    { path: '/', method: 'POST' },
-    { path: '/studio', method: 'POST' },
-    { path: '/studio/*', method: 'POST' },
-  ],
+const botIdGlobal = globalThis as typeof globalThis & { __crtvBotIdInit?: boolean };
+
+const botIdDeepAnalysisRoute = (path: string, method: string) => ({
+  path,
+  method,
+  advancedOptions: { checkLevel: 'deepAnalysis' as const },
 });
+
+if (!botIdGlobal.__crtvBotIdInit) {
+  botIdGlobal.__crtvBotIdInit = true;
+
+  initBotId({
+    protect: [
+      botIdDeepAnalysisRoute('/api/swap/execute', 'POST'),
+      botIdDeepAnalysisRoute('/api/ipfs/upload', 'POST'),
+      botIdDeepAnalysisRoute('/api/creator-profiles/upsert', 'POST'),
+      botIdDeepAnalysisRoute('/api/creator-profiles/link-orb', 'POST'),
+      // Orb QR init/poll omitted: high-frequency polling; rate-limited server routes instead.
+      botIdDeepAnalysisRoute('/api/creator-profiles', 'POST'),
+      botIdDeepAnalysisRoute('/api/creator-profiles', 'PUT'),
+      botIdDeepAnalysisRoute('/api/creator-profiles', 'DELETE'),
+      botIdDeepAnalysisRoute('/api/story/transfer', 'POST'),
+      botIdDeepAnalysisRoute('/api/story/mint', 'POST'),
+      botIdDeepAnalysisRoute('/api/story/register-stream', 'POST'),
+      botIdDeepAnalysisRoute('/api/story/mint-derivative', 'POST'),
+      botIdDeepAnalysisRoute('/api/story/prepare-mint', 'POST'),
+      // rpc-proxy omitted: BotID blocks legitimate client RPC (e.g. eth_getBalance for funding wallet).
+      // metokens-subgraph omitted: read-only GraphQL proxy; BotID 403 breaks portfolio balance queries.
+      botIdDeepAnalysisRoute('/api/story/factory/deploy-collection', 'POST'),
+      botIdDeepAnalysisRoute('/api/poap/create-event', 'POST'),
+      botIdDeepAnalysisRoute('/api/poap-proxy', 'POST'),
+      botIdDeepAnalysisRoute('/api/metokens/sync', 'POST'),
+      botIdDeepAnalysisRoute('/api/metokens/alchemy', 'POST'),
+      botIdDeepAnalysisRoute('/api/metokens', 'POST'),
+      botIdDeepAnalysisRoute('/api/metokens/*', 'PUT'),
+      botIdDeepAnalysisRoute('/api/metokens/*/balance', 'PUT'),
+      // metokens-subgraph: read-only GraphQL proxy — excluded from BotID (see rpc-proxy note above).
+      botIdDeepAnalysisRoute('/api/membership', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer/sign-jwt', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer/token-gate', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer/stream/*/recording', 'POST'),
+      botIdDeepAnalysisRoute('/api/streams/recordings/finalize', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer/clips', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer', 'POST'),
+      botIdDeepAnalysisRoute('/api/livepeer/attestation', 'POST'),
+      botIdDeepAnalysisRoute('/api/ai/upload-to-ipfs', 'POST'),
+      botIdDeepAnalysisRoute('/api/ai/generate-thumbnail', 'POST'),
+      botIdDeepAnalysisRoute('/api/unlock-nft', 'POST'),
+      botIdDeepAnalysisRoute('/api/video-assets/sync-views/*', 'POST'),
+      botIdDeepAnalysisRoute('/api/video-assets/*/regenerate-thumbnail', 'POST'),
+      botIdDeepAnalysisRoute('/api/coinbase/session-token', 'POST'),
+      botIdDeepAnalysisRoute('/api/reality-eth-subgraph', 'POST'),
+      botIdDeepAnalysisRoute('/api/metokens/*/transactions', 'POST'),
+      botIdDeepAnalysisRoute('/api/predictions/quota', 'GET'),
+      botIdDeepAnalysisRoute('/api/predictions/record', 'POST'),
+      botIdDeepAnalysisRoute('/api/predictions/metadata', 'GET'),
+      botIdDeepAnalysisRoute('/api/search/videos', 'GET'),
+      botIdDeepAnalysisRoute('/api/search/market', 'GET'),
+      botIdDeepAnalysisRoute('/api/search/predictions', 'GET'),
+      // Server actions: pages that invoke saveCreatorCollectionAction (Next.js POSTs to page URL)
+      botIdDeepAnalysisRoute('/', 'POST'),
+      botIdDeepAnalysisRoute('/studio', 'POST'),
+      botIdDeepAnalysisRoute('/studio/*', 'POST'),
+    ],
+  });
+}

--- a/lib/middleware/botIdGuard.ts
+++ b/lib/middleware/botIdGuard.ts
@@ -4,9 +4,19 @@ import { serverLogger } from "@/lib/utils/logger";
 
 export const BOTID_DENIED_CODE = "BOTID_DENIED" as const;
 
+/** Must match Vercel Firewall → BotID → Deep Analysis and instrumentation-client.ts. */
+export const BOTID_DEEP_ANALYSIS_OPTIONS = {
+  advancedOptions: { checkLevel: "deepAnalysis" as const },
+} satisfies NonNullable<Parameters<typeof checkBotId>[0]>;
+
 export type BotIdGuardResult =
   | { allowed: true }
   | { allowed: false; response: NextResponse };
+
+/** Server-side BotID check using Deep Analysis (Kasada). */
+export async function checkBotIdDeep() {
+  return checkBotId(BOTID_DEEP_ANALYSIS_OPTIONS);
+}
 
 /**
  * Run BotID verification. Blocks unverified bots; allows humans and verified bots.
@@ -14,7 +24,7 @@ export type BotIdGuardResult =
 export async function requireHumanOrVerifiedBot(
   context?: string,
 ): Promise<BotIdGuardResult> {
-  const verification = await checkBotId();
+  const verification = await checkBotIdDeep();
 
   if (verification.isBot && !verification.isVerifiedBot) {
     serverLogger.warn("[botIdGuard] access denied", {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@xmtp/browser-sdk": "^5.0.1",
     "ai": "^4.0.0",
     "alchemy-sdk": "^3.6.5",
-    "botid": "^1.5.10",
+    "botid": "^1.5.11",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ importers:
         specifier: ^3.6.5
         version: 3.6.5(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       botid:
-        specifier: ^1.5.10
+        specifier: ^1.5.11
         version: 1.5.11(next@16.2.4(patch_hash=0972eee94825cc241ce5b5d29fee118e3c0a18bd26640a1590095c564702165d)(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       browser-image-compression:
         specifier: ^2.0.2
@@ -16531,7 +16531,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1


### PR DESCRIPTION
## Summary

- Fixes **Create Stream** and live studio 403 errors caused by broken BotID/Kasada verification (`is-bot` 400 → 403 on protected routes).
- Excludes wallet-authenticated live routes (`/api/livepeer/stream-key`, `/api/livepeer/livepeer-proxy`) from BotID; wallet signature + rate limiting remain the security boundary.
- Makes `initBotId()` idempotent to prevent `KPSDK has already been configured` console errors.
- Upgrades `botid` to **1.5.11** and enables **Deep Analysis** consistently via `checkBotIdDeep()` and matching `checkLevel: 'deepAnalysis'` on all protected client routes.
- Improves live page error handling (`parseStreamProxyFailure`, single retry on `BOTID_DENIED`).
- Also includes prior **infra updates** commit: agent skills, membership guard, and wallet auth hook adjustments.

## Dashboard

After merge, enable **Vercel Firewall → BotID → Deep Analysis** (client and server are now aligned).

## Test plan

- [ ] Deploy preview and open `/live/{creatorAddress}` — `GET /api/livepeer/stream-key` returns 404 (no stream) or 200, not 403
- [ ] Click **Create Stream** — `POST /api/livepeer/livepeer-proxy` returns 200/409, not 403
- [ ] Console: no repeating `KPSDK has already been configured` or `c.js` error spam
- [ ] Protected routes (e.g. swap, upload) still return 403 for direct curl without BotID headers
- [ ] `vitest run lib/middleware/botIdGuard.test.ts app/api/livepeer/livepeer-proxy/route.test.ts`


Made with [Cursor](https://cursor.com)