### PR TITLE
Footer branding, apps drawer, and USD wallet balances

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,14 +3,12 @@ import Image from "next/image";
 import { SITE_LOGO } from "@/context/context";
 
 export default function Component() {
-  // Get current Year
   const currentYear = new Date().getFullYear();
 
   return (
     <footer className="w-full border-t bg-[#F7F7F7] dark:bg-gray-950 dark:border-gray-800 py-4 md:py-2.5">
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex flex-col md:flex-row items-center justify-between gap-4 md:gap-0">
-          {/* Logo */}
           <Link href="/" className="flex items-center" prefetch={false}>
             <Image
               src={SITE_LOGO}
@@ -27,89 +25,17 @@ export default function Component() {
             </h1>
           </Link>
 
-          <div className="flex flex-col md:flex-row items-center gap-2 md:gap-4">
-            <Link
-              href="https://app.creativeplatform.xyz"
-              className="flex items-center text-[13px] text-gray-600 dark:text-gray-300 \
-                hover:text-red-600 dark:hover:text-red-400 focus-visible:text-red-600 dark:focus-visible:text-red-400 \
-                transition-colors duration-300 ease-in-out group"
-              prefetch={false}
-            >
-              <PowerIcon
-                className="h-[18px] w-[18px] mr-1 group-hover:stroke-red-600 \
-                  dark:group-hover:stroke-red-400 transition-colors duration-300 ease-in-out"
-              />
-              Exit dApp
-            </Link>
-
-            <Link
-              href="https://creativeplatform.xyz"
-              prefetch={false}
-              className="text-xs text-gray-500 dark:text-gray-400 text-center md:text-left \
-                hover:text-red-600 dark:hover:text-red-400 focus-visible:text-red-600 dark:focus-visible:text-red-400 \
-                transition-colors duration-300 ease-in-out"
-            >
-              © {currentYear} Creative Organization DAO. All rights reserved.
-            </Link>
-          </div>
+          <Link
+            href="https://creativeplatform.xyz"
+            prefetch={false}
+            className="text-xs text-gray-500 dark:text-gray-400 text-center md:text-left \
+              hover:text-red-600 dark:hover:text-red-400 focus-visible:text-red-600 dark:focus-visible:text-red-400 \
+              transition-colors duration-300 ease-in-out"
+          >
+            © {currentYear} Creative Platform, Inc. All rights reserved.
+          </Link>
         </div>
       </div>
     </footer>
-  );
-}
-
-function MountainIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="m8 3 4 8 5-5 5 15H2L8 3z" />
-    </svg>
-  );
-}
-
-function PowerIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 3v9M5.63 5.64a9 9 0 1 0 12.74 0" />
-    </svg>
-  );
-}
-
-function XIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
   );
 }

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -293,6 +293,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
   const [isArrowUp, setIsArrowUp] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const [balanceRefreshKey, setBalanceRefreshKey] = useState(0);
   const [dialogAction, setDialogAction] = useState<
     "buy" | "send" | "swap" | "session-keys"
   >("buy");
@@ -727,8 +728,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
       setSelectedNFT(null);
       setSendType('token');
 
-      // Refresh balances - refetch on next render
-      // Token balances will be refreshed on next component update
+      setBalanceRefreshKey((key) => key + 1);
     } catch (error: unknown) {
       logger.error("Error sending transaction:", error);
       toast({
@@ -1056,6 +1056,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               <AlchemySwapWidget
                 onSwapSuccess={() => {
                   setIsDialogOpen(false);
+                  setBalanceRefreshKey((key) => key + 1);
                   toast({
                     title: "Swap Completed",
                     description: "Your token swap was successful!",
@@ -1639,7 +1640,10 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
 
             {/* Balances Section */}
             <div className="px-2 py-2">
-              <TokenBalance />
+              <TokenBalance
+                isVisible={isDropdownOpen}
+                refreshKey={balanceRefreshKey}
+              />
             </div>
 
             {shouldShowMetokens && (

--- a/components/navbar/CreativePlatformAppsDrawer.tsx
+++ b/components/navbar/CreativePlatformAppsDrawer.tsx
@@ -10,7 +10,6 @@ import {
   Disc3,
   Gamepad2,
   Mic,
-  Music2,
   ExternalLink,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -56,12 +55,6 @@ const CREATIVE_PLATFORM_APPS = [
     href: "https://air.creativeplatform.xyz/app",
     icon: Disc3,
     description: "Curate and share music mixes",
-  },
-  {
-    name: "Songchain",
-    href: "/songchain",
-    icon: Music2,
-    description: "Lens music feeds and community on TV",
   },
   {
     name: "Beat Me",

--- a/components/wallet/balance/TokenBalance.tsx
+++ b/components/wallet/balance/TokenBalance.tsx
@@ -1,239 +1,151 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useSmartAccountClient, useUser, useChain } from "@account-kit/react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { formatUnits, createPublicClient, http } from "viem";
-import { getUsdcTokenContract } from "@/lib/contracts/USDCToken";
-import { getDaiTokenContract } from "@/lib/contracts/DAIToken";
-import { getUsdsTokenContract } from "@/lib/contracts/USDSToken";
-import { getGhoTokenContract } from "@/lib/contracts/GHOToken";
+import { formatUnits } from "viem";
 import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
-import { logger } from '@/lib/utils/logger';
-import { getTokenIcon } from '@/lib/utils/token-icons';
+import { getTokenIcon } from "@/lib/utils/token-icons";
+import { useTokenBalances } from "@/lib/hooks/wallet/useTokenBalances";
+import { PriceService } from "@/lib/sdk/alchemy/price-service";
+import { TOKEN_INFO, type TokenSymbol } from "@/lib/sdk/alchemy/swap-service";
 
+type TokenBalanceProps = {
+  /** Refetch when the parent menu becomes visible (e.g. account dropdown opens). */
+  isVisible?: boolean;
+  /** Increment to force a balance refresh after send/swap. */
+  refreshKey?: number;
+};
 
-interface TokenBalanceData {
-  symbol: string;
-  balance: string;
-  isLoading: boolean;
-  error: string | null;
-}
-
-// Utility function to format balance with proper precision (without symbol)
 function formatBalance(balance: string): string {
-  // Convert to number for comparison
   const num = parseFloat(balance);
   if (num <= 0) return "0";
-  if (num < 0.000001) return "< 0.000001"; // Very small non-zero
+  if (num < 0.000001) return "< 0.000001";
 
-  // For small numbers (less than 1), show up to 6 decimals
   if (num < 1) {
-    return new Intl.NumberFormat('en-US', {
+    return new Intl.NumberFormat("en-US", {
       maximumFractionDigits: 6,
       minimumFractionDigits: 0,
-      useGrouping: false // Don't use commas for decimals
+      useGrouping: false,
     }).format(num);
   }
 
-  // For larger numbers, show up to 4 decimals
-  return new Intl.NumberFormat('en-US', {
+  return new Intl.NumberFormat("en-US", {
     maximumFractionDigits: 4,
     minimumFractionDigits: 0,
-    useGrouping: true
+    useGrouping: true,
   }).format(num);
 }
 
-export function TokenBalance() {
+const TOKEN_ROWS: TokenSymbol[] = ["ETH", "USDC", "DAI", "USDS", "GHO"];
+
+export function TokenBalance({ isVisible, refreshKey = 0 }: TokenBalanceProps) {
   const { client } = useSmartAccountClient({});
   const user = useUser();
   const { chain } = useChain();
-  const [ethBalance, setEthBalance] = useState<bigint | null>(null);
-  const [usdcBalance, setUsdcBalance] = useState<bigint | null>(null);
-  const [daiBalance, setDaiBalance] = useState<bigint | null>(null);
-  const [usdsBalance, setUsdsBalance] = useState<bigint | null>(null);
-  const [ghoBalance, setGhoBalance] = useState<bigint | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const address = client?.account?.address || user?.address;
+
+  const { balances, prices, isLoading, error, refetch } = useTokenBalances(
+    address,
+    chain
+  );
 
   useEffect(() => {
-    let isMounted = true;
-    let abortController: AbortController | null = null;
-
-    async function getBalances() {
-      if (!isMounted) return;
-
-      // Create a new AbortController for this effect
-      abortController = new AbortController();
-      const signal = abortController.signal;
-
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const address = client?.account?.address || user?.address;
-        if (!address || !chain) {
-          if (isMounted && !signal.aborted) {
-            setEthBalance(null);
-            setUsdcBalance(null);
-            setDaiBalance(null);
-            setIsLoading(false);
-          }
-          return;
-        }
-
-        // Map chain.id to key for token contracts
-        let chainKey: keyof typeof import("@/lib/contracts/USDCToken").USDC_TOKEN_ADDRESSES;
-        if (chain.id === 8453) chainKey = "base";
-        else {
-          logger.warn(`Unsupported chain ID: ${chain.id}`);
-          if (isMounted && !signal.aborted) {
-            setError(`Unsupported chain (ID: ${chain.id})`);
-            setEthBalance(null);
-            setUsdcBalance(null);
-            setDaiBalance(null);
-            setIsLoading(false);
-          }
-          return;
-        }
-
-        const publicClient = createPublicClient({
-          chain,
-          transport: http(),
-        });
-
-        // Get ETH balance
-        try {
-          if (!isMounted || signal.aborted) return;
-          const ethBalance = await publicClient.getBalance({
-            address: address as `0x${string}`
-          });
-          if (isMounted && !signal.aborted) {
-            setEthBalance(ethBalance);
-          }
-        } catch (error) {
-          if (isMounted && !signal.aborted) {
-            logger.error("Error fetching ETH balance:", error);
-            setEthBalance(null);
-          }
-        }
-
-        // ERC-20 balances (Base hub collateral stables)
-        const erc20Tokens = [
-          { symbol: 'USDC', contract: getUsdcTokenContract(chainKey), setter: setUsdcBalance },
-          { symbol: 'DAI', contract: getDaiTokenContract(chainKey), setter: setDaiBalance },
-          { symbol: 'USDS', contract: getUsdsTokenContract(chainKey), setter: setUsdsBalance },
-          { symbol: 'GHO', contract: getGhoTokenContract(chainKey), setter: setGhoBalance },
-        ] as const;
-
-        for (const { contract, setter } of erc20Tokens) {
-          try {
-            if (!isMounted || signal.aborted) return;
-            const balance = (await publicClient.readContract({
-              address: contract.address,
-              abi: contract.abi,
-              functionName: "balanceOf",
-              args: [address as `0x${string}`],
-            })) as bigint;
-            if (isMounted && !signal.aborted) {
-              setter(balance);
-            }
-          } catch (error) {
-            if (isMounted && !signal.aborted) {
-              logger.error(`Error fetching ${contract.symbol} balance:`, error);
-              setter(null);
-            }
-          }
-        }
-      } catch (error) {
-        if (isMounted && !signal.aborted) {
-          logger.error("Error fetching balances:", error);
-          setError(error instanceof Error ? error.message : "Unknown error");
-          setEthBalance(null);
-          setUsdcBalance(null);
-          setDaiBalance(null);
-        }
-      } finally {
-        if (isMounted && !signal.aborted) {
-          setIsLoading(false);
-        }
-      }
+    if (isVisible) {
+      void refetch();
     }
+  }, [isVisible, refetch]);
 
-    getBalances();
-
-    return () => {
-      isMounted = false;
-      if (abortController) {
-        abortController.abort("Component unmounted or dependencies changed");
-      }
-    };
-  }, [client, user, chain]);
+  useEffect(() => {
+    if (refreshKey > 0) {
+      void refetch();
+    }
+  }, [refreshKey, refetch]);
 
   const chainId = chain?.id;
-  const tokenRows = [
-    { symbol: 'ETH', balance: ethBalance, decimals: 18 },
-    { symbol: 'USDC', balance: usdcBalance, decimals: 6 },
-    { symbol: 'DAI', balance: daiBalance, decimals: 18 },
-    { symbol: 'USDS', balance: usdsBalance, decimals: 18 },
-    { symbol: 'GHO', balance: ghoBalance, decimals: 18 },
-  ] as const;
+
+  const tokenRows = TOKEN_ROWS.map((symbol) => {
+    const balance = balances[symbol];
+    const decimals = TOKEN_INFO[symbol].decimals;
+    const amount =
+      balance !== null ? parseFloat(formatUnits(balance, decimals)) : 0;
+    const usdValue = amount * (prices[symbol] ?? 0);
+    return { symbol, amount, formattedAmount: formatBalance(String(amount)), usdValue };
+  });
+
+  const totalUsd = tokenRows.reduce((sum, row) => sum + row.usdValue, 0);
 
   if (isLoading) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium">Balances</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {tokenRows.map(({ symbol }) => (
+      <div className="space-y-2">
+        <span className="text-sm font-medium text-gray-500">Balances</span>
+        <div className="pb-2 border-b border-gray-200 dark:border-gray-700">
+          <Skeleton className="h-3 w-16 mb-1" />
+          <Skeleton className="h-6 w-24" />
+        </div>
+        <div className="space-y-2">
+          {TOKEN_ROWS.map((symbol) => (
             <div key={symbol} className="flex items-center justify-between">
               <div className="flex items-center space-x-2">
-                <Image src={getTokenIcon(symbol, chainId)} alt={symbol} width={24} height={24} className="w-6 h-6" />
+                <Image
+                  src={getTokenIcon(symbol, chainId)}
+                  alt={symbol}
+                  width={24}
+                  height={24}
+                  className="w-6 h-6"
+                />
                 <span className="text-sm">{symbol}</span>
               </div>
-              <Skeleton className="h-5 w-16" />
+              <Skeleton className="h-8 w-16" />
             </div>
           ))}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     );
   }
 
   if (error) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium">Balances</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-sm text-red-500">
-            Error loading balances: {error}
-          </div>
-        </CardContent>
-      </Card>
+      <div className="space-y-2">
+        <span className="text-sm font-medium text-gray-500">Balances</span>
+        <div className="text-sm text-red-500">Error loading balances: {error}</div>
+      </div>
     );
   }
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium">Balances</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {tokenRows.map(({ symbol, balance, decimals }) => (
+    <div className="space-y-2">
+      <span className="text-sm font-medium text-gray-500">Balances</span>
+
+      <div className="pb-2 border-b border-gray-200 dark:border-gray-700">
+        <div className="text-xs text-gray-500 mb-1">Total Value</div>
+        <div className="text-lg font-semibold">
+          {PriceService.formatUSD(totalUsd)}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        {tokenRows.map(({ symbol, formattedAmount, usdValue }) => (
           <div key={symbol} className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
-              <Image src={getTokenIcon(symbol, chainId)} alt={symbol} width={24} height={24} className="w-6 h-6" />
+              <Image
+                src={getTokenIcon(symbol, chainId)}
+                alt={symbol}
+                width={24}
+                height={24}
+                className="w-6 h-6"
+              />
               <span className="text-sm">{symbol}</span>
             </div>
-            <span className="text-sm font-medium">
-              {balance ? formatBalance(formatUnits(balance, decimals)) : "0"}
-            </span>
+            <div className="text-right">
+              <div className="text-sm font-medium">{formattedAmount}</div>
+              <div className="text-xs text-gray-500">
+                {PriceService.formatUSD(usdValue)}
+              </div>
+            </div>
           </div>
         ))}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/components/wallet/balance/TokenBalance.tsx
+++ b/components/wallet/balance/TokenBalance.tsx
@@ -2,10 +2,13 @@
 
 import { useEffect } from "react";
 import { useSmartAccountClient, useUser, useChain } from "@account-kit/react";
-import { formatUnits } from "viem";
 import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
 import { getTokenIcon } from "@/lib/utils/token-icons";
+import {
+  formatTokenBalance,
+  tokenBalanceToUsd,
+} from "@/lib/utils/format-token-balance";
 import { useTokenBalances } from "@/lib/hooks/wallet/useTokenBalances";
 import { PriceService } from "@/lib/sdk/alchemy/price-service";
 import { TOKEN_INFO, type TokenSymbol } from "@/lib/sdk/alchemy/swap-service";
@@ -16,26 +19,6 @@ type TokenBalanceProps = {
   /** Increment to force a balance refresh after send/swap. */
   refreshKey?: number;
 };
-
-function formatBalance(balance: string): string {
-  const num = parseFloat(balance);
-  if (num <= 0) return "0";
-  if (num < 0.000001) return "< 0.000001";
-
-  if (num < 1) {
-    return new Intl.NumberFormat("en-US", {
-      maximumFractionDigits: 6,
-      minimumFractionDigits: 0,
-      useGrouping: false,
-    }).format(num);
-  }
-
-  return new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 4,
-    minimumFractionDigits: 0,
-    useGrouping: true,
-  }).format(num);
-}
 
 const TOKEN_ROWS: TokenSymbol[] = ["ETH", "USDC", "DAI", "USDS", "GHO"];
 
@@ -52,13 +35,13 @@ export function TokenBalance({ isVisible, refreshKey = 0 }: TokenBalanceProps) {
 
   useEffect(() => {
     if (isVisible) {
-      void refetch();
+      void refetch({ background: true });
     }
   }, [isVisible, refetch]);
 
   useEffect(() => {
     if (refreshKey > 0) {
-      void refetch();
+      void refetch({ background: true });
     }
   }, [refreshKey, refetch]);
 
@@ -67,10 +50,14 @@ export function TokenBalance({ isVisible, refreshKey = 0 }: TokenBalanceProps) {
   const tokenRows = TOKEN_ROWS.map((symbol) => {
     const balance = balances[symbol];
     const decimals = TOKEN_INFO[symbol].decimals;
-    const amount =
-      balance !== null ? parseFloat(formatUnits(balance, decimals)) : 0;
-    const usdValue = amount * (prices[symbol] ?? 0);
-    return { symbol, amount, formattedAmount: formatBalance(String(amount)), usdValue };
+    const formattedAmount =
+      balance !== null ? formatTokenBalance(balance, decimals) : "0";
+    const usdValue =
+      balance !== null
+        ? tokenBalanceToUsd(balance, decimals, prices[symbol] ?? 0)
+        : 0;
+
+    return { symbol, formattedAmount, usdValue };
   });
 
   const totalUsd = tokenRows.reduce((sum, row) => sum + row.usdValue, 0);

--- a/lib/hooks/wallet/useTokenBalances.ts
+++ b/lib/hooks/wallet/useTokenBalances.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPublicClient, http, type Chain } from "viem";
+import { getUsdcTokenContract } from "@/lib/contracts/USDCToken";
+import { getDaiTokenContract } from "@/lib/contracts/DAIToken";
+import { getUsdsTokenContract } from "@/lib/contracts/USDSToken";
+import { getGhoTokenContract } from "@/lib/contracts/GHOToken";
+import { priceService } from "@/lib/sdk/alchemy/price-service";
+import {
+  SWAP_UI_TOKENS,
+  emptyTokenPrices,
+  type TokenSymbol,
+} from "@/lib/sdk/alchemy/swap-service";
+import { logger } from "@/lib/utils/logger";
+
+export type WalletTokenBalances = Record<TokenSymbol, bigint | null>;
+
+const EMPTY_BALANCES: WalletTokenBalances = {
+  ETH: null,
+  USDC: null,
+  DAI: null,
+  USDS: null,
+  GHO: null,
+};
+
+function getChainKey(
+  chainId: number
+): keyof typeof import("@/lib/contracts/USDCToken").USDC_TOKEN_ADDRESSES | null {
+  if (chainId === 8453) return "base";
+  return null;
+}
+
+export function useTokenBalances(
+  address: string | undefined,
+  chain: Chain | undefined
+) {
+  const [balances, setBalances] = useState<WalletTokenBalances>(EMPTY_BALANCES);
+  const [prices, setPrices] =
+    useState<Record<TokenSymbol, number>>(emptyTokenPrices());
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(async () => {
+    abortRef.current?.abort();
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+    const { signal } = abortController;
+
+    setIsLoading(true);
+    setError(null);
+
+    if (!address || !chain) {
+      setBalances(EMPTY_BALANCES);
+      setIsLoading(false);
+      return;
+    }
+
+    const chainKey = getChainKey(chain.id);
+    if (!chainKey) {
+      setError(`Unsupported chain (ID: ${chain.id})`);
+      setBalances(EMPTY_BALANCES);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const publicClient = createPublicClient({
+        chain,
+        transport: http(),
+      });
+
+      const nextBalances: WalletTokenBalances = { ...EMPTY_BALANCES };
+
+      try {
+        if (signal.aborted) return;
+        nextBalances.ETH = await publicClient.getBalance({
+          address: address as `0x${string}`,
+        });
+      } catch (err) {
+        logger.error("Error fetching ETH balance:", err);
+      }
+
+      const erc20Tokens = [
+        { symbol: "USDC" as const, contract: getUsdcTokenContract(chainKey) },
+        { symbol: "DAI" as const, contract: getDaiTokenContract(chainKey) },
+        { symbol: "USDS" as const, contract: getUsdsTokenContract(chainKey) },
+        { symbol: "GHO" as const, contract: getGhoTokenContract(chainKey) },
+      ];
+
+      for (const { symbol, contract } of erc20Tokens) {
+        try {
+          if (signal.aborted) return;
+          nextBalances[symbol] = (await publicClient.readContract({
+            address: contract.address,
+            abi: contract.abi,
+            functionName: "balanceOf",
+            args: [address as `0x${string}`],
+          })) as bigint;
+        } catch (err) {
+          logger.error(`Error fetching ${symbol} balance:`, err);
+        }
+      }
+
+      if (signal.aborted) return;
+      setBalances(nextBalances);
+
+      const tokenPrices = await priceService.getTokenPrices([...SWAP_UI_TOKENS]);
+      if (signal.aborted) return;
+      setPrices(tokenPrices);
+    } catch (err) {
+      if (signal.aborted) return;
+      logger.error("Error fetching balances:", err);
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setBalances(EMPTY_BALANCES);
+    } finally {
+      if (!signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  }, [address, chain]);
+
+  useEffect(() => {
+    void refetch();
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [refetch]);
+
+  return { balances, prices, isLoading, error, refetch };
+}

--- a/lib/hooks/wallet/useTokenBalances.ts
+++ b/lib/hooks/wallet/useTokenBalances.ts
@@ -1,11 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createPublicClient, http, type Chain } from "viem";
-import { getUsdcTokenContract } from "@/lib/contracts/USDCToken";
-import { getDaiTokenContract } from "@/lib/contracts/DAIToken";
-import { getUsdsTokenContract } from "@/lib/contracts/USDSToken";
-import { getGhoTokenContract } from "@/lib/contracts/GHOToken";
+import type { Chain } from "viem";
+import { fetchWalletTokenBalances } from "@/lib/sdk/alchemy/wallet-balances";
+import type { WalletTokenBalances } from "@/lib/sdk/alchemy/wallet-balances";
 import { priceService } from "@/lib/sdk/alchemy/price-service";
 import {
   SWAP_UI_TOKENS,
@@ -14,7 +12,12 @@ import {
 } from "@/lib/sdk/alchemy/swap-service";
 import { logger } from "@/lib/utils/logger";
 
-export type WalletTokenBalances = Record<TokenSymbol, bigint | null>;
+export type { WalletTokenBalances };
+
+type RefetchOptions = {
+  /** When true, keep showing existing balances while refreshing. */
+  background?: boolean;
+};
 
 const EMPTY_BALANCES: WalletTokenBalances = {
   ETH: null,
@@ -24,11 +27,8 @@ const EMPTY_BALANCES: WalletTokenBalances = {
   GHO: null,
 };
 
-function getChainKey(
-  chainId: number
-): keyof typeof import("@/lib/contracts/USDCToken").USDC_TOKEN_ADDRESSES | null {
-  if (chainId === 8453) return "base";
-  return null;
+function isBaseChain(chain: Chain): boolean {
+  return chain.id === 8453;
 }
 
 export function useTokenBalances(
@@ -40,92 +40,70 @@ export function useTokenBalances(
     useState<Record<TokenSymbol, number>>(emptyTokenPrices());
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  const fetchGenerationRef = useRef(0);
+  const hasLoadedRef = useRef(false);
 
-  const refetch = useCallback(async () => {
-    abortRef.current?.abort();
-    const abortController = new AbortController();
-    abortRef.current = abortController;
-    const { signal } = abortController;
+  const refetch = useCallback(
+    async (options?: RefetchOptions) => {
+      const generation = ++fetchGenerationRef.current;
+      const background = options?.background ?? false;
+      const showLoading = !background || !hasLoadedRef.current;
 
-    setIsLoading(true);
-    setError(null);
+      if (showLoading) {
+        setIsLoading(true);
+      }
+      setError(null);
 
-    if (!address || !chain) {
-      setBalances(EMPTY_BALANCES);
-      setIsLoading(false);
-      return;
-    }
+      if (!address || !chain) {
+        if (generation !== fetchGenerationRef.current) return;
+        setBalances(EMPTY_BALANCES);
+        setIsLoading(false);
+        hasLoadedRef.current = false;
+        return;
+      }
 
-    const chainKey = getChainKey(chain.id);
-    if (!chainKey) {
-      setError(`Unsupported chain (ID: ${chain.id})`);
-      setBalances(EMPTY_BALANCES);
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      const publicClient = createPublicClient({
-        chain,
-        transport: http(),
-      });
-
-      const nextBalances: WalletTokenBalances = { ...EMPTY_BALANCES };
+      if (!isBaseChain(chain)) {
+        if (generation !== fetchGenerationRef.current) return;
+        setError(`Unsupported chain (ID: ${chain.id})`);
+        setBalances(EMPTY_BALANCES);
+        setIsLoading(false);
+        hasLoadedRef.current = false;
+        return;
+      }
 
       try {
-        if (signal.aborted) return;
-        nextBalances.ETH = await publicClient.getBalance({
-          address: address as `0x${string}`,
-        });
+        const [nextBalances, tokenPrices] = await Promise.all([
+          fetchWalletTokenBalances(address),
+          priceService.getTokenPrices([...SWAP_UI_TOKENS]),
+        ]);
+
+        if (generation !== fetchGenerationRef.current) return;
+
+        setBalances(nextBalances);
+        setPrices(tokenPrices);
+        hasLoadedRef.current = true;
       } catch (err) {
-        logger.error("Error fetching ETH balance:", err);
-      }
+        if (generation !== fetchGenerationRef.current) return;
 
-      const erc20Tokens = [
-        { symbol: "USDC" as const, contract: getUsdcTokenContract(chainKey) },
-        { symbol: "DAI" as const, contract: getDaiTokenContract(chainKey) },
-        { symbol: "USDS" as const, contract: getUsdsTokenContract(chainKey) },
-        { symbol: "GHO" as const, contract: getGhoTokenContract(chainKey) },
-      ];
+        logger.error("Error fetching balances:", err);
+        const message = err instanceof Error ? err.message : "Unknown error";
 
-      for (const { symbol, contract } of erc20Tokens) {
-        try {
-          if (signal.aborted) return;
-          nextBalances[symbol] = (await publicClient.readContract({
-            address: contract.address,
-            abi: contract.abi,
-            functionName: "balanceOf",
-            args: [address as `0x${string}`],
-          })) as bigint;
-        } catch (err) {
-          logger.error(`Error fetching ${symbol} balance:`, err);
+        if (!hasLoadedRef.current) {
+          setError(message);
+          setBalances(EMPTY_BALANCES);
+        }
+      } finally {
+        if (generation === fetchGenerationRef.current) {
+          setIsLoading(false);
         }
       }
-
-      if (signal.aborted) return;
-      setBalances(nextBalances);
-
-      const tokenPrices = await priceService.getTokenPrices([...SWAP_UI_TOKENS]);
-      if (signal.aborted) return;
-      setPrices(tokenPrices);
-    } catch (err) {
-      if (signal.aborted) return;
-      logger.error("Error fetching balances:", err);
-      setError(err instanceof Error ? err.message : "Unknown error");
-      setBalances(EMPTY_BALANCES);
-    } finally {
-      if (!signal.aborted) {
-        setIsLoading(false);
-      }
-    }
-  }, [address, chain]);
+    },
+    [address, chain]
+  );
 
   useEffect(() => {
+    hasLoadedRef.current = false;
     void refetch();
-    return () => {
-      abortRef.current?.abort();
-    };
   }, [refetch]);
 
   return { balances, prices, isLoading, error, refetch };

--- a/lib/sdk/alchemy/price-service.ts
+++ b/lib/sdk/alchemy/price-service.ts
@@ -1,118 +1,173 @@
-import { type TokenSymbol } from './swap-service';
-import { serverLogger } from '@/lib/utils/logger';
+import { Network } from "alchemy-sdk";
+import { alchemyClient } from "@/lib/sdk/alchemy/alchemy-client";
+import { BASE_TOKENS, type TokenSymbol } from "./swap-service";
+import { serverLogger } from "@/lib/utils/logger";
 
-// Price data interface
 export interface TokenPrice {
   symbol: TokenSymbol;
-  price: number; // USD price
-  lastUpdated: number; // timestamp
+  price: number;
+  lastUpdated: number;
 }
 
-// Price cache to avoid excessive API calls
 const priceCache = new Map<TokenSymbol, TokenPrice>();
-const CACHE_DURATION = 60000; // 1 minute cache
+const CACHE_DURATION = 60000;
 
-const COINGECKO_IDS: Record<TokenSymbol, string> = {
-  ETH: 'ethereum',
-  USDC: 'usd-coin',
-  DAI: 'dai',
-  USDS: 'usds',
-  GHO: 'gho',
+const FALLBACK_PRICES: Record<TokenSymbol, number> = {
+  ETH: 3000,
+  USDC: 1,
+  DAI: 1,
+  USDS: 1,
+  GHO: 1,
 };
+
+/** Base canonical WETH — used as ETH price proxy when symbol lookup fails. */
+const BASE_WETH_ADDRESS = "0x4200000000000000000000000000000000000006";
+
+const ADDRESS_FALLBACK_SYMBOLS: TokenSymbol[] = [
+  "USDC",
+  "DAI",
+  "USDS",
+  "GHO",
+];
+
+const ADDRESS_TO_SYMBOL: Record<string, TokenSymbol> = Object.fromEntries(
+  ADDRESS_FALLBACK_SYMBOLS.map((symbol) => [
+    BASE_TOKENS[symbol].toLowerCase(),
+    symbol,
+  ])
+) as Record<string, TokenSymbol>;
+
+function parseUsdPrice(
+  prices: Array<{ currency: string; value: string }>
+): number {
+  const usd = prices.find((p) => p.currency.toLowerCase() === "usd");
+  if (!usd) return 0;
+  const value = parseFloat(usd.value);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function cachePrice(symbol: TokenSymbol, price: number): void {
+  priceCache.set(symbol, {
+    symbol,
+    price,
+    lastUpdated: Date.now(),
+  });
+}
 
 export class PriceService {
   private static instance: PriceService;
-  private apiKey: string;
 
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
-  static getInstance(apiKey?: string): PriceService {
+  static getInstance(): PriceService {
     if (!PriceService.instance) {
-      if (!apiKey) {
-        throw new Error('API key required for first PriceService instantiation');
-      }
-      PriceService.instance = new PriceService(apiKey);
+      PriceService.instance = new PriceService();
     }
     return PriceService.instance;
   }
 
-  /**
-   * Get current USD price for a token
-   */
   async getTokenPrice(symbol: TokenSymbol): Promise<number> {
-    // Check cache first
     const cached = priceCache.get(symbol);
     if (cached && Date.now() - cached.lastUpdated < CACHE_DURATION) {
       return cached.price;
     }
 
     try {
-      const price = await this.fetchTokenPrice(symbol);
-
-      // Update cache
-      priceCache.set(symbol, {
-        symbol,
-        price,
-        lastUpdated: Date.now(),
-      });
-
-      return price;
+      const prices = await this.getTokenPrices([symbol]);
+      return prices[symbol];
     } catch (error) {
       serverLogger.error(`Failed to fetch price for ${symbol}:`, error);
-
-      // Return cached price if available, even if expired
-      if (cached) {
-        return cached.price;
-      }
-
-      // Fallback prices (approximate)
-      const fallbackPrices: Record<TokenSymbol, number> = {
-        ETH: 3000,
-        USDC: 1,
-        DAI: 1,
-        USDS: 1,
-        GHO: 1,
-      };
-
-      return fallbackPrices[symbol];
+      if (cached) return cached.price;
+      return FALLBACK_PRICES[symbol];
     }
   }
 
-  /**
-   * Fetch price from CoinGecko API
-   */
-  private async fetchTokenPrice(symbol: TokenSymbol): Promise<number> {
-    const coinId = COINGECKO_IDS[symbol];
-    if (!coinId) {
-      throw new Error(`Unknown token symbol: ${symbol}`);
+  private async fetchPricesBySymbol(
+    symbols: TokenSymbol[]
+  ): Promise<Partial<Record<TokenSymbol, number>>> {
+    if (symbols.length === 0) return {};
+
+    const response = await alchemyClient.prices.getTokenPriceBySymbol(symbols);
+    const prices: Partial<Record<TokenSymbol, number>> = {};
+
+    for (const result of response.data) {
+      const symbol = result.symbol.toUpperCase() as TokenSymbol;
+      if (result.error) {
+        serverLogger.error(
+          `Alchemy price error for ${symbol}:`,
+          result.error.message
+        );
+        continue;
+      }
+      const price = parseUsdPrice(result.prices);
+      if (price > 0) {
+        prices[symbol] = price;
+      }
     }
 
-    const response = await fetch(
-      `https://api.coingecko.com/api/v3/simple/price?ids=${coinId}&vs_currencies=usd`,
-      {
-        headers: {
-          'Accept': 'application/json',
-        },
-      }
+    return prices;
+  }
+
+  private async fetchPricesByAddress(
+    symbols: TokenSymbol[]
+  ): Promise<Partial<Record<TokenSymbol, number>>> {
+    if (symbols.length === 0) return {};
+
+    const response = await alchemyClient.prices.getTokenPriceByAddress(
+      symbols.map((symbol) => ({
+        network: Network.BASE_MAINNET,
+        address: BASE_TOKENS[symbol],
+      }))
     );
 
-    if (!response.ok) {
-      throw new Error(`CoinGecko API error: ${response.status}`);
+    const prices: Partial<Record<TokenSymbol, number>> = {};
+
+    for (const result of response.data) {
+      const symbol = ADDRESS_TO_SYMBOL[result.address.toLowerCase()];
+      if (!symbol) continue;
+
+      if (result.error) {
+        serverLogger.error(
+          `Alchemy price error for ${symbol}:`,
+          result.error.message
+        );
+        continue;
+      }
+
+      const price = parseUsdPrice(result.prices);
+      if (price > 0) {
+        prices[symbol] = price;
+      }
     }
 
-    const data = await response.json();
-    return data[coinId]?.usd || 0;
+    return prices;
   }
 
-  /**
-   * Get prices for multiple tokens at once
-   */
-  async getTokenPrices(symbols: TokenSymbol[]): Promise<Record<TokenSymbol, number>> {
-    const prices: Record<TokenSymbol, number> = {} as Record<TokenSymbol, number>;
+  private async fetchEthPriceByWeth(): Promise<number | undefined> {
+    const response = await alchemyClient.prices.getTokenPriceByAddress([
+      {
+        network: Network.BASE_MAINNET,
+        address: BASE_WETH_ADDRESS,
+      },
+    ]);
 
-    // Check cache for all tokens first
+    const result = response.data[0];
+    if (!result || result.error) {
+      if (result?.error) {
+        serverLogger.error(
+          "Alchemy WETH price error for ETH fallback:",
+          result.error.message
+        );
+      }
+      return undefined;
+    }
+
+    const price = parseUsdPrice(result.prices);
+    return price > 0 ? price : undefined;
+  }
+
+  async getTokenPrices(
+    symbols: TokenSymbol[]
+  ): Promise<Record<TokenSymbol, number>> {
+    const prices = {} as Record<TokenSymbol, number>;
     const uncachedSymbols: TokenSymbol[] = [];
 
     for (const symbol of symbols) {
@@ -124,77 +179,68 @@ export class PriceService {
       }
     }
 
-    // Fetch uncached prices
-    if (uncachedSymbols.length > 0) {
-      try {
-        const coinIds = uncachedSymbols.map(symbol => COINGECKO_IDS[symbol]).join(',');
+    if (uncachedSymbols.length === 0) return prices;
 
-        const response = await fetch(
-          `https://api.coingecko.com/api/v3/simple/price?ids=${coinIds}&vs_currencies=usd`,
-          {
-            headers: {
-              'Accept': 'application/json',
-            },
-          }
-        );
+    try {
+      const symbolPrices = await this.fetchPricesBySymbol(uncachedSymbols);
+      let missingSymbols = uncachedSymbols.filter(
+        (symbol) => symbolPrices[symbol] === undefined
+      );
 
-        if (response.ok) {
-          const data = await response.json();
-
-          for (const symbol of uncachedSymbols) {
-            const coinId = COINGECKO_IDS[symbol];
-            const price = data[coinId]?.usd || 0;
-
-            prices[symbol] = price;
-
-            // Update cache
-            priceCache.set(symbol, {
-              symbol,
-              price,
-              lastUpdated: Date.now(),
-            });
-          }
-        } else {
-          // Fallback to individual requests
-          for (const symbol of uncachedSymbols) {
-            prices[symbol] = await this.getTokenPrice(symbol);
-          }
+      if (missingSymbols.includes("ETH")) {
+        const ethPrice = await this.fetchEthPriceByWeth();
+        if (ethPrice !== undefined) {
+          symbolPrices.ETH = ethPrice;
+          missingSymbols = missingSymbols.filter((symbol) => symbol !== "ETH");
         }
-      } catch (error) {
-        serverLogger.error('Failed to fetch multiple prices:', error);
+      }
 
-        // Fallback to individual requests
-        for (const symbol of uncachedSymbols) {
-          prices[symbol] = await this.getTokenPrice(symbol);
+      const addressPrices =
+        missingSymbols.length > 0
+          ? await this.fetchPricesByAddress(
+              missingSymbols.filter((symbol) => symbol !== "ETH")
+            )
+          : {};
+
+      for (const symbol of uncachedSymbols) {
+        const apiPrice = symbolPrices[symbol] ?? addressPrices[symbol];
+
+        const price =
+          apiPrice ??
+          priceCache.get(symbol)?.price ??
+          FALLBACK_PRICES[symbol];
+
+        prices[symbol] = price;
+
+        if (apiPrice !== undefined) {
+          cachePrice(symbol, apiPrice);
         }
+      }
+    } catch (error) {
+      serverLogger.error("Failed to fetch Alchemy token prices:", error);
+
+      for (const symbol of uncachedSymbols) {
+        prices[symbol] =
+          priceCache.get(symbol)?.price ?? FALLBACK_PRICES[symbol];
       }
     }
 
     return prices;
   }
 
-  /**
-   * Convert token amount to USD value
-   */
   async convertToUSD(amount: number, symbol: TokenSymbol): Promise<number> {
     const price = await this.getTokenPrice(symbol);
     return amount * price;
   }
 
-  /**
-   * Convert USD value to token amount
-   */
   async convertFromUSD(usdAmount: number, symbol: TokenSymbol): Promise<number> {
     const price = await this.getTokenPrice(symbol);
     return usdAmount / price;
   }
 
-  /**
-   * Format USD value for display
-   */
   static formatUSD(amount: number): string {
     if (amount < 0.01) {
-      return '< $0.01';
+      return "< $0.01";
     }
     if (amount < 1) {
       return `$${amount.toFixed(4)}`;
@@ -211,15 +257,15 @@ export class PriceService {
     return `$${(amount / 1000000).toFixed(1)}M`;
   }
 
-  /**
-   * Format token amount with USD value
-   */
-  static formatTokenWithUSD(amount: number, symbol: TokenSymbol, usdValue: number): string {
-    const formattedAmount = amount.toFixed(6).replace(/\.?0+$/, '');
+  static formatTokenWithUSD(
+    amount: number,
+    symbol: TokenSymbol,
+    usdValue: number
+  ): string {
+    const formattedAmount = amount.toFixed(6).replace(/\.?0+$/, "");
     const formattedUSD = PriceService.formatUSD(usdValue);
     return `${formattedAmount} ${symbol} (${formattedUSD})`;
   }
 }
 
-// Export singleton instance
-export const priceService = PriceService.getInstance(process.env.NEXT_PUBLIC_ALCHEMY_API_KEY);
+export const priceService = PriceService.getInstance();

--- a/lib/sdk/alchemy/wallet-balances.ts
+++ b/lib/sdk/alchemy/wallet-balances.ts
@@ -1,0 +1,70 @@
+import { alchemyClient } from "@/lib/sdk/alchemy/alchemy-client";
+import {
+  BASE_TOKENS,
+  type TokenSymbol,
+} from "@/lib/sdk/alchemy/swap-service";
+import { logger } from "@/lib/utils/logger";
+
+export type WalletTokenBalances = Record<TokenSymbol, bigint | null>;
+
+const EMPTY_BALANCES: WalletTokenBalances = {
+  ETH: null,
+  USDC: null,
+  DAI: null,
+  USDS: null,
+  GHO: null,
+};
+
+const ERC20_SYMBOLS = ["USDC", "DAI", "USDS", "GHO"] as const;
+
+const CONTRACT_TO_SYMBOL = Object.fromEntries(
+  ERC20_SYMBOLS.map((symbol) => [BASE_TOKENS[symbol].toLowerCase(), symbol])
+) as Record<string, (typeof ERC20_SYMBOLS)[number]>;
+
+function hexBalanceToBigInt(hex: string | null | undefined): bigint {
+  if (!hex || hex === "0x" || hex === "0x0") return 0n;
+  return BigInt(hex);
+}
+
+/**
+ * Fetch ETH + known stablecoin balances via Alchemy Token API.
+ * Partial failures return whatever balances could be fetched.
+ */
+export async function fetchWalletTokenBalances(
+  address: string
+): Promise<WalletTokenBalances> {
+  const nextBalances: WalletTokenBalances = { ...EMPTY_BALANCES };
+  const erc20Addresses = ERC20_SYMBOLS.map((symbol) => BASE_TOKENS[symbol]);
+
+  const [ethResult, tokenResult] = await Promise.allSettled([
+    alchemyClient.core.getBalance(address),
+    alchemyClient.core.getTokenBalances(address, erc20Addresses),
+  ]);
+
+  if (ethResult.status === "fulfilled") {
+    nextBalances.ETH = BigInt(ethResult.value.toString());
+  } else {
+    logger.error("Error fetching ETH balance:", ethResult.reason);
+  }
+
+  if (tokenResult.status === "fulfilled") {
+    for (const entry of tokenResult.value.tokenBalances ?? []) {
+      if (entry.error) {
+        logger.error(
+          `Alchemy token balance error for ${entry.contractAddress}:`,
+          entry.error
+        );
+        continue;
+      }
+
+      const symbol = CONTRACT_TO_SYMBOL[entry.contractAddress.toLowerCase()];
+      if (!symbol) continue;
+
+      nextBalances[symbol] = hexBalanceToBigInt(entry.tokenBalance);
+    }
+  } else {
+    logger.error("Error fetching ERC-20 balances:", tokenResult.reason);
+  }
+
+  return nextBalances;
+}

--- a/lib/utils/format-token-balance.ts
+++ b/lib/utils/format-token-balance.ts
@@ -1,0 +1,45 @@
+import { formatUnits } from "viem";
+
+/** Format a decimal string token amount for display (no symbol suffix). */
+export function formatBalanceDisplay(amount: string): string {
+  const num = Number.parseFloat(amount);
+  if (!Number.isFinite(num) || num <= 0) return "0";
+  if (num < 0.000001) return "< 0.000001";
+
+  if (num < 1) {
+    return new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: 6,
+      minimumFractionDigits: 0,
+      useGrouping: false,
+    }).format(num);
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: 0,
+    useGrouping: true,
+  }).format(num);
+}
+
+export function formatTokenBalance(balance: bigint, decimals: number): string {
+  return formatBalanceDisplay(formatUnits(balance, decimals));
+}
+
+/** Convert on-chain balance to USD while preserving fractional precision from formatUnits. */
+export function tokenBalanceToUsd(
+  balance: bigint,
+  decimals: number,
+  price: number
+): number {
+  if (balance === 0n || price === 0) return 0;
+
+  const units = formatUnits(balance, decimals);
+  const [wholePart, fractionalPart = ""] = units.split(".");
+  const whole = BigInt(wholePart || "0");
+  const fractionValue =
+    fractionalPart.length > 0
+      ? Number(fractionalPart) / 10 ** fractionalPart.length
+      : 0;
+
+  return (Number(whole) + fractionValue) * price;
+}


### PR DESCRIPTION
## Summary
- Update footer copyright to Creative Platform, Inc. and remove the Exit dApp link.
- Remove Songchain from the Creative Platform apps drawer.
- Show per-token and total USD values in the account dropdown balances section, with refetch on dropdown open and after send/swap.

## Test plan
- [ ] Footer shows Creative Platform, Inc. and no Exit dApp link
- [ ] Creative Platform apps drawer no longer lists Songchain
- [ ] Account dropdown shows token amounts with USD subtext and a Total Value header
- [ ] Balances refresh when reopening the dropdown
- [ ] Balances refresh after a successful send or swap


Made with [Cursor](https://cursor.com)