### PR TITLE
Migrate wallet auth to Privy and Alchemy Wallet APIs v5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ LIVEPEER_FULL_API_URL=https://livepeer.studio
 LIVEPEER_API_URL=https://livepeer.studio
 LIVEPEER_WEBHOOK_ID=
 
+# --- Privy (signer migration) ---
+NEXT_PUBLIC_PRIVY_APP_ID=
+NEXT_PUBLIC_PRIVY_CLIENT_ID=
+# Used for Alchemy→Privy migration OAuth redirects (defaults to VERCEL_URL or localhost)
+NEXT_PUBLIC_URL=
+
 # --- Alchemy ---
 NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID=
 NEXT_PUBLIC_ALCHEMY_RPC_URL=

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,3 @@
-import { config } from "@/config";
-import { cookieToInitialState } from "@account-kit/core";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { headers } from "next/headers";
@@ -17,7 +15,6 @@ import { LayoutClientChunks } from "@/components/LayoutClientChunks";
 const inter = Inter({
   subsets: ["latin"],
   display: "swap",
-  // Avoid Chrome "preloaded but not used" when first paint is delayed (dev/HMR, heavy pages).
   preload: false,
   adjustFontFallback: true,
 });
@@ -57,12 +54,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Persist state across pages
   const headersList = await headers();
-  const initialState = cookieToInitialState(
-    config,
-    headersList.get("cookie") ?? undefined
-  );
   const isEmbedRoute = headersList.get("x-crtv-embed-route") === "1";
 
   return (
@@ -74,11 +66,7 @@ export default async function RootLayout({
           rel="apple-touch-icon"
           href="/icons/CreativeTV_blur-192x192.png"
         />
-        {/* Default favicon */}
         <link rel="icon" href="/favicon.ico" sizes="any" />
-        {/* Optional: SVG or PNG favicons */}
-        {/* <link rel="icon" type="image/svg+xml" href="/favicon.svg" /> */}
-        {/* <link rel="icon" type="image/png" href="/favicon.png" /> */}
       </head>
       <body
         className={cn(
@@ -88,9 +76,8 @@ export default async function RootLayout({
         suppressHydrationWarning
       >
         <div id="alchemy-signer-iframe-container" style={{ display: "none" }} />
-        {/* Alchemy signer iframe container for modular account functionality */}
         <LayoutClientChunks />
-        <Providers initialState={initialState}>
+        <Providers>
           <ErrorBoundary>
             {!isEmbedRoute ? <Tour /> : null}
             {!isEmbedRoute ? <Navbar /> : null}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { stack } from "@/lib/sdk/stack/stackClient";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import LeaderboardItem from "@/components/leaderboard/LeaderboardItem";
 import { FaSpinner } from "react-icons/fa";
 import { Button } from "@/components/ui/button";

--- a/app/live/[address]/LivePageClient.tsx
+++ b/app/live/[address]/LivePageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useSignerStatus } from "@account-kit/react";
+import { useSignerStatus } from "@/lib/wallet/react";
 import { isAddress } from "viem";
 import { useCreatorWalletAddress } from "@/lib/hooks/accountkit/useCreatorWalletAddress";
 import { logger } from "@/lib/utils/logger";

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MeTokenPortfolio } from '@/components/wallet/balance/MeTokenPortfolio';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Wallet, TrendingUp, Plus, ArrowLeft } from 'lucide-react';

--- a/app/predict/create/page.tsx
+++ b/app/predict/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,9 +1,15 @@
 "use client";
 import "@/lib/utils/suppressDevWarnings";
 import "@/lib/utils/xmtp/wasm-patch";
-import { config, queryClient } from "@/config";
-import { AlchemyAccountProvider } from "@account-kit/react";
-import { AlchemyClientState } from "@account-kit/core";
+// Migration SDK styles use Tailwind v4 @layer base, incompatible with our Tailwind v3
+// PostCSS setup. Modal remains functional without the stylesheet.
+import { queryClient } from "@/config";
+import { PrivyProvider } from "@privy-io/react-auth";
+import { MigrationProvider } from "@privy-io/alchemy-migration";
+import { alchemyMigrationConfig } from "@/lib/sdk/wallet/migration-config";
+import { getPrivyConfig } from "@/lib/wallet/privy-config";
+import { WalletChainProvider } from "@/lib/wallet/chain-context";
+import { WalletClientProvider } from "@/lib/wallet/wallet-context";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense, useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
@@ -16,8 +22,7 @@ import { ApolloNextAppProvider } from "@apollo/client-integration-nextjs";
 import { makeClient } from "./apolloWrapper";
 import { RadixProvider } from "@/components/ui/radix-provider";
 import { cleanupExistingIframes } from "@/components/IframeCleanup";
-import { MembershipGuard } from "@/components/auth/MembershipGuard";
-import { AccountKitStoreGuard } from "@/components/auth/AccountKitStoreGuard";
+import { WalletReadyGuard } from "@/components/auth/WalletReadyGuard";
 import { AuthErrorMonitor } from "@/components/auth/AuthErrorMonitor";
 import { OrbSessionProvider } from "@/context/OrbSessionContext";
 import { OrbLoginModal } from "@/components/auth/OrbLoginModal";
@@ -35,24 +40,30 @@ function ErrorFallback({ error }: { error: Error }) {
   );
 }
 
-export const Providers = (
-  props: PropsWithChildren<{ initialState?: AlchemyClientState }>
-) => {
+export const Providers = (props: PropsWithChildren) => {
   const [isReady, setIsReady] = useState(false);
+  const privyAppId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  const privyClientId = process.env.NEXT_PUBLIC_PRIVY_CLIENT_ID;
 
   useEffect(() => {
-    // Only clean up DUPLICATE iframes, not the active one
-    // This prevents breaking the signer connection while still handling hot-reload duplicates
     cleanupExistingIframes();
     setIsReady(true);
   }, []);
 
-  // Don't render providers until ready
-  // Note: We removed aggressive iframe cleanup to preserve the signer connection
   if (!isReady) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         Loading...
+      </div>
+    );
+  }
+
+  if (!privyAppId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Missing NEXT_PUBLIC_PRIVY_APP_ID. Configure Privy in your environment to enable wallet auth.
+        </p>
       </div>
     );
   }
@@ -68,35 +79,40 @@ export const Providers = (
       >
         <QueryClientProvider client={queryClient}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <ApolloNextAppProvider makeClient={makeClient}>
-              <NoSSR>
-                <AlchemyAccountProvider
-                  config={config}
-                  queryClient={queryClient}
-                  initialState={props.initialState}
-                >
-                  <RadixProvider>
-                    <HeliaProvider>
-                      <TourProvider>
-                        <VideoProvider>
-                          <AccountKitStoreGuard>
-                            <AuthErrorMonitor />
-                            <OrbSessionProvider>
-                              <MembershipGuard>
-                                {props.children}
-                              </MembershipGuard>
-                              <OrbLoginModal />
-                              <OrbLinkingOverlay />
-                              <Toaster position="top-right" richColors />
-                            </OrbSessionProvider>
-                          </AccountKitStoreGuard>
-                        </VideoProvider>
-                      </TourProvider>
-                    </HeliaProvider>
-                  </RadixProvider>
-                </AlchemyAccountProvider>
-              </NoSSR>
-            </ApolloNextAppProvider>
+            <PrivyProvider appId={privyAppId} config={getPrivyConfig()}>
+              <MigrationProvider
+                alchemyConfig={alchemyMigrationConfig}
+                privyAppId={privyAppId}
+                privyClientId={privyClientId}
+                showDebugButton={process.env.NODE_ENV === "development"}
+              >
+                <WalletChainProvider>
+                  <WalletClientProvider>
+                    <ApolloNextAppProvider makeClient={makeClient}>
+                      <NoSSR>
+                        <RadixProvider>
+                          <HeliaProvider>
+                            <TourProvider>
+                              <VideoProvider>
+                                <WalletReadyGuard>
+                                  <AuthErrorMonitor />
+                                  <OrbSessionProvider>
+                                    {props.children}
+                                    <OrbLoginModal />
+                                    <OrbLinkingOverlay />
+                                    <Toaster position="top-right" richColors />
+                                  </OrbSessionProvider>
+                                </WalletReadyGuard>
+                              </VideoProvider>
+                            </TourProvider>
+                          </HeliaProvider>
+                        </RadixProvider>
+                      </NoSSR>
+                    </ApolloNextAppProvider>
+                  </WalletClientProvider>
+                </WalletChainProvider>
+              </MigrationProvider>
+            </PrivyProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </Suspense>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,6 +10,7 @@ import { alchemyMigrationConfig } from "@/lib/sdk/wallet/migration-config";
 import { getPrivyConfig } from "@/lib/wallet/privy-config";
 import { WalletChainProvider } from "@/lib/wallet/chain-context";
 import { WalletClientProvider } from "@/lib/wallet/wallet-context";
+import { AuthErrorProvider } from "@/lib/wallet/auth-error-context";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense, useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
@@ -80,38 +81,40 @@ export const Providers = (props: PropsWithChildren) => {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <PrivyProvider appId={privyAppId} config={getPrivyConfig()}>
-              <MigrationProvider
-                alchemyConfig={alchemyMigrationConfig}
-                privyAppId={privyAppId}
-                privyClientId={privyClientId}
-                showDebugButton={process.env.NODE_ENV === "development"}
-              >
-                <WalletChainProvider>
-                  <WalletClientProvider>
-                    <ApolloNextAppProvider makeClient={makeClient}>
-                      <NoSSR>
-                        <RadixProvider>
-                          <HeliaProvider>
-                            <TourProvider>
-                              <VideoProvider>
-                                <WalletReadyGuard>
-                                  <AuthErrorMonitor />
-                                  <OrbSessionProvider>
-                                    {props.children}
-                                    <OrbLoginModal />
-                                    <OrbLinkingOverlay />
-                                    <Toaster position="top-right" richColors />
-                                  </OrbSessionProvider>
-                                </WalletReadyGuard>
-                              </VideoProvider>
-                            </TourProvider>
-                          </HeliaProvider>
-                        </RadixProvider>
-                      </NoSSR>
-                    </ApolloNextAppProvider>
-                  </WalletClientProvider>
-                </WalletChainProvider>
-              </MigrationProvider>
+              <AuthErrorProvider>
+                <MigrationProvider
+                  alchemyConfig={alchemyMigrationConfig}
+                  privyAppId={privyAppId}
+                  privyClientId={privyClientId}
+                  showDebugButton={process.env.NODE_ENV === "development"}
+                >
+                  <WalletChainProvider>
+                    <WalletClientProvider>
+                      <ApolloNextAppProvider makeClient={makeClient}>
+                        <NoSSR>
+                          <RadixProvider>
+                            <HeliaProvider>
+                              <TourProvider>
+                                <VideoProvider>
+                                  <WalletReadyGuard>
+                                    <AuthErrorMonitor />
+                                    <OrbSessionProvider>
+                                      {props.children}
+                                      <OrbLoginModal />
+                                      <OrbLinkingOverlay />
+                                      <Toaster position="top-right" richColors />
+                                    </OrbSessionProvider>
+                                  </WalletReadyGuard>
+                                </VideoProvider>
+                              </TourProvider>
+                            </HeliaProvider>
+                          </RadixProvider>
+                        </NoSSR>
+                      </ApolloNextAppProvider>
+                    </WalletClientProvider>
+                  </WalletChainProvider>
+                </MigrationProvider>
+              </AuthErrorProvider>
             </PrivyProvider>
           </ThemeProvider>
         </QueryClientProvider>

--- a/app/upload/[address]/UploadPageClient.tsx
+++ b/app/upload/[address]/UploadPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useUser, useSmartAccountClient, useSignerStatus } from "@account-kit/react";
+import { useUser, useSmartAccountClient, useSignerStatus } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { isAddress } from "viem";
 import { logger } from '@/lib/utils/logger';

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";

--- a/app/vote/create/page.tsx
+++ b/app/vote/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -10,7 +10,7 @@ import { LiveChat } from "@/components/Live/LiveChat";
 import { ClipCreator } from "@/components/Live/ClipCreator";
 import { DigitalTwinOverlay } from "@/components/Live/DigitalTwinOverlay";
 import { Src } from "@livepeer/react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle } from "lucide-react";

--- a/components/Live/ClipCreator.tsx
+++ b/components/Live/ClipCreator.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useState } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/components/Live/LiveChat.tsx
+++ b/components/Live/LiveChat.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo } from "react";
 import { useLiveChatModerated } from "@/lib/hooks/xmtp/useLiveChatModerated";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/components/Live/LiveStreamMeTokenGate.tsx
+++ b/components/Live/LiveStreamMeTokenGate.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Lock, PenLine, Wallet } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useAuthModal } from "@account-kit/react";
+import { useAuthModal } from "@/lib/wallet/react";
 import { VideoMeTokenBuyDialog } from "@/components/Videos/VideoMeTokenBuyDialog";
 
 export interface LiveStreamGateInfo {

--- a/components/Market/QuickTradeDialog.tsx
+++ b/components/Market/QuickTradeDialog.tsx
@@ -15,7 +15,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle, TrendingUp } from 'lucide-react';
 import { useMeTokensSupabase } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { formatEther, parseEther } from 'viem';
-import { useSmartAccountClient, useAuthModal, useUser } from '@account-kit/react';
+import { useSmartAccountClient, useAuthModal, useUser } from '@/lib/wallet/react';
 import { getDaiTokenContract } from '@/lib/contracts/DAIToken';
 import { erc20Abi } from 'viem';
 import { DaiFundingOptions } from '@/components/wallet/funding/DaiFundingOptions';

--- a/components/Marketplace/VideoPurchaseDialog.tsx
+++ b/components/Marketplace/VideoPurchaseDialog.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useMeTokensSupabase } from "@/lib/hooks/metokens/useMeTokensSupabase";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { useMeTokenPurchase } from "@/lib/hooks/metokens/useMeTokenPurchase";
 import { Loader2, Lock, Coins, AlertCircle } from "lucide-react";
 import { formatEther, parseEther } from "viem";

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,7 +16,7 @@ import {
   useAuthModal,
   useUser,
   useChain,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import ThemeToggleComponent from "./ThemeToggle/toggleComponent";
 import { toast } from "sonner";
 import { CheckIcon } from "@radix-ui/react-icons";

--- a/components/SendTransaction.tsx
+++ b/components/SendTransaction.tsx
@@ -27,7 +27,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/SmartAccountActions.tsx
+++ b/components/SmartAccountActions.tsx
@@ -17,7 +17,7 @@
  * - Uses Account Kit React hooks for smart account interactions
  * 
  * Dependencies:
- * - @account-kit/react: Provides hooks for smart account interactions
+ * - @/lib/wallet/react: Provides hooks for smart account interactions
  * - useWalletStatus: Custom hook that manages wallet connection and smart account status
  * - UI components from shadcn/ui library (Button, Input, Label, Tabs)
  * - toast from sonner for notifications
@@ -39,7 +39,7 @@ import {
   useSendUserOperation,
   useSignMessage,
   useSignTypedData,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -5,11 +5,12 @@ import {
     Joyride,
     EVENTS,
     STATUS,
-    type CallBackProps,
+    ACTIONS,
+    type EventData,
     type Step,
 } from 'react-joyride';
 import { usePathname } from 'next/navigation';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { useTour } from '@/context/TourContext';
 import { logger } from '@/lib/utils/logger';
 
@@ -21,15 +22,15 @@ const DESKTOP_STEPS: TourStep[] = [
     {
         target: '#connect-wallet-btn',
         content: 'Sign in to get started! Click "Get Started" to create your account with just your email.',
-        disableBeacon: true,
-        spotlightClicks: true,
+        skipBeacon: true,
+        blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'connect' },
     },
     {
         target: '#nav-user-menu',
         content: 'Click your profile to open the menu, then select "Upload" to start adding content.',
-        spotlightClicks: true,
+        blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'user-menu' },
     },
@@ -63,22 +64,22 @@ const MOBILE_STEPS: TourStep[] = [
     {
         target: '#mobile-menu-btn',
         content: 'Tap the menu icon to open navigation and sign in.',
-        disableBeacon: true,
-        spotlightClicks: true,
+        skipBeacon: true,
+        blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'connect', openMobileMenu: false },
     },
     {
         target: '#connect-wallet-btn-mobile',
         content: 'Tap "Get Started" to create your account with just your email.',
-        spotlightClicks: true,
+        blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'connect-wallet', openMobileMenu: true },
     },
     {
         target: '#nav-user-menu',
         content: 'After signing in, tap your profile avatar to open account options.',
-        spotlightClicks: true,
+        blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'user-menu' },
     },
@@ -186,7 +187,7 @@ export const Tour = () => {
         [isMobile, prepareStepTarget, setStepIndex, steps],
     );
 
-    const handleJoyrideCallback = (data: CallBackProps) => {
+    const handleJoyrideCallback = (data: EventData) => {
         const { index, status, type, action } = data;
         const currentStep = steps[index];
         const currentId = currentStep?.data?.id;
@@ -213,7 +214,7 @@ export const Tour = () => {
             return;
         }
 
-        if (type === EVENTS.STEP_AFTER && action !== 'prev') {
+        if (type === EVENTS.STEP_AFTER && action !== ACTIONS.PREV) {
             if (index < steps.length - 1) {
                 void advanceToStep(index + 1);
             }
@@ -358,35 +359,24 @@ export const Tour = () => {
             steps={steps}
             run={run}
             stepIndex={stepIndex}
-            callback={handleJoyrideCallback}
+            onEvent={handleJoyrideCallback}
             continuous
-            showProgress
-            showSkipButton
-            disableOverlayClose
             scrollToFirstStep
-            scrollOffset={96}
-            disableScrollParentFix={false}
-            spotlightPadding={10}
-            floaterProps={{
-                styles: {
-                    floater: {
-                        filter: 'none',
-                    },
-                },
+            options={{
+                primaryColor: '#4f46e5',
+                zIndex: 10000,
+                showProgress: true,
+                buttons: ['back', 'close', 'primary', 'skip'],
+                overlayClickAction: false,
+                scrollOffset: 96,
+                spotlightPadding: 10,
             }}
             styles={{
                 tooltip: {
                     transition: 'none',
                 },
-                options: {
-                    primaryColor: '#4f46e5',
-                    zIndex: 10000,
-                },
-                overlay: {
-                    zIndex: 9999,
-                },
-                spotlight: {
-                    zIndex: 10000,
+                floater: {
+                    filter: 'none',
                 },
             }}
             tooltipComponent={TourTooltip}

--- a/components/UserProfile/AlchemyMeTokenCreator.tsx
+++ b/components/UserProfile/AlchemyMeTokenCreator.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle, ExternalLink, Info } from 'lucide-react';
 import { formatEther, parseEther, encodeFunctionData, maxUint256 } from 'viem';
-import { useSmartAccountClient, useChain } from '@account-kit/react';
+import { useSmartAccountClient, useChain } from '@/lib/wallet/react';
 import { useToast } from '@/components/ui/use-toast';
 import { DaiFundingOptions } from '@/components/wallet/funding/DaiFundingOptions';
 import { logger } from '@/lib/utils/logger';

--- a/components/UserProfile/AvatarUpload.tsx
+++ b/components/UserProfile/AvatarUpload.tsx
@@ -7,7 +7,7 @@ import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useAvatarUpload } from '@/lib/hooks/metokens/useAvatarUpload';
 import { useCreatorProfile } from '@/lib/hooks/metokens/useCreatorProfile';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { useWalletStatus } from '@/lib/hooks/accountkit/useWalletStatus';
 import { Upload, X, User, AlertCircle, CheckCircle } from 'lucide-react';
 import { convertFailingGateway } from '@/lib/utils/image-gateway';

--- a/components/UserProfile/CancelMembershipButton.tsx
+++ b/components/UserProfile/CancelMembershipButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useSendUserOperation, useSmartAccountClient } from "@account-kit/react";
+import { useSendUserOperation, useSmartAccountClient } from "@/lib/wallet/react";
 import { encodeFunctionData, type Abi } from "viem";
 import { Button } from "@/components/ui/button";
 import { appendBuilderCode } from "@/lib/utils/builder-code";

--- a/components/UserProfile/CreativeBankTab.tsx
+++ b/components/UserProfile/CreativeBankTab.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Loader2, Send, ExternalLink, AlertCircle, RefreshCw, Wallet } from 'lucide-react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { type Address, parseUnits, formatUnits, erc20Abi, encodeFunctionData } from 'viem';
 import { BASE_TOKENS } from '@/lib/sdk/alchemy/swap-service';
 import { useGasSponsorship } from '@/lib/hooks/wallet/useGasSponsorship';
@@ -45,7 +45,7 @@ export function CreativeBankTab() {
                 functionName: 'balanceOf',
                 args: [userAddress as Address],
             });
-            setUsdcBalance(balance);
+            setUsdcBalance(balance as bigint);
             setIsLoadingBalance(false);
         } catch (err) {
             logger.warn('Failed to fetch USDC balance:', err);

--- a/components/UserProfile/CreatorProfileManager.tsx
+++ b/components/UserProfile/CreatorProfileManager.tsx
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useCreatorProfile } from '@/lib/hooks/metokens/useCreatorProfile';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { useToast } from '@/components/ui/use-toast';
 import { useWalletStatus } from '@/lib/hooks/accountkit/useWalletStatus';
 import { AvatarUpload } from './AvatarUpload';

--- a/components/UserProfile/MeTokenCreator.tsx
+++ b/components/UserProfile/MeTokenCreator.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useMeTokensSupabase } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { useMeTokenHubs } from '@/lib/hooks/metokens/useMeTokenHubs';
 import { CollateralHubGuide, STABLECOIN_SUMMARY } from '@/components/metokens/CollateralHubGuide';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { useToast } from '@/components/ui/use-toast';
 import { Loader2, CheckCircle, AlertCircle, Info } from 'lucide-react';
 import { logger } from '@/lib/utils/logger';

--- a/components/UserProfile/MeTokenSubscription.tsx
+++ b/components/UserProfile/MeTokenSubscription.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle, ExternalLink } from 'lucide-react';
 import Image from 'next/image';
 import { formatEther, parseEther, encodeFunctionData, maxUint256 } from 'viem';
-import { useSmartAccountClient, useChain } from '@account-kit/react';
+import { useSmartAccountClient, useChain } from '@/lib/wallet/react';
 import { useMeTokensSupabase, MeTokenData } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { getHubVaultAddress } from '@/lib/utils/metokenSubscriptionUtils';
 import { DaiFundingOptions } from '@/components/wallet/funding/DaiFundingOptions';

--- a/components/UserProfile/MeTokenTrading.tsx
+++ b/components/UserProfile/MeTokenTrading.tsx
@@ -9,7 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useMeTokensSupabase, MeTokenData } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { Loader2, TrendingUp, TrendingDown, AlertCircle, CheckCircle, Lock, ExternalLink } from 'lucide-react';
 import { formatEther, parseEther, encodeFunctionData } from 'viem';
-import { useSmartAccountClient, useChain, useAuthModal, useUser } from '@account-kit/react';
+import { useSmartAccountClient, useChain, useAuthModal, useUser } from '@/lib/wallet/react';
 import { DAI_TOKEN_ADDRESSES, getDaiTokenContract } from '@/lib/contracts/DAIToken';
 import { erc20Abi } from 'viem';
 import { MeTokenSubscription } from './MeTokenSubscription';

--- a/components/UserProfile/MeTokensSection.tsx
+++ b/components/UserProfile/MeTokensSection.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/components/ui/use-toast';
 import { useMeTokensSupabase, MeTokenData } from '@/lib/hooks/metokens/useMeTokensSupabase';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { RobustMeTokenCreator } from './RobustMeTokenCreator';
 import { MeTokenTrading } from './MeTokenTrading';
 import { MeTokenInfo } from './MeTokenInfo';

--- a/components/UserProfile/ProfileOwnerGuard.tsx
+++ b/components/UserProfile/ProfileOwnerGuard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { isAddress } from "viem";
 import { logger } from "@/lib/utils/logger";

--- a/components/UserProfile/RobustMeTokenCreator.tsx
+++ b/components/UserProfile/RobustMeTokenCreator.tsx
@@ -30,7 +30,7 @@ import {
   X
 } from 'lucide-react';
 import { formatEther, parseEther } from 'viem';
-import { useSmartAccountClient, useChain } from '@account-kit/react';
+import { useSmartAccountClient, useChain } from '@/lib/wallet/react';
 import { useToast } from '@/components/ui/use-toast';
 import { useMeTokenCreation, PendingMeTokenTransaction, CreationStatus } from '@/lib/hooks/metokens/useMeTokenCreation';
 import { getDaiTokenContract } from '@/lib/contracts/DAIToken';

--- a/components/UserProfile/UserProfile.tsx
+++ b/components/UserProfile/UserProfile.tsx
@@ -5,7 +5,7 @@ import { NextPage } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, useContext } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { userToAccount } from "@/lib/types/account";
 import { ListUploadedAssets } from "@/components/UserProfile/list-uploaded-assets/ListUploadedAssets";
 import {

--- a/components/Videos/Upload/CrossChainSwap.tsx
+++ b/components/Videos/Upload/CrossChainSwap.tsx
@@ -7,7 +7,7 @@ import {
     useSignAndSendPreparedCalls,
     useWaitForCallsStatus,
     useUser,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -161,7 +161,10 @@ export function CrossChainSwap({ onSwapSuccess, requiredAmount, recipientAddress
                 swapParams.to = targetRecipient;
             }
 
-            const result = await prepareSwapAsync(swapParams);
+            const result = await prepareSwapAsync(swapParams) as {
+                quote: { minimumToAmount?: string | bigint };
+                [key: string]: unknown;
+            };
 
             const { quote: swapQuote, ...calls } = result;
 
@@ -172,7 +175,10 @@ export function CrossChainSwap({ onSwapSuccess, requiredAmount, recipientAddress
             });
 
             if (swapQuote.minimumToAmount) {
-                const rawAmount = BigInt(swapQuote.minimumToAmount);
+                const rawAmount =
+                    typeof swapQuote.minimumToAmount === "bigint"
+                        ? swapQuote.minimumToAmount
+                        : BigInt(swapQuote.minimumToAmount);
                 const formattedAmount = formatEther(rawAmount);
                 const ipAmount = parseFloat(formattedAmount);
 

--- a/components/Videos/Upload/CrossChainSwap.tsx
+++ b/components/Videos/Upload/CrossChainSwap.tsx
@@ -164,7 +164,11 @@ export function CrossChainSwap({ onSwapSuccess, requiredAmount, recipientAddress
             const result = await prepareSwapAsync(swapParams) as {
                 quote: { minimumToAmount?: string | bigint };
                 [key: string]: unknown;
-            };
+            } | null | undefined;
+
+            if (!result) {
+                throw new Error("Failed to prepare swap: no result returned");
+            }
 
             const { quote: swapQuote, ...calls } = result;
 

--- a/components/Videos/Upload/NFTMintingStep.tsx
+++ b/components/Videos/Upload/NFTMintingStep.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/components/Videos/Upload/TransferIP.tsx
+++ b/components/Videos/Upload/TransferIP.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/Videos/Upload/index.tsx
+++ b/components/Videos/Upload/index.tsx
@@ -22,7 +22,7 @@ import type { VideoAsset } from "@/lib/types/video-asset";
 import { useUniversalAccount } from "@/lib/hooks/accountkit/useUniversalAccount";
 import { getLivepeerAsset } from "@/app/api/livepeer/assetUploadActions";
 import { useAutoDeployContentCoin } from "@/lib/hooks/marketplace/useAutoDeployContentCoin";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { createSplitForVideo } from "@/services/splits";
 import { logger } from "@/lib/utils/logger";
 

--- a/components/Videos/VideoChat.tsx
+++ b/components/Videos/VideoChat.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { useVideoChat } from "@/lib/hooks/xmtp/useVideoChat";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/components/Videos/VideoComments.tsx
+++ b/components/Videos/VideoComments.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { useVideoComments } from "@/lib/hooks/video/useVideoComments";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -11,7 +11,7 @@ import {
 import { Src } from "@livepeer/react";
 import * as Popover from "@radix-ui/react-popover";
 
-import { useUser, useAuthModal } from "@account-kit/react";
+import { useUser, useAuthModal } from "@/lib/wallet/react";
 import { userToAccount } from "@/lib/types/account";
 
 import {

--- a/components/Videos/VideoEditButton.tsx
+++ b/components/Videos/VideoEditButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { VideoEditDialog } from "./VideoEditDialog";

--- a/components/Videos/VideoMeTokenBuyDialog.tsx
+++ b/components/Videos/VideoMeTokenBuyDialog.tsx
@@ -14,7 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle, TrendingUp } from 'lucide-react';
 import { useMeTokensSupabase } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { formatEther, parseEther, encodeFunctionData } from 'viem';
-import { useSmartAccountClient, useAuthModal, useUser } from '@account-kit/react';
+import { useSmartAccountClient, useAuthModal, useUser } from '@/lib/wallet/react';
 import { getDaiTokenContract } from '@/lib/contracts/DAIToken';
 import { erc20Abi } from 'viem';
 import { METOKEN_ABI } from '@/lib/contracts/MeToken';

--- a/components/Videos/VideoSplitDistributeButton.tsx
+++ b/components/Videos/VideoSplitDistributeButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { DollarSign, Loader2 } from "lucide-react";
 import { toast } from "sonner";

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -34,7 +34,7 @@ import {
   useUser,
   useChain,
   useSendUserOperation,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import { useUnifiedLogout } from "@/hooks/useUnifiedLogout";
 import { base } from "@account-kit/infra";
 import { Button } from "@/components/ui/button";

--- a/components/account-dropdown/MembershipSection.tsx
+++ b/components/account-dropdown/MembershipSection.tsx
@@ -14,7 +14,7 @@ import {
   type LockAddressValue,
 } from "../../lib/sdk/unlock/services";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 
 interface MembershipSectionProps {
   className?: string;

--- a/components/account-dropdown/MobileOrbSection.tsx
+++ b/components/account-dropdown/MobileOrbSection.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useOrbSession } from "@/context/OrbSessionContext";
 import { shortenAddress } from "@/lib/utils/utils";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 
 export function MobileOrbSection() {
   const user = useUser();

--- a/components/auth/AuthErrorMonitor.tsx
+++ b/components/auth/AuthErrorMonitor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useAuthError } from "@account-kit/react";
+import { useAuthError } from "@/lib/wallet/react";
 import { toast } from "sonner";
 import { formatAccountKitAuthError } from "@/lib/auth/format-account-kit-auth-error";
 

--- a/components/auth/GuardLoadingFallback.tsx
+++ b/components/auth/GuardLoadingFallback.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { useLogout } from '@account-kit/react';
+import { useLogout } from '@/lib/wallet/react';
 import { clearStoredOrbSession } from '@/lib/sdk/orb/login';
 import { resetAppSession } from '@/lib/auth/session-recovery';
 

--- a/components/auth/LoginButton.tsx
+++ b/components/auth/LoginButton.tsx
@@ -5,7 +5,7 @@ import {
   useAuthModal,
   useUser,
   useSmartAccountClient,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";

--- a/components/auth/LoginWithEthereumButton.tsx
+++ b/components/auth/LoginWithEthereumButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useAuthModal, useUser } from "@account-kit/react";
+import { useAuthModal, useUser } from "@/lib/wallet/react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 

--- a/components/auth/WalletReadyGuard.tsx
+++ b/components/auth/WalletReadyGuard.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { GuardLoadingFallback } from "@/components/auth/GuardLoadingFallback";
+
+/**
+ * Waits for Privy auth SDK initialization before rendering wallet-dependent guards.
+ */
+export function WalletReadyGuard({ children }: { children: React.ReactNode }) {
+  const { ready } = usePrivy();
+
+  if (!ready) {
+    return (
+      <GuardLoadingFallback isLoading allowBypass={false}>
+        {children}
+      </GuardLoadingFallback>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/components/home-page/DearCreativePublications.tsx
+++ b/components/home-page/DearCreativePublications.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { NewsletterModal } from "./NewsletterModal";
 import { getPublicationPosts, getSubscriberCount, getCoinData } from "@/app/actions/paragraph";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { Newspaper } from "lucide-react";
 import { logger } from '@/lib/utils/logger';
 

--- a/components/home-page/DearCreativeTradeButton.tsx
+++ b/components/home-page/DearCreativeTradeButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { useSmartAccountClient, useUser, useAuthModal } from "@account-kit/react";
+import { useSmartAccountClient, useUser, useAuthModal } from "@/lib/wallet/react";
 import { getBuyArgs, getSellArgs, getQuote } from "@/app/actions/paragraph";
 import { parseEther, encodeFunctionData, parseAbi, formatEther } from "viem";
 import { Loader2, ArrowRightLeft } from "lucide-react";

--- a/components/home-page/TopChart.tsx
+++ b/components/home-page/TopChart.tsx
@@ -7,7 +7,7 @@ import { stack } from "@/lib/sdk/stack/stackClient";
 import { Button } from "../ui/button";
 import { FaSpinner, FaTrophy } from "react-icons/fa";
 import Link from "next/link";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { Address, getAddress } from "viem";
 import { logger } from '@/lib/utils/logger';
 

--- a/components/memberships/MembershipHome.tsx
+++ b/components/memberships/MembershipHome.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSendUserOperation, useSmartAccountClient, useUser, useChain } from "@account-kit/react";
+import { useSendUserOperation, useSmartAccountClient, useUser, useChain } from "@/lib/wallet/react";
 import { formatUnits, parseUnits, encodeFunctionData, encodeAbiParameters, type Abi, erc20Abi, createPublicClient, http } from "viem";
 import { MembershipButton } from "./MembershipButton";
 import { MembershipCard } from "./MembershipCard";

--- a/components/predictions/BetForm.tsx
+++ b/components/predictions/BetForm.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { base } from "@account-kit/infra";
 import {
   createPublicClient,

--- a/components/predictions/ClaimWinningsCard.tsx
+++ b/components/predictions/ClaimWinningsCard.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { base } from "@account-kit/infra";
 import { createPublicClient, http, fallback, formatEther } from "viem";
 import {

--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useChain, useAuthModal, useSmartAccountClient } from "@account-kit/react";
+import { useChain, useAuthModal, useSmartAccountClient } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { base } from "@account-kit/infra";

--- a/components/predictions/EvidenceSubmissionModal.tsx
+++ b/components/predictions/EvidenceSubmissionModal.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { submitEvidence } from "@/lib/sdk/reality-eth/reality-eth-arbitrator";
 import { useToast } from "@/components/ui/use-toast";
 import { Loader2, Upload } from "lucide-react";

--- a/components/proposal-list/ProposalList.tsx
+++ b/components/proposal-list/ProposalList.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2, Clock, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
-import { useChain, useAuthModal, useSignTypedData } from "@account-kit/react";
+import { useChain, useAuthModal, useSignTypedData } from "@/lib/wallet/react";
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
 import { createVote } from "@/app/vote/[id]/actions";
 import { SNAPSHOT_SPACE } from "@/context/context";

--- a/components/songchain/HallidayOnramp.tsx
+++ b/components/songchain/HallidayOnramp.tsx
@@ -6,7 +6,7 @@ import {
   openHallidayPayments,
 } from "@halliday-sdk/payments";
 import { connectWalletClient } from "@halliday-sdk/payments/viem";
-import { useAuthModal, useSmartAccountClient, useUser } from "@account-kit/react";
+import { useAuthModal, useSmartAccountClient, useUser } from "@/lib/wallet/react";
 import type { WalletClient } from "viem";
 import { Button } from "@/components/ui/button";
 import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
-import { useChain } from "@account-kit/react";
+import { useChain } from "@/lib/wallet/react";
 import { base, optimism } from "@account-kit/infra";
 import Image from "next/image";
 

--- a/components/vote/Create.tsx
+++ b/components/vote/Create.tsx
@@ -318,7 +318,7 @@ function Create() {
       // Best-effort: verify signer is responsive and bound to the expected EOA.
       // Some environments report waitForConnected timeouts even when signing works, so do not hard-fail on it.
       try {
-        const signerAddr = signer.address;
+        const signerAddr = signer?.address;
         logger.debug("Signer getAddress():", signerAddr);
         if (signerAddr?.toLowerCase?.() !== walletAddress.toLowerCase()) {
           logger.warn(

--- a/components/vote/Create.tsx
+++ b/components/vote/Create.tsx
@@ -4,7 +4,7 @@ import React, { useState, Suspense, useEffect } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useChain, useAuthModal, useSigner } from "@account-kit/react";
+import { useChain, useAuthModal, useSigner } from "@/lib/wallet/react";
 import { useRouter } from "next/navigation";
 import { createProposal } from "@/app/vote/create/[address]/actions";
 import { SNAPSHOT_SPACE } from "@/context/context";
@@ -318,12 +318,7 @@ function Create() {
       // Best-effort: verify signer is responsive and bound to the expected EOA.
       // Some environments report waitForConnected timeouts even when signing works, so do not hard-fail on it.
       try {
-        const signerAddr = await Promise.race([
-          signer.getAddress(),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("getAddress timed out")), 10000),
-          ),
-        ]);
+        const signerAddr = signer.address;
         logger.debug("Signer getAddress():", signerAddr);
         if (signerAddr?.toLowerCase?.() !== walletAddress.toLowerCase()) {
           logger.warn(

--- a/components/wallet/balance/DaiBalanceChecker.tsx
+++ b/components/wallet/balance/DaiBalanceChecker.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, useCallback } from 'react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { formatEther } from 'viem';
 import { erc20Abi } from 'viem';
 import { DAI_TOKEN_ADDRESSES } from '@/lib/contracts/DAIToken';

--- a/components/wallet/balance/MeTokenBalances.tsx
+++ b/components/wallet/balance/MeTokenBalances.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSmartAccountClient, useUser } from "@account-kit/react";
+import { useSmartAccountClient, useUser } from "@/lib/wallet/react";
 import { formatEther } from "viem";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMeTokensSupabase, MeTokenData } from "@/lib/hooks/metokens/useMeTokensSupabase";

--- a/components/wallet/balance/MeTokenPortfolio.tsx
+++ b/components/wallet/balance/MeTokenPortfolio.tsx
@@ -17,8 +17,8 @@ import {
   AlertCircle,
   Loader2
 } from 'lucide-react';
-import { useUser } from '@account-kit/react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import Link from 'next/link';
 import { convertFailingGateway } from '@/lib/utils/image-gateway';
 

--- a/components/wallet/balance/TokenBalance.tsx
+++ b/components/wallet/balance/TokenBalance.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSmartAccountClient, useUser, useChain } from "@account-kit/react";
+import { useSmartAccountClient, useUser, useChain } from "@/lib/wallet/react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatUnits, createPublicClient, http } from "viem";
 import { getUsdcTokenContract } from "@/lib/contracts/USDCToken";

--- a/components/wallet/buy/cdp-fund-button.tsx
+++ b/components/wallet/buy/cdp-fund-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { getOnrampBuyUrl } from "@coinbase/onchainkit/fund";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { useState } from "react";
 import { logger } from '@/lib/utils/logger';
 

--- a/components/wallet/buy/coinbase-fund-button.tsx
+++ b/components/wallet/buy/coinbase-fund-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 import { logger } from '@/lib/utils/logger';

--- a/components/wallet/buy/coinbase-offramp-button.tsx
+++ b/components/wallet/buy/coinbase-offramp-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useSmartAccountClient, useUser } from "@account-kit/react";
+import { useSmartAccountClient, useUser } from "@/lib/wallet/react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 import { logger } from '@/lib/utils/logger';

--- a/components/wallet/buy/dai-fund-button.tsx
+++ b/components/wallet/buy/dai-fund-button.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";

--- a/components/wallet/funding/DaiFundingOptions.tsx
+++ b/components/wallet/funding/DaiFundingOptions.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2, AlertCircle, CheckCircle, CreditCard, ArrowRightLeft } from 'lucide-react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { formatEther } from 'viem';
 import { erc20Abi } from 'viem';
 import { DAI_TOKEN_ADDRESSES } from '@/lib/contracts/DAIToken';

--- a/components/wallet/swap/AlchemySwapWidget.tsx
+++ b/components/wallet/swap/AlchemySwapWidget.tsx
@@ -8,14 +8,14 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Loader2, ArrowRightLeft, CheckCircle, XCircle, ExternalLink, DollarSign } from 'lucide-react';
 import Image from 'next/image';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient, useChain } from '@/lib/wallet/react';
 import { type Hex, type Address, parseEther, formatEther, encodeFunctionData, erc20Abi, parseUnits, maxUint256 } from 'viem';
 import { alchemySwapService, AlchemySwapService, type TokenSymbol, BASE_TOKENS, TOKEN_INFO, SWAP_UI_TOKENS, emptyTokenBalances, emptyTokenPrices } from '@/lib/sdk/alchemy/swap-service';
 import { priceService, PriceService } from '@/lib/sdk/alchemy/price-service';
 import { CurrencyConverter } from '@/lib/utils/currency-converter';
 import { logger } from '@/lib/utils/logger';
 import { getTokenIcon } from '@/lib/utils/token-icons';
-import { swapActions } from "@account-kit/wallet-client/experimental";
+import { swapActions } from "@alchemy/wallet-apis/experimental";
 
 const ERC20_BALANCE_ABI = [{
   name: 'balanceOf',
@@ -47,6 +47,7 @@ interface SwapState {
 export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false, defaultToToken = 'USDC' }: AlchemySwapWidgetProps) {
 
   const { address, client } = useSmartAccountClient({});
+  const { chain } = useChain();
 
   const [swapState, setSwapState] = useState<SwapState>({
     fromToken: 'ETH',
@@ -615,7 +616,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
               </select>
 
               <Image
-                src={getTokenIcon(swapState.fromToken, client?.chain?.id)}
+                src={getTokenIcon(swapState.fromToken, client?.chain?.id ?? chain?.id)}
                 alt={swapState.fromToken}
                 width={32}
                 height={32}
@@ -665,7 +666,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
           <div className="flex justify-between text-xs text-muted-foreground">
             <div className="flex items-center space-x-1">
               <Image
-                src={getTokenIcon(swapState.fromToken, client?.chain?.id)}
+                src={getTokenIcon(swapState.fromToken, client?.chain?.id ?? chain?.id)}
                 alt={swapState.fromToken}
                 width={20}
                 height={20}
@@ -738,7 +739,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
               </select>
 
               <Image
-                src={getTokenIcon(swapState.toToken, client?.chain?.id)}
+                src={getTokenIcon(swapState.toToken, client?.chain?.id ?? chain?.id)}
                 alt={swapState.toToken}
                 width={32}
                 height={32}
@@ -773,7 +774,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
           <div className="flex justify-between text-xs text-muted-foreground">
             <div className="flex items-center space-x-1">
               <Image
-                src={getTokenIcon(swapState.toToken, client?.chain?.id)}
+                src={getTokenIcon(swapState.toToken, client?.chain?.id ?? chain?.id)}
                 alt={swapState.toToken}
                 width={20}
                 height={20}

--- a/components/wallet/swap/DaiSwapButton.tsx
+++ b/components/wallet/swap/DaiSwapButton.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Loader2, ArrowRightLeft, CheckCircle, XCircle, ExternalLink } from 'lucide-react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { type Address, type Hex } from 'viem';
 import { alchemySwapService, AlchemySwapService, type TokenSymbol } from '@/lib/sdk/alchemy/swap-service';
 import { logger } from '@/lib/utils/logger';

--- a/config.ts
+++ b/config.ts
@@ -7,16 +7,12 @@ import { alchemy, base } from "@account-kit/infra";
 import { http } from "viem";
 import { QueryClient } from "@tanstack/react-query";
 import { modularAccountFactoryAddresses } from "./lib/utils/modularAccount";
-import { getStoryChain } from "./lib/sdk/story/chains";
-import { getLensChain } from "./lib/sdk/lens/chains";
+import { storyChain, lensChain } from "@/lib/wallet/chains";
 import { SITE_TOPIC_LOGO } from "./context/context";
 import Image from "next/image";
 import React from "react";
 
-// Define the chains we want to support (Base + Story + Lens for client-side signing)
-const storyChain = getStoryChain();
-export const lensChain = getLensChain();
-export const chains = [base, storyChain, lensChain];
+export { walletChains as chains, lensChain } from "@/lib/wallet/chains";
 
 // Default chain for initial connection
 const defaultChain = base;
@@ -107,7 +103,6 @@ const uiConfig: AlchemyAccountsUIConfig = {
       [{ type: "email", emailMode: "otp" }, { type: "passkey" }],
       [
         { type: "social", authProviderId: "google", mode: "popup" },
-        { type: "social", authProviderId: "facebook", mode: "popup" },
         { type: "social", authProviderId: "twitch", mode: "popup" },
       ],
     ],

--- a/context/OrbSessionContext.tsx
+++ b/context/OrbSessionContext.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
   useSyncExternalStore,
 } from 'react';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import useModularAccount from '@/lib/hooks/accountkit/useModularAccount';
 import {
   getOrbLogin,

--- a/docs/PRIVY_MIGRATION_CLEANUP.md
+++ b/docs/PRIVY_MIGRATION_CLEANUP.md
@@ -1,0 +1,33 @@
+# Post-Migration Cleanup Checklist
+
+Run after nearly all users have logged in and completed wallet key migration.
+
+## Remove migration stack
+
+- [ ] Remove `@privy-io/alchemy-migration` and `MigrationProvider` from `app/providers.tsx`
+- [ ] Remove `@privy-io/alchemy-migration/styles.css` import
+- [ ] Uninstall `@account-kit/react` (if no longer required)
+
+## Remove legacy Alchemy signer UI
+
+- [ ] Remove `#alchemy-signer-iframe-container` from `app/layout.tsx`
+- [ ] Delete `components/IframeCleanup.tsx` and related cleanup calls
+- [ ] Delete `lib/sdk/accountKit/signer.ts`
+
+## Simplify Privy config
+
+- [ ] Remove `createWalletCreationOnLoginPlugin` from `lib/wallet/privy-config.ts`
+- [ ] Keep `embeddedWallets.ethereum.createOnLogin: "users-without-wallets"`
+
+## Optional package removal
+
+Evaluate removing if unused:
+
+- `@account-kit/core`, `@account-kit/signer`, `@account-kit/wallet-client`
+- `@aa-sdk/core`, `@aa-sdk/ethers`
+- Keep `@account-kit/smart-contracts` if still using `predictModularAccountV2Address`
+
+## Config cleanup
+
+- [ ] Remove legacy `config.ts` Account Kit `createConfig` if only used for migration
+- [ ] Keep `queryClient` export in a slim `config.ts` or move to `lib/query-client.ts`

--- a/docs/PRIVY_MIGRATION_CUTOVER.md
+++ b/docs/PRIVY_MIGRATION_CUTOVER.md
@@ -1,0 +1,38 @@
+# Privy + Wallet APIs v5 — Production Cutover (Step 4)
+
+Follow this checklist when deploying the signer migration to production.
+
+## Prerequisites
+
+- [ ] Privy app configured with email, passkey, Google, Twitch (no Facebook)
+- [ ] Privy **allowed domains** include production + staging URLs
+- [ ] OAuth **redirect URLs** configured for Google/Twitch (`NEXT_PUBLIC_URL` or Vercel URL)
+- [ ] `NEXT_PUBLIC_PRIVY_APP_ID` and `NEXT_PUBLIC_PRIVY_CLIENT_ID` set in Vercel
+- [ ] Alchemy Gas Manager policy linked to the same app as `NEXT_PUBLIC_ALCHEMY_API_KEY`
+- [ ] CSP allows Privy (`auth.privy.io`, WalletConnect) — see `next.config.mjs` headers
+- [ ] Staging validated: login, send transaction, migration modal for test Alchemy user
+
+## Cutover sequence (critical)
+
+**Order: Deploy → Export → Import** (never export before deploy).
+
+1. **Pause new signups briefly** (optional maintenance window)
+2. **Deploy** this branch to production (Privy + `MigrationProvider` live)
+3. **Export users** from Alchemy Dashboard → Wallets → Export → download JSON
+4. **Import users** into Privy Dashboard → User management → Users → Import users
+5. **Verify** a returning user sees the migration modal and completes key transfer
+6. **Monitor** migration completion; users who log in later can still migrate
+
+If export ran before deploy, run a **second export** after deploy to catch signups in the gap.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Migration modal never appears | User not imported — delete Privy user, re-import from Alchemy export |
+| Modal never appears | Privy auto-created wallet first — confirm `createWalletCreationOnLoginPlugin` is active |
+| Wrong wallet address on send | Ensure non-7702 mode: `requestAccount({ accountType: "sma-b" })` + `account: scaAddress` |
+
+## Post-migration cleanup (after ~100% key transfer)
+
+See `docs/PRIVY_MIGRATION_CLEANUP.md`.

--- a/hooks/useCreatorVideoLibrary.ts
+++ b/hooks/useCreatorVideoLibrary.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import useModularAccount from '@/lib/hooks/accountkit/useModularAccount';
 import type { VideoAsset } from '@/lib/types/video-asset';
 import { fetchPublishedVideos } from '@/lib/utils/published-videos-client';

--- a/hooks/useIsVideoAdmin.ts
+++ b/hooks/useIsVideoAdmin.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { VIDEO_ADMIN_ADDRESS } from "@/lib/constants/admin";
 

--- a/hooks/useLens.ts
+++ b/hooks/useLens.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { useSmartAccountClient, useUser } from "@account-kit/react";
+import { useSmartAccountClient, useUser } from "@/lib/wallet/react";
 import { signLensChallenge } from "@/lib/sdk/lens/account-kit-adapter";
 import { publicClient } from "@/lib/sdk/lens/client";
 import { useOrbSession } from "@/context/OrbSessionContext";

--- a/hooks/useLensOrbWrite.ts
+++ b/hooks/useLensOrbWrite.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
-import { useAuthModal } from '@account-kit/react';
+import { useAuthModal } from '@/lib/wallet/react';
 import { useOrbSession } from '@/context/OrbSessionContext';
 import { resumeLensSessionFromOrb } from '@/lib/sdk/lens/orb-session-client';
 import {

--- a/hooks/useUnifiedLogout.ts
+++ b/hooks/useUnifiedLogout.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useLogout } from '@account-kit/react';
+import { useLogout } from '@/lib/wallet/react';
 import { useOrbSession } from '@/context/OrbSessionContext';
 
 /** Signs out of both Account Kit wallet and Orb / Lens session. */

--- a/lib/auth/useWalletAuth.ts
+++ b/lib/auth/useWalletAuth.ts
@@ -12,7 +12,7 @@
  */
 
 import { useCallback, useEffect, useRef } from "react";
-import { useSignMessage, useUser } from "@account-kit/react";
+import { useSignMessage, useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { logger } from "@/lib/utils/logger";
 

--- a/lib/hooks/accountkit/useAuthStateMonitor.ts
+++ b/lib/hooks/accountkit/useAuthStateMonitor.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from 'react';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { toast } from 'sonner';
 import { logger } from '@/lib/utils/logger';
 

--- a/lib/hooks/accountkit/useBatchTransactions.ts
+++ b/lib/hooks/accountkit/useBatchTransactions.ts
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import {
   useSmartAccountClient,
-} from "@account-kit/react";
+} from "@/lib/wallet/react";
 import { toast } from "sonner";
 import { logger } from '@/lib/utils/logger';
 import { appendBuilderCode } from "@/lib/utils/builder-code";

--- a/lib/hooks/accountkit/useCreatorWalletAddress.ts
+++ b/lib/hooks/accountkit/useCreatorWalletAddress.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 
 /**

--- a/lib/hooks/accountkit/useModularAccount.ts
+++ b/lib/hooks/accountkit/useModularAccount.ts
@@ -1,4 +1,4 @@
-import { useSmartAccountClient, useUser, useChain } from "@account-kit/react";
+import { useSmartAccountClient, useUser, useChain } from "@/lib/wallet/react";
 import { base } from "@account-kit/infra";
 import { modularAccountFactoryAddresses } from "@/lib/utils/modularAccount";
 import { Chain } from "viem";

--- a/lib/hooks/accountkit/useSessionKey.ts
+++ b/lib/hooks/accountkit/useSessionKey.ts
@@ -1,11 +1,12 @@
 import { useCallback, useState } from "react";
-import { useSmartAccountClient, useChain } from "@account-kit/react";
+import { useSmartAccountClient, useChain } from "@/lib/wallet/react";
 import { generatePrivateKey } from "viem/accounts";
 import { LocalAccountSigner } from "@aa-sdk/core";
 import { createModularAccountV2Client } from "@account-kit/smart-contracts";
 import { type SmartAccountSigner } from "@aa-sdk/core";
 import { alchemy } from "@account-kit/infra";
 import { useSessionKeyStorage } from "./useSessionKeyStorage";
+import { buildSessionKeyContext } from "@/lib/wallet/session-keys";
 import { logger } from '@/lib/utils/logger';
 
 
@@ -121,6 +122,7 @@ export function useSessionKey(options: UseSessionKeyOptions = {}) {
   return {
     createSessionKey,
     useSessionKeyClient,
+    buildSessionKeyContext,
     isInstalling,
   };
 }

--- a/lib/hooks/accountkit/useSessionKeyStorage.ts
+++ b/lib/hooks/accountkit/useSessionKeyStorage.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { type SessionKeyPermissions } from "./useSessionKey";
 import { logger } from '@/lib/utils/logger';
 

--- a/lib/hooks/accountkit/useSmartWalletDisplayAddress.ts
+++ b/lib/hooks/accountkit/useSmartWalletDisplayAddress.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "./useModularAccount";
 import { shortenAddress } from "@/lib/utils/utils";
 

--- a/lib/hooks/accountkit/useUniversalAccount.ts
+++ b/lib/hooks/accountkit/useUniversalAccount.ts
@@ -1,5 +1,5 @@
 import useModularAccount from "./useModularAccount";
-import { useAccount } from "@account-kit/react";
+import { useAccount } from "@/lib/wallet/react";
 
 /**
  * Returns the best available wallet address (SCA or EOA) and its type.

--- a/lib/hooks/accountkit/useWalletStatus.ts
+++ b/lib/hooks/accountkit/useWalletStatus.ts
@@ -1,4 +1,4 @@
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "./useModularAccount";
 import { isWalletConnected } from "@/lib/utils/wallet";
 

--- a/lib/hooks/livepeer/useCreateVerifiableAttestation.ts
+++ b/lib/hooks/livepeer/useCreateVerifiableAttestation.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { useSignTypedData } from "@account-kit/react";
+import { useSignTypedData } from "@/lib/wallet/react";
 import { useUniversalAccount } from "@/lib/hooks/accountkit/useUniversalAccount";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import {
   VERIFIABLE_VIDEO_DOMAIN,
   VERIFIABLE_VIDEO_TYPES,

--- a/lib/hooks/marketplace/useContentCoin.ts
+++ b/lib/hooks/marketplace/useContentCoin.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { createPublicClient, encodeFunctionData, parseEther } from 'viem';
 import { alchemy, base } from '@account-kit/infra';
 import { useToast } from '@/components/ui/use-toast';

--- a/lib/hooks/metokens/useAvatarUpload.ts
+++ b/lib/hooks/metokens/useAvatarUpload.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from 'react';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { IPFSUploadResult } from '@/lib/sdk/ipfs/service';
 import { useCreatorProfile } from './useCreatorProfile';
 import { useToast } from '@/components/ui/use-toast';

--- a/lib/hooks/metokens/useCreatorProfile.ts
+++ b/lib/hooks/metokens/useCreatorProfile.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useUser } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
 import { logger } from '@/lib/utils/logger';
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { formatWalletAuthError } from '@/lib/auth/format-wallet-auth-error';

--- a/lib/hooks/metokens/useMeTokenCreation.ts
+++ b/lib/hooks/metokens/useMeTokenCreation.ts
@@ -12,7 +12,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { useUser, useSmartAccountClient } from '@account-kit/react';
+import { useUser, useSmartAccountClient } from '@/lib/wallet/react';
 import { useGasSponsorship } from '@/lib/hooks/wallet/useGasSponsorship';
 import { parseEther, formatEther, encodeFunctionData, decodeEventLog } from 'viem';
 import { parseBundlerError, shouldRetryError } from '@/lib/utils/bundlerErrorParser';
@@ -532,7 +532,7 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
       });
 
       // Send the operation without blocking on a long timeout
-      let operation: { hash: `0x${string}` };
+      let operation: { hash: string };
       try {
         const sendPromise = client.sendUserOperation({
           uo: {

--- a/lib/hooks/metokens/useMeTokenHoldings.ts
+++ b/lib/hooks/metokens/useMeTokenHoldings.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useUser } from '@account-kit/react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useUser } from '@/lib/wallet/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { formatEther, parseEther } from 'viem';
 import { meTokensSubgraph } from '@/lib/sdk/metokens/subgraph';
 import { creatorProfileSupabaseService, CreatorProfile } from '@/lib/sdk/supabase/creator-profiles';

--- a/lib/hooks/metokens/useMeTokenPurchase.ts
+++ b/lib/hooks/metokens/useMeTokenPurchase.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSmartAccountClient } from '@account-kit/react';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { encodeFunctionData, parseEther } from 'viem';
 import { useToast } from '@/components/ui/use-toast';
 import { useGasSponsorship } from '@/lib/hooks/wallet/useGasSponsorship';

--- a/lib/hooks/metokens/useMeTokens.ts
+++ b/lib/hooks/metokens/useMeTokens.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useUser, useSendUserOperation, useSmartAccountClient } from '@account-kit/react';
+import { useUser, useSendUserOperation, useSmartAccountClient } from '@/lib/wallet/react';
 import { useGasSponsorship } from "@/lib/hooks/wallet/useGasSponsorship";
 import { parseEther, formatEther, encodeFunctionData } from 'viem';
 import { meTokensSubgraph, MeToken } from '@/lib/sdk/metokens/subgraph';

--- a/lib/hooks/metokens/useMeTokensSupabase.ts
+++ b/lib/hooks/metokens/useMeTokensSupabase.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useUser, useSmartAccountClient } from '@account-kit/react';
+import { useUser, useSmartAccountClient } from '@/lib/wallet/react';
 import { parseEther, formatEther, encodeFunctionData } from 'viem';
 import { meTokenSupabaseService, MeToken, MeTokenBalance } from '@/lib/sdk/supabase/metokens';
 import { CreateMeTokenData, UpdateMeTokenData } from '@/lib/sdk/supabase/client';

--- a/lib/hooks/payments/useX402Payment.ts
+++ b/lib/hooks/payments/useX402Payment.ts
@@ -8,12 +8,19 @@
  */
 
 import { useCallback, useState, useMemo } from 'react';
-import { useSmartAccountClient } from '@account-kit/react';
-import { wrapFetchWithPayment, decodeXPaymentResponse } from 'x402-fetch';
+import { useSmartAccountClient } from '@/lib/wallet/react';
 import { USDC_TOKEN_ADDRESSES, USDC_TOKEN_DECIMALS } from '@/lib/contracts/USDCToken';
 import { base, alchemy } from '@account-kit/infra';
 import { erc20Abi, createPublicClient } from 'viem';
 import { logger } from '@/lib/utils/logger';
+
+async function loadX402Fetch() {
+  const mod = await import('x402-fetch');
+  return {
+    wrapFetchWithPayment: mod.wrapFetchWithPayment,
+    decodeXPaymentResponse: mod.decodeXPaymentResponse,
+  };
+}
 
 // x402 Payment Configuration for USDC on Base
 const X402_CONFIG = {
@@ -103,10 +110,9 @@ export function useX402Payment() {
         logger.debug(`Recipient: ${recipientAddress}`);
       }
 
+      const { wrapFetchWithPayment, decodeXPaymentResponse } = await loadX402Fetch();
+
       // Wrap fetch with x402 payment capability
-      // This will automatically handle payment negotiations and token approvals
-      // Note: Type assertion needed due to viem version mismatch between x402's bundled viem and our viem
-      // The x402-fetch library only takes fetch and account as parameters
       const fetchWithPayment = (wrapFetchWithPayment as any)(fetch, client.account);
 
       // Make the x402 payment request

--- a/lib/hooks/unlock/useIsMember.ts
+++ b/lib/hooks/unlock/useIsMember.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMembershipVerification } from "./useMembershipVerification";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { useEffect, useState } from "react";
 
 /**

--- a/lib/hooks/unlock/useMembershipNFTs.ts
+++ b/lib/hooks/unlock/useMembershipNFTs.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useUser, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSmartAccountClient } from "@/lib/wallet/react";
 import { unlockService } from "@/lib/sdk/unlock/services";
 import type { LockAddress } from "@/lib/sdk/unlock/services";
 import { logger } from '@/lib/utils/logger';

--- a/lib/hooks/unlock/useMembershipVerification.ts
+++ b/lib/hooks/unlock/useMembershipVerification.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 
 import {
   unlockService,

--- a/lib/hooks/video/useVideoComments.ts
+++ b/lib/hooks/video/useVideoComments.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import type { VideoComment, CreateCommentInput } from "@/lib/types/video-comments";
 import { logger } from '@/lib/utils/logger';

--- a/lib/hooks/video/useVideoTip.ts
+++ b/lib/hooks/video/useVideoTip.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { useSmartAccountClient } from "@account-kit/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { type Address, type Hex, encodeFunctionData, parseAbi, parseUnits, formatUnits, erc20Abi } from "viem";
 import { USDC_TOKEN_ADDRESSES, USDC_TOKEN_DECIMALS } from "@/lib/contracts/USDCToken";
 import { useGasSponsorship } from "@/lib/hooks/wallet/useGasSponsorship";

--- a/lib/hooks/wallet/usePrivySigner.ts
+++ b/lib/hooks/wallet/usePrivySigner.ts
@@ -1,0 +1,3 @@
+"use client";
+
+export { usePrivySigner } from "@/lib/wallet/react";

--- a/lib/hooks/wallet/useSmartWalletClient.ts
+++ b/lib/hooks/wallet/useSmartWalletClient.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useWalletClientContext } from "@/lib/wallet/wallet-context";
+import { useWalletChain } from "@/lib/wallet/chain-context";
+
+/** React hook for the v5 smart wallet client (non-7702 ModularAccountV2 / sma-b). */
+export function useSmartWalletClient() {
+  const { client, address, isLoadingClient, error, signer, eoaAddress, refreshClient } =
+    useWalletClientContext();
+  const { chain, setChain } = useWalletChain();
+
+  return {
+    client,
+    address,
+    scaAddress: address,
+    eoaAddress,
+    signer,
+    chain,
+    setChain,
+    isLoadingClient,
+    error,
+    refreshClient,
+  };
+}

--- a/lib/hooks/xmtp/useLiveChat.ts
+++ b/lib/hooks/xmtp/useLiveChat.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { Client, Group, Message, DecodedMessage } from "@xmtp/browser-sdk";
 import { ConsentState } from "@xmtp/browser-sdk";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { useXmtpClient } from "./useXmtpClient";
 import { parseTipMessage } from "@/lib/utils/video-tip";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";

--- a/lib/hooks/xmtp/useLiveChatModerated.ts
+++ b/lib/hooks/xmtp/useLiveChatModerated.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { useLiveChat, type UseLiveChatReturn, type LiveChatMessage } from "./useLiveChat";
 import {

--- a/lib/hooks/xmtp/useVideoChat.ts
+++ b/lib/hooks/xmtp/useVideoChat.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { Client, Group, Message, DecodedMessage } from "@xmtp/browser-sdk";
 import { ConsentState } from "@xmtp/browser-sdk";
-import { useUser } from "@account-kit/react";
+import { useUser } from "@/lib/wallet/react";
 import { useXmtpClient } from "./useXmtpClient";
 import { parseTipMessage } from "@/lib/utils/video-tip";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";

--- a/lib/hooks/xmtp/useXmtpClient.ts
+++ b/lib/hooks/xmtp/useXmtpClient.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Client } from "@xmtp/browser-sdk";
-import { useUser, useSignMessage, useSmartAccountClient } from "@account-kit/react";
+import { useUser, useSignMessage, useSmartAccountClient } from "@/lib/wallet/react";
 import { createXmtpSigner } from "@/lib/utils/xmtp/signer";
 import useModularAccount from "@/lib/hooks/accountkit/useModularAccount";
 import { logger } from '@/lib/utils/logger';

--- a/lib/sdk/accountKit/modularAccountClient.ts
+++ b/lib/sdk/accountKit/modularAccountClient.ts
@@ -46,7 +46,7 @@ export async function createModularAccountClient({
 
 /**
  * Helper function to send a user operation
- * For React components, use useSendUserOperation from @account-kit/react instead
+ * For React components, use useSendUserOperation from @/lib/wallet/react instead
  */
 export async function sendUserOperation({
   client,

--- a/lib/sdk/accountKit/signer.ts
+++ b/lib/sdk/accountKit/signer.ts
@@ -1,5 +1,5 @@
 // NOTE: This module is not currently used - Account Kit manages its own signer
-// The useSigner() hook from @account-kit/react should be used instead
+// The useSigner() hook from @/lib/wallet/react should be used instead
 // 
 // The aggressive iframe cleanup that was here has been removed because it was
 // breaking the signer connection. Account Kit's AlchemyAccountProvider manages

--- a/lib/sdk/alchemy/swap-client.ts
+++ b/lib/sdk/alchemy/swap-client.ts
@@ -41,6 +41,7 @@ type SwapWalletClient = {
     calls: Array<{ to: Address; data: Hex; value: bigint }>;
   }) => Promise<{ id: string }>;
   waitForCallsStatus: (args: { id: string }) => Promise<{
+    status?: string;
     receipts?: Array<{ transactionHash?: string }>;
   }>;
   requestAccount: (args: {
@@ -144,9 +145,13 @@ export async function executeSwap(params: {
     throw new Error(`Quote request failed: ${response.status} - ${errorText}`);
   }
 
-  const quoteResponse = await response.json();
-  if (quoteResponse.error) {
-    throw new Error(`RPC Error: ${quoteResponse.error.message}`);
+  const quoteResponse = (await response.json()) as Record<string, unknown> | null;
+  if (!quoteResponse || typeof quoteResponse !== "object") {
+    throw new Error("Invalid JSON response from Alchemy quote API");
+  }
+  const rpcError = quoteResponse.error as { message?: string } | undefined;
+  if (rpcError) {
+    throw new Error(`RPC Error: ${rpcError.message ?? "Unknown error"}`);
   }
   if (!quoteResponse.result) {
     throw new Error("No quote result received from Alchemy");
@@ -173,6 +178,9 @@ export async function executeSwap(params: {
       });
 
       const status = await swapClient.waitForCallsStatus({ id });
+      if (status.status === "reverted") {
+        throw new Error(`Transaction reverted for call ${i + 1}`);
+      }
       const receipt = status.receipts?.[0]?.transactionHash;
       if (isLast && receipt) {
         txHash = receipt as Hex;
@@ -200,6 +208,9 @@ export async function executeSwap(params: {
     });
 
     const status = await swapClient.waitForCallsStatus({ id });
+    if (status.status === "reverted") {
+      throw new Error("Transaction reverted for legacy swap call");
+    }
     txHash = (status.receipts?.[0]?.transactionHash as Hex) ?? null;
   }
 

--- a/lib/sdk/alchemy/swap-client.ts
+++ b/lib/sdk/alchemy/swap-client.ts
@@ -1,8 +1,11 @@
 import "dotenv/config";
 import { type Address, type Hex } from "viem";
-import { LocalAccountSigner } from "@aa-sdk/core";
-import { alchemy, base } from "@account-kit/infra";
-import { createSmartWalletClient } from "@account-kit/wallet-client";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+import {
+  createSmartWalletClient,
+  alchemyWalletTransport,
+} from "@alchemy/wallet-apis";
 import { serverLogger } from "@/lib/utils/logger";
 import { appendBuilderCode } from "@/lib/utils/builder-code";
 
@@ -10,287 +13,203 @@ export const config = {
   policyId: process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID!,
 };
 
-// Client params will be created dynamically to avoid build-time errors
 function getClientParams() {
   const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
   const privateKey = process.env.ALCHEMY_SWAP_PRIVATE_KEY;
-  
+
   if (!apiKey) {
-    throw new Error('NEXT_PUBLIC_ALCHEMY_API_KEY is not configured');
+    throw new Error("NEXT_PUBLIC_ALCHEMY_API_KEY is not configured");
   }
-  
+
   if (!privateKey) {
-    throw new Error('ALCHEMY_SWAP_PRIVATE_KEY is not configured');
+    throw new Error("ALCHEMY_SWAP_PRIVATE_KEY is not configured");
   }
-  
+
   return {
-    transport: alchemy({
-      apiKey,
-    }),
-    chain: base, // Using Base mainnet instead of Sepolia
-    signer: LocalAccountSigner.privateKeyToAccountSigner(
-      privateKey as Hex,
-    ),
+    transport: alchemyWalletTransport({ apiKey }),
+    chain: base,
+    signer: privateKeyToAccount(privateKey as Hex),
+    paymaster: {
+      policyId: process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID!,
+    },
   };
 }
 
-let clientWithoutAccount: any = null;
-let account: any = null;
-let client: any = null;
+type SwapWalletClient = {
+  sendCalls: (args: {
+    account: Address;
+    calls: Array<{ to: Address; data: Hex; value: bigint }>;
+  }) => Promise<{ id: string }>;
+  waitForCallsStatus: (args: { id: string }) => Promise<{
+    receipts?: Array<{ transactionHash?: string }>;
+  }>;
+  requestAccount: (args: {
+    creationHint: { accountType: "sma-b" };
+  }) => Promise<{ address: Address }>;
+};
 
-/**
- * Initialize the swap client
- * This should be called once when the service starts
- */
+let account: { address: Address } | null = null;
+let client: SwapWalletClient | null = null;
+
 export async function initializeSwapClient() {
-  if (client) return client;
+  if (client && account) return client;
 
   try {
     const clientParams = getClientParams();
-    serverLogger.debug('Initializing swap client with params:', {
-      hasApiKey: !!clientParams.transport,
-      hasPrivateKey: !!clientParams.signer,
-      chainId: clientParams.chain.id,
+    const clientWithoutAccount = createSmartWalletClient(clientParams);
+    account = await clientWithoutAccount.requestAccount({
+      creationHint: { accountType: "sma-b" },
     });
-    
-    clientWithoutAccount = createSmartWalletClient(clientParams);
-    serverLogger.debug('Created client without account');
-    
-    account = await clientWithoutAccount.requestAccount();
-    serverLogger.debug('Requested account:', account.address);
-    
+
     client = createSmartWalletClient({
       ...clientParams,
       account: account.address,
-    });
+    }) as SwapWalletClient;
 
     serverLogger.debug("Swap client initialized with account:", account.address);
     return client;
   } catch (error) {
     serverLogger.error("Failed to initialize swap client:", error);
-    try {
-      const clientParams = getClientParams();
-      serverLogger.error("Client params:", {
-        transport: !!clientParams.transport,
-        chain: clientParams.chain.name,
-        hasSigner: !!clientParams.signer,
-      });
-    } catch (paramError) {
-      serverLogger.error("Failed to get client params:", paramError);
-    }
     throw error;
   }
 }
 
-/**
- * Get the initialized swap client
- */
 export async function getSwapClient() {
   if (!client) {
     await initializeSwapClient();
   }
-  return client;
+  return client!;
 }
 
-/**
- * Get the account address
- */
 export async function getSwapAccountAddress(): Promise<Address> {
   if (!account) {
     await initializeSwapClient();
   }
-  return account.address;
+  return account!.address;
 }
 
-/**
- * Execute a swap using the backend client
- */
 export async function executeSwap(params: {
   fromToken: string;
   toToken: string;
   fromAmount: Hex;
   minimumToAmount?: Hex;
 }) {
-  serverLogger.debug('Starting swap execution with params:', params);
-  
-  try {
-    // Check environment variables first
-    const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
-    const policyId = process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID;
-    const privateKey = process.env.ALCHEMY_SWAP_PRIVATE_KEY;
-    
-    serverLogger.debug('Environment variables check:', {
-      hasApiKey: !!apiKey,
-      hasPolicyId: !!policyId,
-      hasPrivateKey: !!privateKey,
-    });
-    
-    if (!apiKey) {
-      throw new Error('NEXT_PUBLIC_ALCHEMY_API_KEY is not set');
-    }
-    
-    if (!policyId) {
-      throw new Error('NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID is not set');
-    }
-    
-    if (!privateKey) {
-      throw new Error('ALCHEMY_SWAP_PRIVATE_KEY is not set');
-    }
-    
-    // Initialize swap client
-    const swapClient = await getSwapClient();
-    const accountAddress = await getSwapAccountAddress();
-    
-    serverLogger.debug('Swap client and account initialized:', { 
-      hasClient: !!swapClient, 
-      accountAddress 
-    });
-    
-    // Request quote from Alchemy
-    const quoteRequest = {
-      method: "wallet_requestQuote_v0" as const,
-      params: [
-        {
-          from: accountAddress,
-          chainId: "0x2105", // Base mainnet
-          fromToken: params.fromToken,
-          toToken: params.toToken,
-          fromAmount: params.fromAmount,
-          minimumToAmount: params.minimumToAmount,
-          capabilities: {
-            paymasterService: {
-              policyId: config.policyId,
-            },
-          },
-        },
-      ],
-    };
+  serverLogger.debug("Starting swap execution with params:", params);
 
-    serverLogger.debug('Requesting quote from Alchemy...');
-    
-    const response = await fetch(
-      `https://api.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+  const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
+  const policyId = process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID;
+  const privateKey = process.env.ALCHEMY_SWAP_PRIVATE_KEY;
+
+  if (!apiKey || !policyId || !privateKey) {
+    throw new Error("Swap environment variables are not fully configured");
+  }
+
+  const swapClient = await getSwapClient();
+  const accountAddress = await getSwapAccountAddress();
+
+  const quoteRequest = {
+    method: "wallet_requestQuote_v0" as const,
+    params: [
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Accept-Encoding": "gzip",
-        },
-        body: JSON.stringify({
-          id: 1,
-          jsonrpc: "2.0",
-          ...quoteRequest,
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      serverLogger.error('Quote request failed:', response.status, errorText);
-      throw new Error(`Quote request failed: ${response.status} - ${errorText}`);
-    }
-
-    const quoteResponse = await response.json();
-    serverLogger.debug('Quote response received');
-    
-    if (quoteResponse.error) {
-      throw new Error(`RPC Error: ${quoteResponse.error.message}`);
-    }
-
-    if (!quoteResponse.result) {
-      throw new Error('No quote result received from Alchemy');
-    }
-
-    const quote = quoteResponse.result;
-    
-    // Execute swap using the quote data
-    // Handle both new format (with calls array) and legacy format
-    const calls = (quote as any).calls;
-    let txHash: Hex | null = null;
-
-    if (calls && Array.isArray(calls) && calls.length > 0) {
-      // New format: execute calls sequentially
-      serverLogger.debug(`Found ${calls.length} prepared calls from quote`);
-      
-      for (let i = 0; i < calls.length; i++) {
-        const call = calls[i];
-        const isLast = i === calls.length - 1;
-        
-        serverLogger.debug(`Executing call ${i + 1}/${calls.length}`, {
-          target: call.to,
-          value: call.value,
-          dataLength: call.data?.length || 0
-        });
-
-        const operation = await swapClient.sendUserOperation({
-          uo: {
-            target: call.to as Address,
-            data: appendBuilderCode(call.data as Hex),
-            value: BigInt(call.value || '0x0'),
+        from: accountAddress,
+        chainId: "0x2105",
+        fromToken: params.fromToken,
+        toToken: params.toToken,
+        fromAmount: params.fromAmount,
+        minimumToAmount: params.minimumToAmount,
+        capabilities: {
+          paymaster: {
+            policyId: config.policyId,
           },
-        });
+        },
+      },
+    ],
+  };
 
-        serverLogger.debug(`UserOperation sent, hash: ${operation.hash}`);
+  const response = await fetch(`https://api.g.alchemy.com/v2/${apiKey}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip",
+    },
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      ...quoteRequest,
+    }),
+  });
 
-        // Wait for transaction receipt
-        const receipt = await swapClient.waitForUserOperationTransaction({
-          hash: operation.hash,
-        });
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Quote request failed: ${response.status} - ${errorText}`);
+  }
 
-        serverLogger.debug(`Transaction confirmed, hash: ${receipt}`);
+  const quoteResponse = await response.json();
+  if (quoteResponse.error) {
+    throw new Error(`RPC Error: ${quoteResponse.error.message}`);
+  }
+  if (!quoteResponse.result) {
+    throw new Error("No quote result received from Alchemy");
+  }
 
-        if (isLast) {
-          txHash = receipt as Hex;
-        }
-      }
-    } else {
-      // Legacy format: use quote.data structure
-      serverLogger.debug('Using legacy quote format');
-      
-      const quoteData = (quote as any).data;
-      if (!quoteData) {
-        throw new Error('Invalid quote format: missing data or calls');
-      }
+  const quote = quoteResponse.result;
+  const calls = (quote as { calls?: Array<{ to: string; data: string; value: string }> }).calls;
+  let txHash: Hex | null = null;
 
-      const target = (quoteData.target || quoteData.sender || accountAddress) as Address;
-      const callData = quoteData.callData as Hex;
-      const value = BigInt(quoteData.value || '0x0');
+  if (calls && Array.isArray(calls) && calls.length > 0) {
+    for (let i = 0; i < calls.length; i++) {
+      const call = calls[i];
+      const isLast = i === calls.length - 1;
 
-      serverLogger.debug('Executing swap with legacy format', {
-        target,
-        value: value.toString(),
-        dataLength: callData.length
+      const { id } = await swapClient.sendCalls({
+        account: accountAddress,
+        calls: [
+          {
+            to: call.to as Address,
+            data: appendBuilderCode(call.data as Hex),
+            value: BigInt(call.value || "0"),
+          },
+        ],
       });
 
-      const operation = await swapClient.sendUserOperation({
-        uo: {
-          target,
+      const status = await swapClient.waitForCallsStatus({ id });
+      const receipt = status.receipts?.[0]?.transactionHash;
+      if (isLast && receipt) {
+        txHash = receipt as Hex;
+      }
+    }
+  } else {
+    const quoteData = (quote as { data?: { target?: string; sender?: string; callData?: string; value?: string } }).data;
+    if (!quoteData) {
+      throw new Error("Invalid quote format: missing data or calls");
+    }
+
+    const target = (quoteData.target || quoteData.sender || accountAddress) as Address;
+    const callData = quoteData.callData as Hex;
+    const value = BigInt(quoteData.value || "0");
+
+    const { id } = await swapClient.sendCalls({
+      account: accountAddress,
+      calls: [
+        {
+          to: target,
           data: appendBuilderCode(callData),
           value,
         },
-      });
+      ],
+    });
 
-      serverLogger.debug(`UserOperation sent, hash: ${operation.hash}`);
-
-      txHash = await swapClient.waitForUserOperationTransaction({
-        hash: operation.hash,
-      }) as Hex;
-
-      serverLogger.debug(`Transaction confirmed, hash: ${txHash}`);
-    }
-
-    if (!txHash) {
-      throw new Error('Failed to get transaction hash from swap execution');
-    }
-
-    return {
-      transactionHash: txHash,
-      success: true,
-      message: "Swap executed successfully."
-    };
-
-  } catch (error) {
-    serverLogger.error('Swap execution failed:', error);
-    throw error;
+    const status = await swapClient.waitForCallsStatus({ id });
+    txHash = (status.receipts?.[0]?.transactionHash as Hex) ?? null;
   }
+
+  if (!txHash) {
+    throw new Error("Failed to get transaction hash from swap execution");
+  }
+
+  return {
+    transactionHash: txHash,
+    success: true,
+    message: "Swap executed successfully.",
+  };
 }

--- a/lib/sdk/wallet/migration-config.ts
+++ b/lib/sdk/wallet/migration-config.ts
@@ -1,0 +1,39 @@
+import { createMigrationConfig } from "@privy-io/alchemy-migration";
+import { alchemy, base } from "@account-kit/infra";
+
+const migrationRedirectUrl =
+  process.env.NEXT_PUBLIC_URL ??
+  (process.env.NEXT_PUBLIC_VERCEL_URL
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+    : "http://localhost:3000");
+
+export const alchemyMigrationConfig = createMigrationConfig(
+  {
+    transport: alchemy({
+      apiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!,
+    }),
+    chain: base,
+    ssr: true,
+  },
+  {
+    auth: {
+      sections: [
+        [{ type: "email", emailMode: "otp" }, { type: "passkey" }],
+        [
+          {
+            type: "social",
+            authProviderId: "google",
+            mode: "redirect",
+            redirectUrl: migrationRedirectUrl,
+          },
+          {
+            type: "social",
+            authProviderId: "twitch",
+            mode: "redirect",
+            redirectUrl: migrationRedirectUrl,
+          },
+        ],
+      ],
+    },
+  },
+);

--- a/lib/sdk/wallet/smart-wallet-client.ts
+++ b/lib/sdk/wallet/smart-wallet-client.ts
@@ -1,0 +1,7 @@
+export {
+  createCompatSmartAccountClient,
+  resolveScaAddress,
+  type CompatSmartAccountClient,
+  type SendUserOperationArgs,
+  type UserOperationCall,
+} from "@/lib/wallet/smart-wallet-client";

--- a/lib/types/account.ts
+++ b/lib/types/account.ts
@@ -1,14 +1,15 @@
 import type { User as BaseUser } from "@account-kit/signer";
 import { type Account as ViemAccount } from "viem";
+import type { CompatUser } from "@/lib/wallet/react";
 
-type User = BaseUser & { type: "eoa" | "sca" };
+type User = (BaseUser & { type: "eoa" | "sca" }) | CompatUser;
 
 export interface Account {
   address: string;
   type: "eoa" | "sca";
 }
 
-export function userToAccount(user: User | null): Account | null {
+export function userToAccount(user: User | CompatUser | null): Account | null {
   if (!user) return null;
 
   return {

--- a/lib/wallet/auth-error-context.tsx
+++ b/lib/wallet/auth-error-context.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import { useLogin } from "@privy-io/react-auth";
+
+type AuthErrorContextValue = {
+  login: () => void;
+  authError: Error | null;
+  clearAuthError: () => void;
+};
+
+const AuthErrorContext = createContext<AuthErrorContextValue | null>(null);
+
+export function AuthErrorProvider({ children }: { children: ReactNode }) {
+  const [authError, setAuthError] = useState<Error | null>(null);
+  const { login } = useLogin({
+    onComplete: () => setAuthError(null),
+    onError: (error) => {
+      setAuthError(error instanceof Error ? error : new Error(String(error)));
+    },
+  });
+
+  const clearAuthError = useCallback(() => setAuthError(null), []);
+
+  return (
+    <AuthErrorContext.Provider value={{ login, authError, clearAuthError }}>
+      {children}
+    </AuthErrorContext.Provider>
+  );
+}
+
+export function useAuthErrorContext() {
+  const ctx = useContext(AuthErrorContext);
+  if (!ctx) {
+    throw new Error("useAuthErrorContext must be used within AuthErrorProvider");
+  }
+  return ctx;
+}

--- a/lib/wallet/chain-context.tsx
+++ b/lib/wallet/chain-context.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { Chain } from "viem";
+import { defaultWalletChain } from "./chains";
+
+type WalletChainContextValue = {
+  chain: Chain;
+  setChain: (args: { chain: Chain }) => void;
+  isSettingChain: boolean;
+};
+
+const WalletChainContext = createContext<WalletChainContextValue | null>(null);
+
+export function WalletChainProvider({ children }: { children: ReactNode }) {
+  const [chain, setChainState] = useState<Chain>(defaultWalletChain);
+  const [isSettingChain, setIsSettingChain] = useState(false);
+
+  const setChain = useCallback(({ chain: nextChain }: { chain: Chain }) => {
+    setIsSettingChain(true);
+    setChainState(nextChain);
+    setIsSettingChain(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({ chain, setChain, isSettingChain }),
+    [chain, setChain, isSettingChain],
+  );
+
+  return (
+    <WalletChainContext.Provider value={value}>
+      {children}
+    </WalletChainContext.Provider>
+  );
+}
+
+export function useWalletChain() {
+  const ctx = useContext(WalletChainContext);
+  if (!ctx) {
+    throw new Error("useWalletChain must be used within WalletChainProvider");
+  }
+  return ctx;
+}

--- a/lib/wallet/chains.ts
+++ b/lib/wallet/chains.ts
@@ -1,0 +1,17 @@
+import { base as viemBase } from "viem/chains";
+import type { Chain } from "viem";
+import { getStoryChain } from "@/lib/sdk/story/chains";
+import { getLensChain } from "@/lib/sdk/lens/chains";
+
+export const storyChain = getStoryChain();
+export const lensChain = getLensChain();
+
+/** Default signing chain (Base mainnet). */
+export const defaultWalletChain: Chain = viemBase;
+
+/** Chains available for wallet signing in the app UI. */
+export const walletChains: Chain[] = [viemBase, storyChain, lensChain];
+
+export function getWalletChainById(chainId: number): Chain | undefined {
+  return walletChains.find((c) => c.id === chainId);
+}

--- a/lib/wallet/privy-config.ts
+++ b/lib/wallet/privy-config.ts
@@ -1,0 +1,26 @@
+import {
+  createWalletCreationOnLoginPlugin,
+  type PrivyClientConfig,
+  type User,
+} from "@privy-io/react-auth";
+
+const walletCreationPluginOptions = {
+  shouldCreateWallet: ({ user }: { user: User }) =>
+    user.customMetadata?.["alchemy_org_id"] === undefined,
+};
+
+export function getPrivyConfig(): PrivyClientConfig {
+  return {
+    loginMethods: ["email", "google", "passkey", "twitch"],
+    appearance: {
+      theme: "dark",
+      accentColor: "#676FFF",
+    },
+    plugins: [createWalletCreationOnLoginPlugin(walletCreationPluginOptions)],
+    embeddedWallets: {
+      ethereum: {
+        createOnLogin: "users-without-wallets",
+      },
+    },
+  };
+}

--- a/lib/wallet/react.tsx
+++ b/lib/wallet/react.tsx
@@ -4,7 +4,8 @@
  * Drop-in replacements for @account-kit/react hooks after Privy + Wallet APIs v5 migration.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePrivy, useLogin, useLogout as usePrivyLogout } from "@privy-io/react-auth";
+import { usePrivy, useLogout as usePrivyLogout } from "@privy-io/react-auth";
+import { useAuthErrorContext } from "./auth-error-context";
 import { requestQuoteV0 } from "@alchemy/wallet-apis/experimental";
 import type { Address, Hex } from "viem";
 import { useWalletChain } from "./chain-context";
@@ -39,7 +40,7 @@ export function useUser(): CompatUser | null {
 }
 
 export function useAuthModal() {
-  const { login } = useLogin();
+  const { login } = useAuthErrorContext();
   return {
     openAuthModal: login,
   };
@@ -88,7 +89,8 @@ export function useSigner() {
 }
 
 export function useAuthError() {
-  return null;
+  const { authError } = useAuthErrorContext();
+  return authError;
 }
 
 type SignMessageHookOptions = {
@@ -290,13 +292,24 @@ export function usePrepareSwap({ client }: { client?: SwapHookClient } = {}) {
         const account = client.scaAddress ?? client.getAddress();
         const capabilities = params.capabilities as Record<string, unknown> | undefined;
         const paymasterService = capabilities?.paymasterService as { policyId?: string } | undefined;
+        const erc20 = capabilities?.erc20 as { tokenAddress?: string } | undefined;
+
+        const quoteCapabilities =
+          paymasterService?.policyId
+            ? {
+                paymaster: {
+                  policyId: paymasterService.policyId,
+                  ...(erc20?.tokenAddress
+                    ? { erc20: { tokenAddress: erc20.tokenAddress } }
+                    : {}),
+                },
+              }
+            : undefined;
 
         return await requestQuoteV0(client as never, {
           ...params,
           account,
-          ...(paymasterService?.policyId
-            ? { capabilities: { paymaster: { policyId: paymasterService.policyId } } }
-            : {}),
+          ...(quoteCapabilities ? { capabilities: quoteCapabilities } : {}),
         } as never);
       } finally {
         setIsPreparingSwap(false);
@@ -366,6 +379,11 @@ export function useWaitForCallsStatus({
       .waitForCallsStatus({ id })
       .then((result) => {
         if (cancelled) return;
+        if (result.status === "reverted") {
+          setError(new Error("Transaction reverted"));
+          setData({ ...result, statusCode: 500 });
+          return;
+        }
         setData({
           ...result,
           statusCode: result.status === "success" ? 200 : 120,

--- a/lib/wallet/react.tsx
+++ b/lib/wallet/react.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+/**
+ * Drop-in replacements for @account-kit/react hooks after Privy + Wallet APIs v5 migration.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePrivy, useLogin, useLogout as usePrivyLogout } from "@privy-io/react-auth";
+import { requestQuoteV0 } from "@alchemy/wallet-apis/experimental";
+import type { Address, Hex } from "viem";
+import { useWalletChain } from "./chain-context";
+import { useWalletClientContext } from "./wallet-context";
+import type { CompatSmartAccountClient, SendUserOperationArgs } from "./smart-wallet-client";
+
+export type CompatUser = {
+  address: Address;
+  email?: string;
+  type: "sca" | "eoa";
+};
+
+export function useUser(): CompatUser | null {
+  const { user, authenticated } = usePrivy();
+  const { eoaAddress, address: scaAddress } = useWalletClientContext();
+
+  return useMemo(() => {
+    if (!authenticated || !user) return null;
+    const email =
+      user.email?.address ??
+      user.google?.email ??
+      user.twitch?.username ??
+      undefined;
+    const walletAddress = eoaAddress ?? scaAddress;
+    if (!walletAddress) return null;
+    return {
+      address: walletAddress as Address,
+      email,
+      type: scaAddress ? ("sca" as const) : ("eoa" as const),
+    };
+  }, [authenticated, user, eoaAddress, scaAddress]);
+}
+
+export function useAuthModal() {
+  const { login } = useLogin();
+  return {
+    openAuthModal: login,
+  };
+}
+
+export function useLogout() {
+  const { logout } = usePrivyLogout();
+  return { logout };
+}
+
+export function useSignerStatus() {
+  const { authenticated, ready } = usePrivy();
+  return {
+    isConnected: authenticated,
+    isInitializing: !ready,
+    isAuthenticating: !ready,
+  };
+}
+
+export function useChain() {
+  return useWalletChain();
+}
+
+type SmartAccountClientOptions = {
+  type?: string;
+};
+
+export function useSmartAccountClient(_options?: SmartAccountClientOptions) {
+  const { client, address, isLoadingClient, error } = useWalletClientContext();
+  return {
+    client,
+    address,
+    isLoadingClient,
+    error,
+  };
+}
+
+export function useAccount(_options?: SmartAccountClientOptions) {
+  const { address } = useWalletClientContext();
+  return { address };
+}
+
+export function useSigner() {
+  const { signer } = useWalletClientContext();
+  return signer ?? null;
+}
+
+export function useAuthError() {
+  return null;
+}
+
+type SignMessageHookOptions = {
+  client?: CompatSmartAccountClient;
+  onSuccess?: (signature: Hex) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useSignMessage(options: SignMessageHookOptions = {}) {
+  const { signer } = useWalletClientContext();
+  const [isSigningMessage, setIsSigningMessage] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const signMessage = useCallback(
+    async (args?: { message: string | Uint8Array }) => {
+      const message = args?.message;
+      if (!message) {
+        const err = new Error("Message is required");
+        setError(err);
+        optionsRef.current.onError?.(err);
+        throw err;
+      }
+      if (!signer?.signMessage) {
+        const err = new Error("Signer not ready");
+        setError(err);
+        optionsRef.current.onError?.(err);
+        throw err;
+      }
+
+      setIsSigningMessage(true);
+      setError(null);
+      try {
+        const signature = (await signer.signMessage({
+          message: message as string,
+        })) as Hex;
+        optionsRef.current.onSuccess?.(signature);
+        return signature;
+      } catch (err) {
+        const signError = err instanceof Error ? err : new Error(String(err));
+        setError(signError);
+        optionsRef.current.onError?.(signError);
+        throw signError;
+      } finally {
+        setIsSigningMessage(false);
+      }
+    },
+    [signer],
+  );
+
+  return { signMessage, isSigningMessage, error };
+}
+
+type TypedDataPayload = {
+  domain: Record<string, unknown>;
+  types: Record<string, unknown>;
+  primaryType: string;
+  message: Record<string, unknown>;
+};
+
+type SignTypedDataHookOptions = {
+  client?: CompatSmartAccountClient;
+  onSuccess?: (signature: Hex) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useSignTypedData(options: SignTypedDataHookOptions = {}) {
+  const { signer } = useWalletClientContext();
+  const [isSigningTypedData, setIsSigningTypedData] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const signTypedData = useCallback(
+    async (args: { typedData: TypedDataPayload } | TypedDataPayload) => {
+      const typedData = "typedData" in args ? args.typedData : args;
+      if (!signer?.signTypedData) {
+        const err = new Error("Signer not ready");
+        setError(err);
+        optionsRef.current.onError?.(err);
+        throw err;
+      }
+
+      setIsSigningTypedData(true);
+      setError(null);
+      try {
+        const signature = (await signer.signTypedData(
+          typedData as Parameters<NonNullable<typeof signer.signTypedData>>[0],
+        )) as Hex;
+        optionsRef.current.onSuccess?.(signature);
+        return signature;
+      } catch (err) {
+        const signError = err instanceof Error ? err : new Error(String(err));
+        setError(signError);
+        optionsRef.current.onError?.(signError);
+        throw signError;
+      } finally {
+        setIsSigningTypedData(false);
+      }
+    },
+    [signer],
+  );
+
+  return { signTypedData, isSigningTypedData, error };
+}
+
+type SendUserOperationSuccessArgs = {
+  hash: string;
+  request?: { sender: Address };
+};
+
+type SendUserOperationHookArgs = {
+  client?: CompatSmartAccountClient;
+  waitForTxn?: boolean;
+  onSuccess?: (args: SendUserOperationSuccessArgs) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useSendUserOperation({
+  client: clientOverride,
+  waitForTxn = false,
+  onSuccess,
+  onError,
+}: SendUserOperationHookArgs = {}) {
+  const { client: contextClient } = useWalletClientContext();
+  const client = clientOverride ?? contextClient;
+  const [isSendingUserOperation, setIsSendingUserOperation] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const sendUserOperationAsync = useCallback(
+    async (args: SendUserOperationArgs) => {
+      if (!client) {
+        const err = new Error("Smart account client not initialized");
+        setError(err);
+        onError?.(err);
+        throw err;
+      }
+
+      setIsSendingUserOperation(true);
+      setError(null);
+      try {
+        const operation = await client.sendUserOperation(args);
+        if (waitForTxn) {
+          const receipt = await client.waitForUserOperationTransaction({
+            hash: operation.hash,
+          });
+          const successArgs = {
+            hash: receipt,
+            request: operation.request,
+          };
+          onSuccess?.(successArgs);
+          return { ...operation, hash: receipt };
+        }
+        onSuccess?.({ hash: operation.hash, request: operation.request });
+        return operation;
+      } catch (err) {
+        const sendError = err instanceof Error ? err : new Error(String(err));
+        setError(sendError);
+        onError?.(sendError);
+        throw sendError;
+      } finally {
+        setIsSendingUserOperation(false);
+      }
+    },
+    [client, waitForTxn, onSuccess, onError],
+  );
+
+  const sendUserOperation = useCallback(
+    (args: SendUserOperationArgs) => {
+      void sendUserOperationAsync(args);
+    },
+    [sendUserOperationAsync],
+  );
+
+  return {
+    sendUserOperation,
+    sendUserOperationAsync,
+    isSendingUserOperation,
+    error,
+  };
+}
+
+export function usePrivySigner() {
+  const { signer } = useWalletClientContext();
+  return signer;
+}
+
+type SwapHookClient = CompatSmartAccountClient | undefined;
+
+export function usePrepareSwap({ client }: { client?: SwapHookClient } = {}) {
+  const [isPreparingSwap, setIsPreparingSwap] = useState(false);
+
+  const prepareSwapAsync = useCallback(
+    async (params: Record<string, unknown>) => {
+      if (!client) throw new Error("Smart account client not initialized");
+      setIsPreparingSwap(true);
+      try {
+        const account = client.scaAddress ?? client.getAddress();
+        const capabilities = params.capabilities as Record<string, unknown> | undefined;
+        const paymasterService = capabilities?.paymasterService as { policyId?: string } | undefined;
+
+        return await requestQuoteV0(client as never, {
+          ...params,
+          account,
+          ...(paymasterService?.policyId
+            ? { capabilities: { paymaster: { policyId: paymasterService.policyId } } }
+            : {}),
+        } as never);
+      } finally {
+        setIsPreparingSwap(false);
+      }
+    },
+    [client],
+  );
+
+  return { prepareSwapAsync, isPreparingSwap };
+}
+
+export function useSignAndSendPreparedCalls({ client }: { client?: SwapHookClient } = {}) {
+  const [isSigningAndSendingPreparedCalls, setIsSigning] = useState(false);
+  const [signAndSendPreparedCallsResult, setResult] = useState<{
+    preparedCallIds: string[];
+  } | null>(null);
+
+  const signAndSendPreparedCallsAsync = useCallback(
+    async (calls: unknown) => {
+      if (!client) throw new Error("Smart account client not initialized");
+      setIsSigning(true);
+      try {
+        const signed = await client.signPreparedCalls(calls);
+        const result = await client.sendPreparedCalls(signed);
+        setResult(result);
+        return result;
+      } finally {
+        setIsSigning(false);
+      }
+    },
+    [client],
+  );
+
+  return {
+    signAndSendPreparedCallsAsync,
+    isSigningAndSendingPreparedCalls,
+    signAndSendPreparedCallsResult,
+  };
+}
+
+export function useWaitForCallsStatus({
+  client,
+  id,
+}: {
+  client?: SwapHookClient;
+  id?: string;
+} = {}) {
+  const [data, setData] = useState<{
+    statusCode?: number;
+    status?: string;
+    receipts?: Array<{ transactionHash?: string }>;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!client || !id) {
+      setData(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    void client
+      .waitForCallsStatus({ id })
+      .then((result) => {
+        if (cancelled) return;
+        setData({
+          ...result,
+          statusCode: result.status === "success" ? 200 : 120,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, id]);
+
+  return { data, isLoading, error };
+}
+
+export type { CompatSmartAccountClient, SendUserOperationArgs };

--- a/lib/wallet/react.tsx
+++ b/lib/wallet/react.tsx
@@ -124,7 +124,7 @@ export function useSignMessage(options: SignMessageHookOptions = {}) {
       setError(null);
       try {
         const signature = (await signer.signMessage({
-          message: message as string,
+          message: typeof message === "string" ? message : { raw: message },
         })) as Hex;
         optionsRef.current.onSuccess?.(signature);
         return signature;

--- a/lib/wallet/session-keys.ts
+++ b/lib/wallet/session-keys.ts
@@ -1,0 +1,17 @@
+import type { Hex } from "viem";
+import type { SendUserOperationArgs } from "@/lib/wallet/smart-wallet-client";
+
+/**
+ * Build v5 sendCalls permissions context for legacy ModularAccountV2 session keys.
+ * Pass via sendUserOperation({ context: buildSessionKeyContext(entityId) }).
+ */
+export function buildSessionKeyContext(entityId: number): NonNullable<
+  SendUserOperationArgs["context"]
+> {
+  const entityIdHex = `0x${entityId.toString(16).padStart(64, "0")}` as Hex;
+  return {
+    permissions: {
+      context: entityIdHex,
+    },
+  };
+}

--- a/lib/wallet/smart-wallet-client.ts
+++ b/lib/wallet/smart-wallet-client.ts
@@ -98,12 +98,27 @@ export async function resolveScaAddress(
   return address;
 }
 
-function mapPaymasterCapabilities(
+function mapSendCallsCapabilities(
   context?: SendUserOperationArgs["context"],
-): { paymaster?: { policyId: string } } | undefined {
+  permissionsContext?: Hex,
+): Record<string, unknown> | undefined {
   const policyId = context?.paymasterService?.policyId ?? PAYMASTER_POLICY_ID;
-  if (!policyId) return undefined;
-  return { paymaster: { policyId } };
+  const tokenAddress = context?.erc20?.tokenAddress;
+
+  const capabilities: Record<string, unknown> = {};
+
+  if (policyId) {
+    capabilities.paymaster = {
+      policyId,
+      ...(tokenAddress ? { erc20: { tokenAddress } } : {}),
+    };
+  }
+
+  if (permissionsContext) {
+    capabilities.permissions = { context: permissionsContext };
+  }
+
+  return Object.keys(capabilities).length > 0 ? capabilities : undefined;
 }
 
 type WalletClientParams = {
@@ -152,17 +167,10 @@ export async function createCompatSmartAccountClient(
         value: uo.value ?? 0n,
       }));
 
-      const paymasterCaps = mapPaymasterCapabilities(args.context);
-      const permissionsContext = args.context?.permissions?.context;
-      const capabilities =
-        paymasterCaps || permissionsContext
-          ? {
-              ...(paymasterCaps ?? {}),
-              ...(permissionsContext
-                ? { permissions: { context: permissionsContext } }
-                : {}),
-            }
-          : undefined;
+      const capabilities = mapSendCallsCapabilities(
+        args.context,
+        args.context?.permissions?.context,
+      );
 
       const result = await clientWithAccount.sendCalls({
         account: scaAddress,

--- a/lib/wallet/smart-wallet-client.ts
+++ b/lib/wallet/smart-wallet-client.ts
@@ -142,7 +142,11 @@ export async function createCompatSmartAccountClient(
     chain,
     getAddress: () => scaAddress,
     async sendUserOperation(args: SendUserOperationArgs) {
-      const calls = (Array.isArray(args.uo) ? args.uo : [args.uo]).map((uo) => ({
+      const uoArray = Array.isArray(args.uo) ? args.uo : args.uo ? [args.uo] : [];
+      if (uoArray.length === 0) {
+        throw new Error("User operation calls (uo) cannot be empty");
+      }
+      const calls = uoArray.map((uo) => ({
         to: uo.target,
         data: (uo.data ?? "0x") as Hex,
         value: uo.value ?? 0n,
@@ -174,6 +178,9 @@ export async function createCompatSmartAccountClient(
     },
     async waitForUserOperationTransaction({ hash }: { hash: string }) {
       const status = await clientWithAccount.waitForCallsStatus({ id: hash });
+      if (status.status === "reverted") {
+        throw new Error("Transaction reverted");
+      }
       const txHash = status.receipts?.[0]?.transactionHash;
       if (!txHash) {
         throw new Error("Transaction hash not available from call status");

--- a/lib/wallet/smart-wallet-client.ts
+++ b/lib/wallet/smart-wallet-client.ts
@@ -1,0 +1,186 @@
+import {
+  createSmartWalletClient,
+  alchemyWalletTransport,
+} from "@alchemy/wallet-apis";
+import type { LocalAccount } from "viem/accounts";
+import type { Address, Chain, Hash, Hex } from "viem";
+import { http, type Transport } from "viem";
+
+const ALCHEMY_API_KEY = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY ?? "";
+const PAYMASTER_POLICY_ID =
+  process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID?.replace(/^["']|["']$/g, "") ?? "";
+
+export type UserOperationCall = {
+  target: Address;
+  data?: Hex;
+  value?: bigint;
+};
+
+export type SendUserOperationArgs = {
+  uo: UserOperationCall | UserOperationCall[];
+  context?: {
+    paymasterService?: { policyId: string };
+    erc20?: { tokenAddress: string };
+    permissions?: { context?: Hex };
+  };
+  overrides?: Record<string, unknown>;
+};
+
+/** Runtime wallet client with compat helpers (loose typing avoids TS stack overflows). */
+export type CompatSmartAccountClient = {
+  account: { address: Address };
+  scaAddress: Address;
+  chain?: Chain;
+  getAddress: () => Address;
+  sendUserOperation: (
+    args: SendUserOperationArgs,
+  ) => Promise<{ hash: string; request: { sender: Address } }>;
+  waitForUserOperationTransaction: (args: {
+    hash: string;
+  }) => Promise<Hash>;
+  sendCalls: (args: Record<string, unknown>) => Promise<{ id: string }>;
+  waitForCallsStatus: (args: { id: string }) => Promise<{
+    status?: string;
+    receipts?: Array<{ transactionHash?: string }>;
+  }>;
+  requestAccount: (args: {
+    creationHint: { accountType: "sma-b" };
+  }) => Promise<{ address: Address }>;
+  signPreparedCalls: (calls: unknown) => Promise<unknown>;
+  sendPreparedCalls: (calls: unknown) => Promise<{ preparedCallIds: string[] }>;
+  extend: <T>(fn: (client: unknown) => T) => T;
+  readContract: (args: Record<string, unknown>) => Promise<unknown>;
+  getBalance: (args: { address: Address }) => Promise<bigint>;
+  getCode: (args: { address: Address }) => Promise<Hex>;
+  waitForTransactionReceipt: (args: { hash: Hash }) => Promise<unknown>;
+  transport: {
+    request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+    url?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function chainUsesAlchemyTransport(chain: Chain): boolean {
+  return chain.id === 8453;
+}
+
+function getTransportForChain(chain: Chain): Transport | ReturnType<typeof alchemyWalletTransport> {
+  if (chainUsesAlchemyTransport(chain)) {
+    return alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY });
+  }
+  const rpc = chain.rpcUrls.default.http[0];
+  if (!rpc) {
+    throw new Error(`No RPC URL configured for chain ${chain.id}`);
+  }
+  return http(rpc);
+}
+
+const scaAddressCache = new Map<string, Address>();
+
+function cacheKey(signerAddress: Address, chainId: number) {
+  return `${chainId}:${signerAddress.toLowerCase()}`;
+}
+
+export async function resolveScaAddress(
+  client: Pick<CompatSmartAccountClient, "requestAccount">,
+  signerAddress: Address,
+  chainId: number,
+): Promise<Address> {
+  const key = cacheKey(signerAddress, chainId);
+  const cached = scaAddressCache.get(key);
+  if (cached) return cached;
+
+  const { address } = await client.requestAccount({
+    creationHint: { accountType: "sma-b" },
+  });
+  scaAddressCache.set(key, address);
+  return address;
+}
+
+function mapPaymasterCapabilities(
+  context?: SendUserOperationArgs["context"],
+): { paymaster?: { policyId: string } } | undefined {
+  const policyId = context?.paymasterService?.policyId ?? PAYMASTER_POLICY_ID;
+  if (!policyId) return undefined;
+  return { paymaster: { policyId } };
+}
+
+type WalletClientParams = {
+  signer: LocalAccount;
+  transport: Transport | ReturnType<typeof alchemyWalletTransport>;
+  chain: Chain;
+  account?: Address;
+  paymaster?: { policyId: string };
+};
+
+function createWalletClient(params: WalletClientParams): CompatSmartAccountClient {
+  return createSmartWalletClient(params as never) as unknown as CompatSmartAccountClient;
+}
+
+export async function createCompatSmartAccountClient(
+  signer: LocalAccount,
+  chain: Chain,
+): Promise<CompatSmartAccountClient> {
+  const transport = getTransportForChain(chain);
+  const paymaster = PAYMASTER_POLICY_ID ? { policyId: PAYMASTER_POLICY_ID } : undefined;
+
+  const baseClient = createWalletClient({ signer, transport, chain, paymaster });
+  const scaAddress = await resolveScaAddress(baseClient, signer.address, chain.id);
+
+  const clientWithAccount = createWalletClient({
+    signer,
+    transport,
+    chain,
+    account: scaAddress,
+    paymaster,
+  });
+
+  const compat = Object.assign(clientWithAccount, {
+    account: { address: scaAddress },
+    scaAddress,
+    chain,
+    getAddress: () => scaAddress,
+    async sendUserOperation(args: SendUserOperationArgs) {
+      const calls = (Array.isArray(args.uo) ? args.uo : [args.uo]).map((uo) => ({
+        to: uo.target,
+        data: (uo.data ?? "0x") as Hex,
+        value: uo.value ?? 0n,
+      }));
+
+      const paymasterCaps = mapPaymasterCapabilities(args.context);
+      const permissionsContext = args.context?.permissions?.context;
+      const capabilities =
+        paymasterCaps || permissionsContext
+          ? {
+              ...(paymasterCaps ?? {}),
+              ...(permissionsContext
+                ? { permissions: { context: permissionsContext } }
+                : {}),
+            }
+          : undefined;
+
+      const result = await clientWithAccount.sendCalls({
+        account: scaAddress,
+        calls,
+        ...(capabilities ? { capabilities } : {}),
+        ...(args.overrides ?? {}),
+      });
+
+      return {
+        hash: result.id,
+        request: { sender: scaAddress },
+      };
+    },
+    async waitForUserOperationTransaction({ hash }: { hash: string }) {
+      const status = await clientWithAccount.waitForCallsStatus({ id: hash });
+      const txHash = status.receipts?.[0]?.transactionHash;
+      if (!txHash) {
+        throw new Error("Transaction hash not available from call status");
+      }
+      return txHash as Hash;
+    },
+  }) as CompatSmartAccountClient;
+
+  return compat;
+}

--- a/lib/wallet/wallet-context.tsx
+++ b/lib/wallet/wallet-context.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePrivy, useWallets, toViemAccount } from "@privy-io/react-auth";
+import type { LocalAccount } from "viem/accounts";
+import type { Address } from "viem";
+import { useWalletChain } from "./chain-context";
+import {
+  createCompatSmartAccountClient,
+  type CompatSmartAccountClient,
+} from "./smart-wallet-client";
+
+type WalletClientContextValue = {
+  signer: LocalAccount | undefined;
+  eoaAddress: Address | undefined;
+  client: CompatSmartAccountClient | undefined;
+  address: Address | undefined;
+  isLoadingClient: boolean;
+  error: Error | null;
+  refreshClient: () => void;
+};
+
+const WalletClientContext = createContext<WalletClientContextValue | null>(null);
+
+export function WalletClientProvider({ children }: { children: ReactNode }) {
+  const { authenticated, ready } = usePrivy();
+  const { wallets } = useWallets();
+  const embeddedWallet = wallets.find((w) => w.walletClientType === "privy");
+  const { chain } = useWalletChain();
+
+  const [signer, setSigner] = useState<LocalAccount | undefined>();
+  const [client, setClient] = useState<CompatSmartAccountClient | undefined>();
+  const [isLoadingClient, setIsLoadingClient] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refreshClient = useCallback(() => {
+    setRefreshToken((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSigner() {
+      if (!ready || !authenticated || !embeddedWallet) {
+        setSigner(undefined);
+        setClient(undefined);
+        setError(null);
+        return;
+      }
+
+      try {
+        const account = await toViemAccount({ wallet: embeddedWallet });
+        if (!cancelled) setSigner(account);
+      } catch (err) {
+        if (!cancelled) {
+          setSigner(undefined);
+          setError(err instanceof Error ? err : new Error("Failed to load signer"));
+        }
+      }
+    }
+
+    void loadSigner();
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, authenticated, embeddedWallet, refreshToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadClient() {
+      if (!signer) {
+        setClient(undefined);
+        return;
+      }
+
+      setIsLoadingClient(true);
+      setError(null);
+      try {
+        const nextClient = await createCompatSmartAccountClient(signer, chain);
+        if (!cancelled) setClient(nextClient);
+      } catch (err) {
+        if (!cancelled) {
+          setClient(undefined);
+          setError(err instanceof Error ? err : new Error("Failed to load wallet client"));
+        }
+      } finally {
+        if (!cancelled) setIsLoadingClient(false);
+      }
+    }
+
+    void loadClient();
+    return () => {
+      cancelled = true;
+    };
+  }, [signer, chain, refreshToken]);
+
+  const value = useMemo<WalletClientContextValue>(
+    () => ({
+      signer,
+      eoaAddress: signer?.address,
+      client,
+      address: client?.scaAddress,
+      isLoadingClient: !ready || isLoadingClient,
+      error,
+      refreshClient,
+    }),
+    [signer, client, isLoadingClient, ready, error, refreshClient],
+  );
+
+  return (
+    <WalletClientContext.Provider value={value}>
+      {children}
+    </WalletClientContext.Provider>
+  );
+}
+
+export function useWalletClientContext() {
+  const ctx = useContext(WalletClientContext);
+  if (!ctx) {
+    throw new Error("useWalletClientContext must be used within WalletClientProvider");
+  }
+  return ctx;
+}

--- a/lib/wallet/wallet-context.tsx
+++ b/lib/wallet/wallet-context.tsx
@@ -34,6 +34,7 @@ export function WalletClientProvider({ children }: { children: ReactNode }) {
   const { authenticated, ready } = usePrivy();
   const { wallets } = useWallets();
   const { chain } = useWalletChain();
+  const privyWallet = wallets.find((w) => w.walletClientType === "privy");
 
   const [signer, setSigner] = useState<LocalAccount | undefined>();
   const [client, setClient] = useState<CompatSmartAccountClient | undefined>();
@@ -110,11 +111,14 @@ export function WalletClientProvider({ children }: { children: ReactNode }) {
       eoaAddress: signer?.address,
       client,
       address: client?.scaAddress,
-      isLoadingClient: !ready || isLoadingClient,
+      isLoadingClient:
+        !ready ||
+        (authenticated && !error && (!privyWallet || !signer)) ||
+        isLoadingClient,
       error,
       refreshClient,
     }),
-    [signer, client, isLoadingClient, ready, error, refreshClient],
+    [signer, client, isLoadingClient, ready, authenticated, privyWallet, error, refreshClient],
   );
 
   return (

--- a/lib/wallet/wallet-context.tsx
+++ b/lib/wallet/wallet-context.tsx
@@ -33,7 +33,6 @@ const WalletClientContext = createContext<WalletClientContextValue | null>(null)
 export function WalletClientProvider({ children }: { children: ReactNode }) {
   const { authenticated, ready } = usePrivy();
   const { wallets } = useWallets();
-  const embeddedWallet = wallets.find((w) => w.walletClientType === "privy");
   const { chain } = useWalletChain();
 
   const [signer, setSigner] = useState<LocalAccount | undefined>();
@@ -50,7 +49,8 @@ export function WalletClientProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     async function loadSigner() {
-      if (!ready || !authenticated || !embeddedWallet) {
+      const privyWallet = wallets.find((w) => w.walletClientType === "privy");
+      if (!ready || !authenticated || !privyWallet) {
         setSigner(undefined);
         setClient(undefined);
         setError(null);
@@ -58,7 +58,7 @@ export function WalletClientProvider({ children }: { children: ReactNode }) {
       }
 
       try {
-        const account = await toViemAccount({ wallet: embeddedWallet });
+        const account = await toViemAccount({ wallet: privyWallet });
         if (!cancelled) setSigner(account);
       } catch (err) {
         if (!cancelled) {
@@ -72,7 +72,7 @@ export function WalletClientProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [ready, authenticated, embeddedWallet, refreshToken]);
+  }, [ready, authenticated, wallets, refreshToken]);
 
   useEffect(() => {
     let cancelled = false;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,10 +13,10 @@ const withPWA = createPWA({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Optimize memory usage in development
-  turbopack: {},
+  transpilePackages: ['@privy-io/react-auth', '@privy-io/alchemy-migration'],
   experimental: {
     // Reduce memory usage by optimizing compilation
-    optimizePackageImports: ['@account-kit/react', '@account-kit/core', '@apollo/client', 'lucide-react', 'framer-motion'],
+    optimizePackageImports: ['@privy-io/react-auth', '@privy-io/alchemy-migration', '@alchemy/wallet-apis', '@apollo/client', 'lucide-react', 'framer-motion'],
   },
   // External packages that should not be processed by the bundler
   // Externalize thread-stream and pino packages on server to avoid bundling test files
@@ -215,6 +215,22 @@ const nextConfig = {
       }
     }
 
+    // Privy pulls optional Solana funding modules; Creative TV is EVM-only.
+    config.plugins.push(
+      new webpack.IgnorePlugin({
+        checkResource(resource) {
+          return /FundSolWalletWithExternalSolanaWallet/.test(resource || "");
+        },
+      })
+    );
+    config.plugins.push(
+      new webpack.IgnorePlugin({
+        checkResource(resource) {
+          return /@solana-program[\\/]token/.test(resource || "");
+        },
+      })
+    );
+
     return config;
   },
   // Reduce unnecessary rebuilds
@@ -344,15 +360,78 @@ const nextConfig = {
     ],
   },
   async headers() {
+    // Privy CSP requirements: https://docs.privy.io/security/implementation-guide/content-security-policy
+    const privyChildSrc = [
+      "'self'",
+      "https://auth.privy.io",
+      "https://verify.walletconnect.com",
+      "https://verify.walletconnect.org",
+    ].join(" ");
+
+    const privyFrameSrc = [
+      "'self'",
+      "https://auth.privy.io",
+      "https://verify.walletconnect.com",
+      "https://verify.walletconnect.org",
+      "https://challenges.cloudflare.com",
+      "https:",
+    ].join(" ");
+
+    const privyConnectSrc = [
+      "'self'",
+      "https://auth.privy.io",
+      "wss://relay.walletconnect.com",
+      "wss://relay.walletconnect.org",
+      "wss://www.walletlink.org",
+      "https://*.rpc.privy.systems",
+      "https://explorer-api.walletconnect.com",
+      "https://api.g.alchemy.com",
+      "https:",
+      "wss:",
+      "ws:",
+    ].join(" ");
+
+    const privyScriptSrc = [
+      "'self'",
+      "'unsafe-eval'",
+      "'unsafe-inline'",
+      "blob:",
+      "https://challenges.cloudflare.com",
+      "https://va.vercel-scripts.com",
+      "https://vercel.live",
+    ].join(" ");
+
+    const mainCsp = [
+      "default-src 'self'",
+      "img-src 'self' blob: data: https:",
+      "media-src 'self' blob: data: https:",
+      `script-src ${privyScriptSrc}`,
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' data:",
+      `connect-src ${privyConnectSrc}`,
+      `child-src ${privyChildSrc}`,
+      `frame-src ${privyFrameSrc}`,
+      "worker-src 'self' blob:",
+      "manifest-src 'self'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "upgrade-insecure-requests",
+    ].join("; ");
+
     const embedCsp = [
       "default-src 'self'",
       "img-src 'self' blob: data: https:",
       "media-src 'self' blob: data: https:",
-      "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://va.vercel-scripts.com https://vercel.live",
+      `script-src ${privyScriptSrc}`,
       "style-src 'self' 'unsafe-inline'",
       "font-src 'self' data:",
-      "connect-src 'self' https: wss: ws:",
-      "frame-src 'self' https:",
+      `connect-src ${privyConnectSrc}`,
+      `child-src ${privyChildSrc}`,
+      `frame-src ${privyFrameSrc}`,
+      "worker-src 'self' blob:",
+      "manifest-src 'self'",
       "object-src 'none'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -384,21 +463,7 @@ const nextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "img-src 'self' blob: data: https:",
-              "media-src 'self' blob: data: https:",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://va.vercel-scripts.com https://vercel.live",
-              "style-src 'self' 'unsafe-inline'",
-              "font-src 'self' data:",
-              "connect-src 'self' https: wss: ws:",
-              "frame-src 'self' https:",
-              "object-src 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-              "frame-ancestors 'none'",
-              "upgrade-insecure-requests",
-            ].join('; '),
+            value: mainCsp,
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@account-kit/smart-contracts": "^4.82.0",
     "@account-kit/wallet-client": "^4.82.0",
     "@ai-sdk/google": "^1.0.0",
+    "@alchemy/wallet-apis": "^5.0.0",
     "@apollo/client": "^3.13.8",
     "@apollo/client-integration-nextjs": "^0.12.2",
     "@axiomhq/js": "^1.3.1",
@@ -67,6 +68,8 @@
     "@neondatabase/serverless": "^1.0.0",
     "@orbclub/modules": "^0.1.1",
     "@paragraph-com/sdk": "^1.1.0",
+    "@privy-io/alchemy-migration": "^0.0.5",
+    "@privy-io/react-auth": "^3.32.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.11",
@@ -177,6 +180,9 @@
   "pnpm": {
     "patchedDependencies": {
       "next@16.2.4": "patches/next@16.2.4.patch"
+    },
+    "overrides": {
+      "viem": "2.48.8"
     }
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   '@reown/appkit-ui': 1.7.8
   '@reown/appkit-utils': 1.7.8
   '@reown/appkit-wallet': 1.7.8
+  viem: 2.48.8
 
 patchedDependencies:
   next@16.2.4:
@@ -50,7 +51,7 @@ importers:
         version: 4.88.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@account-kit/react':
         specifier: ^4.82.0
-        version: 4.88.1(be7403aab5cc63163cc96d0cf3b83864)
+        version: 4.88.1(b60465725f996a6e633894a5403855be)
       '@account-kit/signer':
         specifier: ^4.82.0
         version: 4.88.1(@types/react@18.3.28)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -63,6 +64,9 @@ importers:
       '@ai-sdk/google':
         specifier: ^1.0.0
         version: 1.2.22(zod@3.25.76)
+      '@alchemy/wallet-apis':
+        specifier: ^5.0.0
+        version: 5.0.6(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@apollo/client':
         specifier: ^3.13.8
         version: 3.14.1(@types/react@18.3.28)(graphql@16.13.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -150,6 +154,12 @@ importers:
       '@paragraph-com/sdk':
         specifier: ^1.1.0
         version: 1.6.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@privy-io/alchemy-migration':
+        specifier: ^0.0.5
+        version: 0.0.5(9684ff722552088ef76af27c5f021a3a)
+      '@privy-io/react-auth':
+        specifier: ^3.32.2
+        version: 3.32.2(e6d89584ab9d634e212fd65c57616cc7)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -400,7 +410,7 @@ importers:
         specifier: ^11.1.0
         version: 11.1.1
       viem:
-        specifier: ^2.23.5
+        specifier: 2.48.8
         version: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       wagmi:
         specifier: ^2.15.3
@@ -410,7 +420,7 @@ importers:
         version: 5.2.0
       x402-fetch:
         specifier: ^0.6.6
-        version: 0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -485,14 +495,14 @@ packages:
     peerDependencies:
       react: 17.x.x || 18.x.x
       react-dom: 17.x.x || 18.x.x
-      viem: 2.x.x
+      viem: 2.48.8
       wagmi: 2.x.x
 
   '@0xsplits/splits-sdk-react@4.4.0':
     resolution: {integrity: sha512-aYxGAx93XcIxKAAyltsS3ck0gerqMOTxr6SpGl+JCJh4ImOluPr24UJ+WU+wK7FY5Q3Zke6TCbDGTJrAF18P+g==}
     peerDependencies:
       react: 17.x.x || 18.x.x
-      viem: ^2.0.0
+      viem: 2.48.8
     peerDependenciesMeta:
       viem:
         optional: true
@@ -500,7 +510,7 @@ packages:
   '@0xsplits/splits-sdk@6.5.0':
     resolution: {integrity: sha512-npgB9u7FsTs0ab2m5FCfYvP/lRZwUUoezZuLvl/xS3PtjSMm6QIJ5fSfifhzKt2jvzuwQdgGUImBQalQF9pdog==}
     peerDependencies:
-      viem: ^2.0.0
+      viem: 2.48.8
     peerDependenciesMeta:
       viem:
         optional: true
@@ -508,23 +518,23 @@ packages:
   '@aa-sdk/core@4.88.1':
     resolution: {integrity: sha512-iSCjKsfEMDTD6LYOzm1ingndhmThFn9rVbFn0uAnFiGU9N8dS0MhvnhL0jVDIc2HLKEXbkXM9KDMZ7UJK8QIzA==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@aa-sdk/ethers@4.88.1':
     resolution: {integrity: sha512-lMBOQYDqAA7G/5F88FX9aaCwxu9j7G4TUfQqZa0oBq5IqTRddD48is79710qKuW4/ABaQUNzPMmJWkE3UoboNg==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@account-kit/core@4.88.1':
     resolution: {integrity: sha512-l1bysp/Ve7fC3rFJqZVG0rZ62XF4x+/2OlSjx3BHm42F7puKbpCMH0BDjsT3SwxHBhpsbzXuxWZkIJLEnE3uPA==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
       wagmi: ^2.15.5
 
   '@account-kit/infra@4.88.1':
     resolution: {integrity: sha512-+PUA4nppNvqwHuPdasxZTK1DB93e7Wj/hqvVSvcqil6GYSDqZPJihaIPb5RO8kcjG7DOvAAkXWlftFPQyahMGg==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@account-kit/logging@4.88.1':
     resolution: {integrity: sha512-VEDqAszm3aSFbSeIi3AQD2sj2UnCme4JNbDyC2stJpiqpW+SDwkpjCOcYH3aaaIBRlsMeXsrcWWHP2solMgshA==}
@@ -545,23 +555,23 @@ packages:
       '@tanstack/react-query': ^5.28.9
       react: '>=18.2.0'
       react-dom: '>=18.2.0'
-      viem: ^2.45.0
+      viem: 2.48.8
       wagmi: ^2.15.5
 
   '@account-kit/signer@4.88.1':
     resolution: {integrity: sha512-7Ya3El3AnXLHmLXy9M9tsJt0fm3u3ZES/HUkzPiLoVsLaooeNQMF8ChvEbzxefijOllwQRH5nu2ZOEybrhGIKA==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@account-kit/smart-contracts@4.88.1':
     resolution: {integrity: sha512-5YXLVr8T/1Bxq8w1euEC8n7CqdM5TlyzWfljfybHU8mszOQ77QC8RLI1ae1bQ/B+2mMl2I7yqbk0PPdw+dDjkw==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@account-kit/wallet-client@4.88.1':
     resolution: {integrity: sha512-/LIuo8UnL35MYkJAYjw9FPoL+eFNwTtVLFPxVgUQwIX8Lv0T7uMdub/78We0gG32HBL5mASQ3pGaHVZHwhOIEQ==}
     peerDependencies:
-      viem: ^2.45.0
+      viem: 2.48.8
 
   '@achingbrain/http-parser-js@0.5.9':
     resolution: {integrity: sha512-nPuMf2zVzBAGRigH/1jFpb/6HmJsps+15f4BPlGDp3vsjYB2ZgruAErUpKpcFiVRz3DHLXcGNmuwmqZx/sVI7A==}
@@ -613,10 +623,37 @@ packages:
   '@alchemy/common@0.0.0-alpha.13':
     resolution: {integrity: sha512-2YRLIeswvdiVHCH245SefRwQgBw3hGRsKWIElhBmcwNOT5QuonTRmORSamffW7SstVwrGS6L7Cr3WXc1iZHfpA==}
 
+  '@alchemy/common@5.0.0-beta.32':
+    resolution: {integrity: sha512-gVUrMhnhdD8UUipd70XUbmxm3PX3OhHK1TSi3ODBGOH3Jd9SoH0+mFagSn62pwi5XFPCOg3UGGXj9bmLKFlGhA==}
+    peerDependencies:
+      viem: 2.48.8
+
+  '@alchemy/common@5.0.6':
+    resolution: {integrity: sha512-9tpQHYVo4d9nAuU+8c352n/oBQXigOoKG+NsQnnU3Dcn6rPDZ8c6EQ0b7ZMn9IejEYrPaQNkYpz5jPwwxdQ/iA==}
+    peerDependencies:
+      viem: 2.48.8
+
   '@alchemy/wallet-api-types@0.1.0-alpha.25':
     resolution: {integrity: sha512-jF5hAJiuLBVtS2RxFyAkbsvHygmBjxf5tmt4/CpsnYjdy5TfiU4H4XaY3ovY2sWO7S9g1Ucz4SvULWtG6hn2kA==}
     peerDependencies:
       typescript: ^5.8.2
+
+  '@alchemy/wallet-api-types@0.2.0-alpha.3':
+    resolution: {integrity: sha512-VaNj8gzGfPveo8i6l3aX4YovQezu4oDuAqyAy2k1LqsLf18pn2+iw3cV/WiFTwMrdQXLtnDYzS9D6NdkgEokzw==}
+    peerDependencies:
+      typescript: ^5.8.2
+
+  '@alchemy/wallet-apis@5.0.6':
+    resolution: {integrity: sha512-CO1whIESzrECFY7CuVQDtpCXks+IhBQB/m6kZU1XQceWvUyd/7lJeMa3C92CALRbY4Sy+F5lCSeA/AyYfrko3g==}
+    peerDependencies:
+      '@solana/kit': '>=6.0.0'
+      '@solana/web3.js': ^1.95.0
+      viem: 2.48.8
+    peerDependenciesMeta:
+      '@solana/kit':
+        optional: true
+      '@solana/web3.js':
+        optional: true
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1306,6 +1343,9 @@ packages:
   '@coinbase/wallet-sdk@3.9.3':
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
 
+  '@coinbase/wallet-sdk@4.3.2':
+    resolution: {integrity: sha512-hOLA2YONq8Z9n8f6oVP6N//FEEHOen7nq+adG/cReol6juFTHUelVN5GnA5zTIxiLFMDcrhDwwgCA6Tdb5jubw==}
+
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
 
@@ -1801,7 +1841,7 @@ packages:
     peerDependencies:
       '@farcaster/miniapp-sdk': ^0.2.3
       '@wagmi/core': ^2.14.1
-      viem: ^2.21.55
+      viem: 2.48.8
 
   '@farcaster/quick-auth@0.0.6':
     resolution: {integrity: sha512-tiZndhpfDtEhaKlkmS5cVDuS+A/tafqZT3y9I44rC69m3beJok6e8dIH2JhxVy3EvOWTyTBnrmNn6GOOh+qK6A==}
@@ -1851,6 +1891,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -1866,12 +1912,12 @@ packages:
   '@gemini-wallet/core@0.2.0':
     resolution: {integrity: sha512-vv9aozWnKrrPWQ3vIFcWk7yta4hQW1Ie0fsNNPeXnjAxkbXr2hqMagEptLuMxpEP2W3mnRu05VDNKzcvAuuZDw==}
     peerDependencies:
-      viem: '>=2.0.0'
+      viem: 2.48.8
 
   '@gemini-wallet/core@0.3.2':
     resolution: {integrity: sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ==}
     peerDependencies:
-      viem: '>=2.0.0'
+      viem: 2.48.8
 
   '@gilbarbara/deep-equal@0.4.1':
     resolution: {integrity: sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==}
@@ -1917,7 +1963,16 @@ packages:
     resolution: {integrity: sha512-Ek47Wenv92KzfmIlyyk6aGpNDdUAM/24RJGwrZgfHm5JevViHBAtTpZL3SGw5A2wl6KzdfWVOCCmwHSRDClqGw==}
     peerDependencies:
       ethers: ^6.12.1
-      viem: ^2.27.2
+      viem: 2.48.8
+
+  '@hcaptcha/loader@2.3.0':
+    resolution: {integrity: sha512-i4lnNxKBe+COf3R1nFZEWaZoHIoJjvDgWqvcNrdZq8ehoSNMN6KVZ56dcQ02qKie2h3+BkbkwlJA9DOIuLlK/g==}
+
+  '@hcaptcha/react-hcaptcha@1.17.4':
+    resolution: {integrity: sha512-rIvgesG1N7SS9sAYYHFoWm+nXqRrxq7RcA9z2pKkDWV+S1GdfmrTNYA1aPyVWVe3eowphTCwyDJvl97Swwy0mw==}
+    peerDependencies:
+      react: '>= 16.3.0'
+      react-dom: '>= 16.3.0'
 
   '@headlessui/react@1.7.19':
     resolution: {integrity: sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==}
@@ -1925,6 +1980,13 @@ packages:
     peerDependencies:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
+
+  '@headlessui/react@2.2.10':
+    resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   '@helia/bitswap@3.2.3':
     resolution: {integrity: sha512-uquUTgYaU5Z08SVFn+Psg1xhkeAqCdLWav0zAaNJE1bQX7UeLItW82+Nh5I40RaH9gMFFqL3IQR0mIzi+bj5Gg==}
@@ -2137,6 +2199,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
+
   '@ipld/car@5.4.3':
     resolution: {integrity: sha512-+6QHy+9sLov1K28PmazHyqEmD5oDeMWa3mwxst8rt5OsP7CmEexwYDOflGSjPDOUWgHQ4WabQnBSZfXKvZ0DUw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -2310,7 +2381,7 @@ packages:
     engines: {node: '>=18', pnpm: '>=9.1.2'}
     peerDependencies:
       ethers: ^6.12.1
-      viem: ^2.12.0
+      viem: 2.48.8
       zksync-ethers: ^6.7.1
     peerDependenciesMeta:
       ethers:
@@ -2327,7 +2398,7 @@ packages:
     resolution: {integrity: sha512-Y7lCJe8gO5+OkLJWHj1SQhlj8nzubYowXI3X4FV1vhXt+RziogC/8IzUgmF5kBeR2f0gh+e5LPtst5O+VL2ZgQ==}
     peerDependencies:
       ethers: ^6.13.4
-      viem: ^2.21.53
+      viem: 2.48.8
       zksync-ethers: ^6.15.3
     peerDependenciesMeta:
       ethers:
@@ -2497,6 +2568,12 @@ packages:
     resolution: {integrity: sha512-digSQzUk6aDPnBYQUeHIFLYvTI9+0YSgrgLnGm5fQ8pVUMo9LAShBW/6frg4RXAgGiDe+pc52ZxjgepJ1hfY9g==}
     hasBin: true
 
+  '@marsidev/react-turnstile@1.5.3':
+    resolution: {integrity: sha512-8Dij2jiNGNczq1U4EKpO4do2XepcTPxSMc2ZzvHndO+gcp68tvMULm27z2P99rGkdB89hc3452NZeu2Rti4g6A==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
+
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
 
@@ -2588,6 +2665,10 @@ packages:
     resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
     peerDependencies:
       three: '>= 0.159.0'
+
+  '@msgpack/msgpack@3.1.2':
+    resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
+    engines: {node: '>= 18'}
 
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
@@ -2984,6 +3065,84 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@privy-io/alchemy-migration@0.0.5':
+    resolution: {integrity: sha512-/91octGdUBOgQq3Ct3KJdKnJTRYPlY1cez58B1wuTxGDk4+3oNaSM+4zpVQKaiiR4hB8c5ylhEw0doNIDCGBCA==}
+    peerDependencies:
+      '@privy-io/react-auth': ^3
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@privy-io/api-base@1.9.1':
+    resolution: {integrity: sha512-Dq7yyZyVQm71gm3d5o1VH9Ahak9gf/zXx6A6E4bx9VVZEYTevL8J3aJAvIIj1qFenc12UGUpWO3oWkn9Cpr+mw==}
+
+  '@privy-io/api-types@0.15.0':
+    resolution: {integrity: sha512-VT5/Wau37+ZRaVZ8CPa224z5qcJTeaQtamq6TfOcPJSdV6cNyX+Phlaeg13xFLjj3dIGkqibZvr0f45VT6PX3A==}
+
+  '@privy-io/are-addresses-equal@0.0.9':
+    resolution: {integrity: sha512-mLBv7cde8ilPYUBjHl6ke+0H3v2hoa5bdShNT0/wm7NYZByvH7/inNN+iK5nTv7D0Ti2rqcfW3UXNxub9eVOpg==}
+
+  '@privy-io/chains@0.3.0':
+    resolution: {integrity: sha512-27dTj94S4PbyiJuknRuqXzYZSqbk62y2Ht/8ppSNlsaIswxrso9uE8w5PKX82zNyz7crHRULfxDPv2xM2ZXHTg==}
+
+  '@privy-io/encoding@0.2.0':
+    resolution: {integrity: sha512-JVAs2aSUt/TnvuP8tI4iv9/A7+EwMhdPKzXTOOeKJyjyVs9eO1abc1SQ2GlFcgKoj1P48JmhQMI4J8LCH4F0IA==}
+
+  '@privy-io/ethereum@0.2.0':
+    resolution: {integrity: sha512-Qr2MlVKMABMh2Ca4VqigrlccaiNCF3fBeG5mZYQr2cZgJI9Wea6aqP6fOmX4KGQw3vJWqgDE8v21T/Kqgc9oAA==}
+    peerDependencies:
+      viem: 2.48.8
+
+  '@privy-io/js-sdk-core@0.67.4':
+    resolution: {integrity: sha512-CM0AVWo4v3+ZwbpUvMiZMXg40a1krJr6lS/KYtm/k/PEKtV8LcSTI3sZoUX6FlVYN0N7sha2sNJoXRFup+OS5Q==}
+    peerDependencies:
+      permissionless: ^0.2.47
+      viem: 2.48.8
+    peerDependenciesMeta:
+      permissionless:
+        optional: true
+      viem:
+        optional: true
+
+  '@privy-io/popup@0.0.4':
+    resolution: {integrity: sha512-Lk5BqB//F9naVOR9tkHbrcGs55fM4ILS50tdsgIQ76Kr9i7Og4Ob5IRGIKb75P11f5hXTwAjMezRmWM/7uAsrw==}
+
+  '@privy-io/react-auth@3.32.2':
+    resolution: {integrity: sha512-9mjVOgKBGbtZ9imI5+W5hI0EsHg9Ge8uM+v/ipDu9LJCglTHX1dsM7S54C2sWobqLeHDvK6MTzvHh2gzd2u8KQ==}
+    peerDependencies:
+      '@abstract-foundation/agw-client': ^1.0.0
+      '@farcaster/mini-app-solana': ^1.0.0
+      '@solana-program/memo': '>=0.8.0'
+      '@solana-program/system': '>=0.8.0'
+      '@solana-program/token': '>=0.6.0'
+      '@solana/kit': '>=3.0.3'
+      '@stripe/crypto': '>=0.1.0'
+      permissionless: ^0.2.47
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@abstract-foundation/agw-client':
+        optional: true
+      '@farcaster/mini-app-solana':
+        optional: true
+      '@solana-program/memo':
+        optional: true
+      '@solana-program/system':
+        optional: true
+      '@solana-program/token':
+        optional: true
+      '@solana/kit':
+        optional: true
+      '@stripe/crypto':
+        optional: true
+      permissionless:
+        optional: true
+
+  '@privy-io/routes@0.2.5':
+    resolution: {integrity: sha512-nUMbBV/q4tcjy7g8wgAsM7J+VkB7scLIm6UrZdx9iRsEfwI3mw5rIV6RYaRrHMCZRPPqYfYSzIgeTQFzBDmV4A==}
+
+  '@privy-io/urls@0.0.4':
+    resolution: {integrity: sha512-YYLt3zD4GlMgVm+VkdMF8BnRYlUrfkcchF7fVTPwdP8ljPytCP295yxi26iOsbJfT/xy3+sLsvvrDthjpk6ERA==}
 
   '@project-serum/sol-wallet-adapter@0.2.6':
     resolution: {integrity: sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==}
@@ -3578,6 +3737,18 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-aria/focus@3.22.1':
+    resolution: {integrity: sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.28.1':
+    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-native-async-storage/async-storage@1.24.0':
     resolution: {integrity: sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==}
     peerDependencies:
@@ -3702,6 +3873,11 @@ packages:
         optional: true
       react-native:
         optional: true
+
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@reality.eth/contracts@3.2.25':
     resolution: {integrity: sha512-MO36RaAPhb/lJq2z85bxo7WaU5wbsrx1+Va9968eUvOG1yyQLIkuHhpEB602JYaUfCVQizvHdTLhcwvmbMSQsQ==}
@@ -3954,17 +4130,11 @@ packages:
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
-  '@scure/bip32@1.6.2':
-    resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
-
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
-
-  '@scure/bip39@1.5.4':
-    resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
@@ -4041,6 +4211,11 @@ packages:
   '@solana-mobile/wallet-standard-mobile@0.5.2':
     resolution: {integrity: sha512-orEGv4N/Ttd0umwfWUzGcEnVc9eJDTgRSEcDitvFWpIf2D968h6128L0rq9/y7sUw88Gvu/lU0euoC2ASEijqQ==}
 
+  '@solana-program/compute-budget@0.11.0':
+    resolution: {integrity: sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
   '@solana-program/compute-budget@0.8.0':
     resolution: {integrity: sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==}
     peerDependencies:
@@ -4066,6 +4241,12 @@ packages:
     peerDependencies:
       '@solana/kit': ^2.1.0
       '@solana/sysvars': ^2.1.0
+
+  '@solana-program/token-2022@0.6.1':
+    resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+      '@solana/sysvars': ^5.0
 
   '@solana-program/token@0.5.1':
     resolution: {integrity: sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==}
@@ -4141,11 +4322,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.8.0':
-    resolution: {integrity: sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==}
+  '@solana/codecs-core@6.10.0':
+    resolution: {integrity: sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.0.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4180,11 +4361,11 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.8.0':
-    resolution: {integrity: sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==}
+  '@solana/codecs-numbers@6.10.0':
+    resolution: {integrity: sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.0.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4208,12 +4389,12 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.8.0':
-    resolution: {integrity: sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==}
+  '@solana/codecs-strings@6.10.0':
+    resolution: {integrity: sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.0.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
@@ -4252,12 +4433,12 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@6.8.0':
-    resolution: {integrity: sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==}
+  '@solana/errors@6.10.0':
+    resolution: {integrity: sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: '>=5.0.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5366,7 +5547,7 @@ packages:
     resolution: {integrity: sha512-0W3sp7BBD2nSqHfNrfjUByLm4l53ciAN+9Gjf8K9KB6d3wmLgnaw1cf40qx7TinrppFvevEi/B8VgcisfCu5KA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      viem: ^1.16.6 || ^2.24.2
+      viem: 2.48.8
 
   '@turnkey/wallet-stamper@1.0.9':
     resolution: {integrity: sha512-BvqmewbwjdQwwDy1o5GY240jinwoIU6pX7uXIxeAKEbhXUlAKlbESW5U1MLnAZj4dK1kNdsr1kvFW53vq5Dsdw==}
@@ -5881,7 +6062,7 @@ packages:
     peerDependencies:
       '@wagmi/core': 2.21.2
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: 2.48.8
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5891,7 +6072,7 @@ packages:
     peerDependencies:
       '@wagmi/core': 2.22.1
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: 2.48.8
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5901,7 +6082,7 @@ packages:
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: 2.48.8
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -5945,12 +6126,19 @@ packages:
     resolution: {integrity: sha512-Tp4MHJYcdWD846PH//2r+Mu4wz1/ZU/fr9av1UWFiaYQ2t2TPLDiZxjLw54AAEpMqlEHemwCgiRiAmjR1NDdTQ==}
     engines: {node: '>=18'}
 
+  '@walletconnect/core@2.22.4':
+    resolution: {integrity: sha512-ZQnyDDpqDPAk5lyLV19BRccQ3wwK3LmAwibuIv3X+44aT/dOs2kQGu9pla3iW2LgZ5qRMYvgvvfr5g3WlDGceQ==}
+    engines: {node: '>=18.20.8'}
+
   '@walletconnect/environment@1.0.1':
     resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
 
   '@walletconnect/ethereum-provider@2.21.1':
     resolution: {integrity: sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+
+  '@walletconnect/ethereum-provider@2.22.4':
+    resolution: {integrity: sha512-qhBxU95nlndiKGz8lO8z9JlsA4Ai8i1via4VWut2fXsW1fkl6qXG9mYhDRFsbavuynUe3dQ+QLjBVDaaNkcKCA==}
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
@@ -5984,6 +6172,9 @@ packages:
   '@walletconnect/logger@2.1.2':
     resolution: {integrity: sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==}
 
+  '@walletconnect/logger@3.0.0':
+    resolution: {integrity: sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==}
+
   '@walletconnect/relay-api@1.0.11':
     resolution: {integrity: sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==}
 
@@ -6005,6 +6196,9 @@ packages:
     resolution: {integrity: sha512-QaXzmPsMnKGV6tc4UcdnQVNOz4zyXgarvdIQibJ4L3EmLat73r5ZVl4c0cCOcoaV7rgM9Wbphgu5E/7jNcd3Zg==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
+  '@walletconnect/sign-client@2.22.4':
+    resolution: {integrity: sha512-la+sol0KL33Fyx5DRlupHREIv8wA6W33bRfuLAfLm8pINRTT06j9rz0IHIqJihiALebFxVZNYzJnF65PhV0q3g==}
+
   '@walletconnect/solana-adapter@0.0.8':
     resolution: {integrity: sha512-Qb7MT8SdkeBldfUCmF+rYW6vL98mxPuT1yAwww5X2vpx7xEPZvFCoAKnyT5fXu0v56rMxhW3MGejnHyyYdDY7Q==}
     peerDependencies:
@@ -6023,6 +6217,9 @@ packages:
   '@walletconnect/types@2.21.1':
     resolution: {integrity: sha512-UeefNadqP6IyfwWC1Yi7ux+ljbP2R66PLfDrDm8izmvlPmYlqRerJWJvYO4t0Vvr9wrG4Ko7E0c4M7FaPKT/sQ==}
 
+  '@walletconnect/types@2.22.4':
+    resolution: {integrity: sha512-KJdiS9ezXzx1uASanldYaaenDwb42VOQ6Rj86H7FRwfYddhNnYnyEaDjDKOdToGRGcpt5Uzom6qYUOnrWEbp5g==}
+
   '@walletconnect/universal-provider@2.19.0':
     resolution: {integrity: sha512-e9JvadT5F8QwdLmd7qBrmACq04MT7LQEe1m3X2Fzvs3DWo8dzY8QbacnJy4XSv5PCdxMWnua+2EavBk8nrI9QA==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
@@ -6035,6 +6232,9 @@ packages:
     resolution: {integrity: sha512-Wjx9G8gUHVMnYfxtasC9poGm8QMiPCpXpbbLFT+iPoQskDDly8BwueWnqKs4Mx2SdIAWAwuXeZ5ojk5qQOxJJg==}
     deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
+  '@walletconnect/universal-provider@2.22.4':
+    resolution: {integrity: sha512-TF2RNX13qxa0rrBAhVDs5+C2G8CHX7L0PH5hF2uyQHdGyxZ3pFbXf8rxmeW1yKlB76FSbW80XXNrUes6eK/xHg==}
+
   '@walletconnect/utils@2.19.0':
     resolution: {integrity: sha512-LZ0D8kevknKfrfA0Sq3Hf3PpmM8oWyNfsyWwFR51t//2LBgtN2Amz5xyoDDJcjLibIbKAxpuo/i0JYAQxz+aPA==}
 
@@ -6043,6 +6243,9 @@ packages:
 
   '@walletconnect/utils@2.21.1':
     resolution: {integrity: sha512-VPZvTcrNQCkbGOjFRbC24mm/pzbRMUq2DSQoiHlhh0X1U7ZhuIrzVtAoKsrzu6rqjz0EEtGxCr3K1TGRqDG4NA==}
+
+  '@walletconnect/utils@2.22.4':
+    resolution: {integrity: sha512-coAPrNiTiD+snpiXQyXakMVeYcddqVqII7aLU39TeILdPoXeNPc2MAja+MF7cKNM/PA3tespljvvxck/oTm4+Q==}
 
   '@walletconnect/window-getters@1.0.1':
     resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
@@ -6189,17 +6392,6 @@ packages:
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
-  abitype@1.0.8:
-    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -6833,6 +7025,10 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
   cardinal@2.1.1:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
     hasBin: true
@@ -7020,6 +7216,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -7605,6 +7805,9 @@ packages:
   es-toolkit@1.33.0:
     resolution: {integrity: sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg==}
 
+  es-toolkit@1.39.3:
+    resolution: {integrity: sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==}
+
   es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
     engines: {node: '>=0.10'}
@@ -7922,6 +8125,9 @@ packages:
   fast-base64-decode@1.0.0:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
 
@@ -7944,6 +8150,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-password-entropy@1.1.1:
+    resolution: {integrity: sha512-dxm29/BPFrNgyEDygg/lf9c2xQR0vnQhG7+hZjAI39M/3um9fD4xiqG6F0ZjW6bya5m9CI0u6YryHGRtxCGCiw==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -8868,11 +9077,6 @@ packages:
     peerDependencies:
       ws: '*'
 
-  isows@1.0.6:
-    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
-    peerDependencies:
-      ws: '*'
-
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
@@ -9185,6 +9389,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
@@ -9370,6 +9577,9 @@ packages:
   libp2p@3.2.3:
     resolution: {integrity: sha512-sri0KjdVrzKlahFqrMC/v0wsmvbpIasM0yA1jCAM4d5+Xjj1IN4yFzksSIVqKu6pqhhggR+Pr2ZgTBkH3BlpMw==}
 
+  libphonenumber-js@1.13.7:
+    resolution: {integrity: sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==}
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -9531,6 +9741,11 @@ packages:
 
   lucide-react@0.477.0:
     resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide-react@0.554.0:
+    resolution: {integrity: sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10280,6 +10495,14 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  ox@0.11.3:
+    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.14.20:
     resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
     peerDependencies:
@@ -10304,14 +10527,6 @@ packages:
       typescript:
         optional: true
 
-  ox@0.6.7:
-    resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.6.9:
     resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
@@ -10322,6 +10537,14 @@ packages:
 
   ox@0.9.17:
     resolution: {integrity: sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.9.3:
+    resolution: {integrity: sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -10504,8 +10727,18 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
+  pino-abstract-transport@1.2.0:
+    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@10.3.1:
+    resolution: {integrity: sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==}
+    hasBin: true
 
   pino-pretty@13.1.3:
     resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
@@ -10513,6 +10746,13 @@ packages:
 
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.0.0:
+    resolution: {integrity: sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==}
+    hasBin: true
 
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
@@ -10545,7 +10785,7 @@ packages:
       '@wagmi/core': '>=2.16.3'
       react: '>=18'
       typescript: '>=5.4.0'
-      viem: '>=2.37.0'
+      viem: 2.48.8
       wagmi: '>=2.0.0'
     peerDependenciesMeta:
       '@tanstack/react-query':
@@ -10569,7 +10809,7 @@ packages:
       react: '>=18'
       react-native: '>=0.81.4'
       typescript: '>=5.4.0'
-      viem: '>=2.37.0'
+      viem: 2.48.8
       wagmi: '>=2.0.0'
     peerDependenciesMeta:
       '@tanstack/react-query':
@@ -10683,6 +10923,9 @@ packages:
 
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -10847,6 +11090,12 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-blockies@1.4.1:
     resolution: {integrity: sha512-4N015X5oPNnD3xQPsiqolOFzPZSSWyc5mJhJUZShUCHtiGUxVN+1qsWTcglkHMNySux9hUofaispqcw9QkWP5Q==}
     peerDependencies:
@@ -10856,6 +11105,12 @@ packages:
     resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-device-detect@2.2.3:
+    resolution: {integrity: sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==}
+    peerDependencies:
+      react: '>= 0.14.0'
+      react-dom: '>= 0.14.0'
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
@@ -10995,6 +11250,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -11050,6 +11310,10 @@ packages:
 
   real-require@0.1.0:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
   redent@3.0.0:
@@ -11320,6 +11584,9 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
+  secure-password-utilities@0.2.1:
+    resolution: {integrity: sha512-znUg8ae3cpuAaogiFBhP82gD2daVkSz4Qv/L7OWjB7wWvfbCdeqqQuJkm2/IvhKQPOV0T739YPR6rb7vs0uWaw==}
+
   selderee@0.6.0:
     resolution: {integrity: sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==}
 
@@ -11451,6 +11718,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slow-redact@0.3.2:
+    resolution: {integrity: sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -11480,6 +11750,9 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonic-boom@3.8.1:
+    resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -11818,6 +12091,9 @@ packages:
   sync-multihash-sha2@1.0.0:
     resolution: {integrity: sha512-A5gVpmtKF0ov+/XID0M0QRJqF2QxAsj3x/LlDC8yivzgoYCoWkV+XaZPfVu7Vj1T/hYzYS1tfjwboSbXjqocug==}
 
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
@@ -11898,6 +12174,9 @@ packages:
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
 
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
+
   three-mesh-bvh@0.7.8:
     resolution: {integrity: sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==}
     deprecated: Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.
@@ -11936,6 +12215,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -12177,6 +12459,10 @@ packages:
 
   ua-is-frozen@0.1.2:
     resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
+
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
+    hasBin: true
 
   ua-parser-js@2.0.9:
     resolution: {integrity: sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==}
@@ -12524,14 +12810,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.23.2:
-    resolution: {integrity: sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   viem@2.48.8:
     resolution: {integrity: sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==}
     peerDependencies:
@@ -12614,7 +12892,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
       typescript: '>=5.0.4'
-      viem: 2.x
+      viem: 2.48.8
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -12903,11 +13181,26 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   x402-fetch@0.6.6:
     resolution: {integrity: sha512-a2cneKdXlAXxZoFHhq42Ftv4+YTn1inrAvcUeop4fu8DKG1Nus1OemI0PvBOrKm2yM5gfCaqQhVGpIPiWziLYA==}
 
   x402@0.6.6:
     resolution: {integrity: sha512-gKkxqKBT0mH7fSLld6Mz9ML52dmu1XeOPhVtiUCA3EzkfY6p0EJ3ijKhIKN0Jh8Q6kVXrFlJ/4iAUS1dNDA2lA==}
+
+  x402@0.7.3:
+    resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -13253,7 +13546,7 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
 
-  '@account-kit/react@4.88.1(be7403aab5cc63163cc96d0cf3b83864)':
+  '@account-kit/react@4.88.1(b60465725f996a6e633894a5403855be)':
     dependencies:
       '@account-kit/core': 4.88.1(b89f2e249673e995dd3ea4032b39b207)
       '@account-kit/infra': 4.88.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -13261,7 +13554,7 @@ snapshots:
       '@account-kit/signer': 4.88.1(@types/react@18.3.28)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@account-kit/wallet-client': 4.88.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)
-      '@solana/wallet-adapter-wallets': 0.19.38(@babel/runtime@7.29.2)(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bs58@6.0.0)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@solana/wallet-adapter-wallets': 0.19.38(@babel/runtime@7.29.2)(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bs58@6.0.0)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@tanstack/react-form': 0.33.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       '@tanstack/react-query': 5.100.9(react@19.2.5)
@@ -13451,6 +13744,16 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@alchemy/common@5.0.0-beta.32(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 3.25.76
+
+  '@alchemy/common@5.0.6(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 3.25.76
+
   '@alchemy/wallet-api-types@0.1.0-alpha.25(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@alchemy/common': 0.0.0-alpha.13(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -13463,6 +13766,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
+
+  '@alchemy/wallet-api-types@0.2.0-alpha.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@alchemy/common': 5.0.0-beta.32(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      deep-equal: 2.2.3
+      ox: 0.6.12(typescript@5.9.3)(zod@4.4.3)
+      typescript: 5.9.3
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@alchemy/wallet-apis@5.0.6(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      '@alchemy/common': 5.0.6(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@alchemy/wallet-api-types': 0.2.0-alpha.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      deep-equal: 2.2.3
+      ox: 0.11.3(typescript@5.9.3)(zod@4.4.3)
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 4.4.3
+    optionalDependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -14440,6 +14771,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@coinbase/wallet-sdk@4.3.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.4
+      preact: 10.29.1
+
   '@coinbase/wallet-sdk@4.3.6(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -15061,6 +15399,14 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@floating-ui/react@0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tabbable: 6.5.0
+
   '@floating-ui/utils@0.2.11': {}
 
   '@fractalwagmi/popup-connection@1.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -15138,12 +15484,31 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@hcaptcha/loader@2.3.0': {}
+
+  '@hcaptcha/react-hcaptcha@1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@hcaptcha/loader': 2.3.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@headlessui/react@1.7.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/react-virtual': 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       client-only: 0.0.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  '@headlessui/react@2.2.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-aria/focus': 3.22.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-aria/interactions': 3.28.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-virtual': 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
   '@helia/bitswap@3.2.3':
     dependencies:
@@ -15437,6 +15802,18 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.21
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.21
+
+  '@internationalized/string@3.2.9':
+    dependencies:
+      '@swc/helpers': 0.5.21
 
   '@ipld/car@5.4.3':
     dependencies:
@@ -16365,6 +16742,11 @@ snapshots:
     dependencies:
       '@go-task/go-npm': 0.2.0
 
+  '@marsidev/react-turnstile@1.5.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@mediapipe/tasks-vision@0.10.17': {}
 
   '@metamask/eth-json-rpc-provider@1.0.1':
@@ -16558,6 +16940,8 @@ snapshots:
     dependencies:
       promise-worker-transferable: 1.0.4
       three: 0.169.0
+
+  '@msgpack/msgpack@3.1.2': {}
 
   '@multiformats/base-x@4.0.1': {}
 
@@ -16987,6 +17371,201 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@privy-io/alchemy-migration@0.0.5(9684ff722552088ef76af27c5f021a3a)':
+    dependencies:
+      '@account-kit/react': 4.88.1(b60465725f996a6e633894a5403855be)
+      '@privy-io/react-auth': 3.32.2(e6d89584ab9d634e212fd65c57616cc7)
+      '@tanstack/react-query': 5.100.9(react@19.2.5)
+      clsx: 2.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/runtime'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@sentry/types'
+      - '@solana/sysvars'
+      - '@tanstack/start'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@wagmi/core'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-constants
+      - expo-localization
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react-native
+      - react-native-get-random-values
+      - react-native-inappbrowser-reborn
+      - react-native-mmkv
+      - react-native-passkey
+      - supports-color
+      - tslib
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - wagmi
+      - ws
+      - zod
+
+  '@privy-io/api-base@1.9.1':
+    dependencies:
+      zod: 3.25.76
+
+  '@privy-io/api-types@0.15.0': {}
+
+  '@privy-io/are-addresses-equal@0.0.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+    dependencies:
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@privy-io/chains@0.3.0': {}
+
+  '@privy-io/encoding@0.2.0':
+    dependencies:
+      '@scure/base': 1.2.6
+
+  '@privy-io/ethereum@0.2.0(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+
+  '@privy-io/js-sdk-core@0.67.4(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))':
+    dependencies:
+      '@privy-io/api-base': 1.9.1
+      '@privy-io/api-types': 0.15.0
+      '@privy-io/chains': 0.3.0
+      '@privy-io/encoding': 0.2.0
+      '@privy-io/ethereum': 0.2.0(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@privy-io/routes': 0.2.5
+      canonicalize: 2.1.0
+      eventemitter3: 5.0.4
+      fetch-retry: 6.0.0
+      jose: 4.15.9
+      js-cookie: 3.0.5
+      libphonenumber-js: 1.13.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+
+  '@privy-io/popup@0.0.4': {}
+
+  '@privy-io/react-auth@3.32.2(e6d89584ab9d634e212fd65c57616cc7)':
+    dependencies:
+      '@base-org/account': 1.1.1(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.2
+      '@floating-ui/react': 0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@headlessui/react': 2.2.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@heroicons/react': 2.2.0(react@19.2.5)
+      '@marsidev/react-turnstile': 1.5.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@privy-io/api-base': 1.9.1
+      '@privy-io/api-types': 0.15.0
+      '@privy-io/are-addresses-equal': 0.0.9(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@privy-io/chains': 0.3.0
+      '@privy-io/encoding': 0.2.0
+      '@privy-io/ethereum': 0.2.0(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@privy-io/js-sdk-core': 0.67.4(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
+      '@privy-io/popup': 0.0.4
+      '@privy-io/routes': 0.2.5
+      '@privy-io/urls': 0.0.4
+      '@scure/base': 1.2.6
+      '@simplewebauthn/browser': 13.3.0
+      '@tanstack/react-virtual': 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@wallet-standard/app': 1.1.0
+      '@walletconnect/ethereum-provider': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      eventemitter3: 5.0.4
+      fast-password-entropy: 1.1.1
+      jose: 4.15.9
+      js-cookie: 3.0.5
+      lucide-react: 0.554.0(react@19.2.5)
+      mipd: 0.0.7(typescript@5.9.3)
+      ofetch: 1.5.1
+      pino-pretty: 10.3.1
+      qrcode: 1.5.4
+      react: 19.2.5
+      react-device-detect: 2.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+      secure-password-utilities: 0.2.1
+      styled-components: 6.4.1(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)
+      stylis: 4.3.6
+      tinycolor2: 1.6.0
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      x402: 0.7.3(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      zustand: 5.0.12(@types/react@18.3.28)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@solana-program/system': 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - css-to-react-native
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react-native
+      - supports-color
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@privy-io/routes@0.2.5':
+    dependencies:
+      '@privy-io/api-types': 0.15.0
+
+  '@privy-io/urls@0.0.4': {}
 
   '@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -17572,6 +18151,21 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-aria/focus@3.22.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@swc/helpers': 0.5.21
+      react: 19.2.5
+      react-aria: 3.50.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@react-aria/interactions@3.28.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-types/shared': 3.36.0(react@19.2.5)
+      '@swc/helpers': 0.5.21
+      react: 19.2.5
+      react-aria: 3.50.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+
   '@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))':
     dependencies:
       merge-options: 3.0.4
@@ -17736,6 +18330,10 @@ snapshots:
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@types/react'
+
+  '@react-types/shared@3.36.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
 
   '@reality.eth/contracts@3.2.25(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -18220,15 +18818,9 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
 
-  '@scure/bip32@1.6.2':
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.6
-
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -18236,11 +18828,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
-
-  '@scure/bip39@1.5.4':
-    dependencies:
-      '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.6
 
   '@scure/bip39@1.6.0':
     dependencies:
@@ -18355,7 +18942,7 @@ snapshots:
 
   '@solana-mobile/mobile-wallet-adapter-protocol@2.2.8(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
@@ -18403,30 +18990,47 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/system@0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+    optional: true
 
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token@0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+    optional: true
 
   '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -18506,9 +19110,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@6.8.0(typescript@5.9.3)':
+  '@solana/codecs-core@6.10.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -18540,10 +19144,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.8.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@6.10.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
-      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -18564,11 +19168,11 @@ snapshots:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
-  '@solana/codecs-strings@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
-      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
@@ -18609,10 +19213,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/errors@6.8.0(typescript@5.9.3)':
+  '@solana/errors@6.10.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.3
+      commander: 15.0.0
     optionalDependencies:
       typescript: 5.9.3
 
@@ -18681,7 +19285,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -18694,11 +19298,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -18903,14 +19507,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/functional': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -18918,7 +19522,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18942,7 +19546,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.9.3)
@@ -18950,7 +19554,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -19138,7 +19742,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -19146,7 +19750,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -19455,11 +20059,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/wallet-adapter-trezor@0.1.6(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@solana/wallet-adapter-trezor@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@trezor/connect-web': 9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/connect-web': 9.7.3(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       buffer: 6.0.3
     transitivePeerDependencies:
       - '@solana/sysvars'
@@ -19522,7 +20126,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.38(@babel/runtime@7.29.2)(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bs58@6.0.0)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@solana/wallet-adapter-wallets@0.19.38(@babel/runtime@7.29.2)(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bs58@6.0.0)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-avana': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
@@ -19555,7 +20159,7 @@ snapshots:
       '@solana/wallet-adapter-tokenary': 0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-tokenpocket': 0.4.23(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-torus': 0.11.32(@babel/runtime@7.29.2)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/wallet-adapter-trezor': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-trust': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-unsafe-burner': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-walletconnect': 0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -19873,7 +20477,7 @@ snapshots:
       '@supabase/phoenix': 0.4.1
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -20104,13 +20708,13 @@ snapshots:
       - react-native
       - utf-8-validate
 
-  '@trezor/blockchain-link@2.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/blockchain-link@2.6.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@stellar/stellar-sdk': 14.2.0
       '@trezor/blockchain-link-types': 1.5.1(tslib@2.8.1)
@@ -20158,9 +20762,9 @@ snapshots:
       - expo-localization
       - react-native
 
-  '@trezor/connect-web@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/connect-web@9.7.3(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@trezor/connect': 9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/connect': 9.7.3(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/connect-common': 0.5.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)
       '@trezor/utils': 9.5.0(tslib@2.8.1)
       '@trezor/websocket-client': 1.3.0(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
@@ -20179,7 +20783,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@trezor/connect@9.7.3(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@trezor/connect@9.7.3(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@ethereumjs/common': 10.1.1
       '@ethereumjs/tx': 10.1.1
@@ -20187,12 +20791,12 @@ snapshots:
       '@mobily/ts-belt': 3.13.1
       '@noble/hashes': 1.8.0
       '@scure/bip39': 1.6.0
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@trezor/blockchain-link': 2.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@trezor/blockchain-link': 2.6.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@trezor/blockchain-link-types': 1.5.1(tslib@2.8.1)
       '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)(utf-8-validate@6.0.6)
       '@trezor/connect-analytics': 1.4.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(tslib@2.8.1)
@@ -20320,7 +20924,7 @@ snapshots:
     dependencies:
       '@trezor/utils': 9.5.0(tslib@2.8.1)
       tslib: 2.8.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -20476,7 +21080,7 @@ snapshots:
 
   '@turnkey/webauthn-stamper@0.4.3':
     dependencies:
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       buffer: 6.0.3
 
   '@turnkey/webauthn-stamper@0.5.1':
@@ -21295,6 +21899,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/core@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/utils': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(typescript@5.9.3)(zod@3.25.76)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.39.3
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -21311,6 +21959,48 @@ snapshots:
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
       '@walletconnect/universal-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/ethereum-provider@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+    dependencies:
+      '@reown/appkit': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/sign-client': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/types': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/universal-provider': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/utils': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(typescript@5.9.3)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -21419,6 +22109,11 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       pino: 7.11.0
 
+  '@walletconnect/logger@3.0.0':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      pino: 10.0.0
+
   '@walletconnect/relay-api@1.0.11':
     dependencies:
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -21517,6 +22212,42 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
       '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+    dependencies:
+      '@walletconnect/core': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/utils': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(typescript@5.9.3)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -21670,6 +22401,35 @@ snapshots:
       - ioredis
       - uploadthing
 
+  '@walletconnect/types@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/logger': 3.0.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
   '@walletconnect/universal-provider@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -21790,6 +22550,46 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/universal-provider@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/sign-client': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/types': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/utils': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(typescript@5.9.3)(zod@3.25.76)
+      es-toolkit: 1.39.3
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/utils@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
@@ -21808,7 +22608,7 @@ snapshots:
       elliptic: 6.6.1
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21852,7 +22652,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21896,7 +22696,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21920,6 +22720,51 @@ snapshots:
       - typescript
       - uploadthing
       - utf-8-validate
+      - zod
+
+  '@walletconnect/utils@2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)(typescript@5.9.3)(zod@3.25.76)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.22.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@vercel/functions@2.2.13)
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.3)(zod@3.25.76)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
       - zod
 
   '@walletconnect/window-getters@1.0.1':
@@ -22075,7 +22920,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       eventemitter3: 5.0.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -22120,11 +22965,6 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
-    optionalDependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
-
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.9.3
@@ -22134,6 +22974,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76
+
+  abitype@1.2.3(typescript@5.9.3)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
 
   abitype@1.2.4(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -22789,7 +23634,7 @@ snapshots:
 
   bs58check@4.0.0:
     dependencies:
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       bs58: 6.0.0
 
   bser@2.1.1:
@@ -22856,6 +23701,8 @@ snapshots:
       three: 0.169.0
 
   caniuse-lite@1.0.30001791: {}
+
+  canonicalize@2.1.0: {}
 
   cardinal@2.1.1:
     dependencies:
@@ -23044,6 +23891,8 @@ snapshots:
   commander@14.0.2: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 
@@ -23726,6 +24575,8 @@ snapshots:
 
   es-toolkit@1.33.0: {}
 
+  es-toolkit@1.39.3: {}
+
   es5-ext@0.10.64:
     dependencies:
       es6-iterator: 2.0.3
@@ -24254,6 +25105,8 @@ snapshots:
 
   fast-base64-decode@1.0.0: {}
 
+  fast-copy@3.0.2: {}
+
   fast-copy@4.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -24279,6 +25132,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-password-entropy@1.1.1: {}
 
   fast-redact@3.5.0: {}
 
@@ -25371,10 +26226,6 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
-    dependencies:
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-
   isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -25951,6 +26802,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@4.15.9: {}
+
   jose@5.10.0: {}
 
   jose@6.2.3: {}
@@ -26008,7 +26861,7 @@ snapshots:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -26187,6 +27040,8 @@ snapshots:
       race-signal: 2.0.0
       uint8arrays: 5.1.1
 
+  libphonenumber-js@1.13.7: {}
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -26347,6 +27202,10 @@ snapshots:
       yallist: 4.0.0
 
   lucide-react@0.477.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  lucide-react@0.554.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 
@@ -27404,6 +28263,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  ox@0.11.3(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.20(typescript@5.9.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -27428,6 +28302,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -27462,14 +28351,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.12(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -27499,6 +28388,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.9.3(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -27688,9 +28592,35 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
+  pino-abstract-transport@1.2.0:
+    dependencies:
+      readable-stream: 4.7.0
+      split2: 4.2.0
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
+
+  pino-pretty@10.3.1:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.2.0
+      pump: 3.0.4
+      readable-stream: 4.7.0
+      secure-json-parse: 2.7.0
+      sonic-boom: 3.8.1
+      strip-json-comments: 3.1.1
 
   pino-pretty@13.1.3:
     dependencies:
@@ -27709,6 +28639,22 @@ snapshots:
       strip-json-comments: 5.0.3
 
   pino-std-serializers@4.0.0: {}
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.0.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.2
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
 
   pino@7.11.0:
     dependencies:
@@ -27865,6 +28811,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@1.0.0: {}
+
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -28099,6 +29047,20 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-aria@3.50.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.5)
+      '@swc/helpers': 0.5.21
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-stately: 3.48.0(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   react-blockies@1.4.1(react@19.2.5):
     dependencies:
       prop-types: 15.8.1
@@ -28108,6 +29070,12 @@ snapshots:
     dependencies:
       prop-types: 15.8.1
       react: 19.2.5
+
+  react-device-detect@2.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      ua-parser-js: 1.0.41
 
   react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -28304,6 +29272,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  react-stately@3.48.0(react@19.2.5):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.36.0(react@19.2.5)
+      '@swc/helpers': 0.5.21
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@19.2.5):
     dependencies:
       get-nonce: 1.0.1
@@ -28368,6 +29346,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   real-require@0.1.0: {}
+
+  real-require@0.2.0: {}
 
   redent@3.0.0:
     dependencies:
@@ -28602,7 +29582,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 11.1.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -28706,6 +29686,8 @@ snapshots:
   secure-json-parse@2.7.0: {}
 
   secure-json-parse@4.1.0: {}
+
+  secure-password-utilities@0.2.1: {}
 
   selderee@0.6.0:
     dependencies:
@@ -28886,6 +29868,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slow-redact@0.3.2: {}
+
   smart-buffer@4.2.0: {}
 
   smol-toml@1.6.1: {}
@@ -28924,6 +29908,10 @@ snapshots:
   solady@0.0.180: {}
 
   sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@3.8.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -29260,6 +30248,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  tabbable@6.5.0: {}
+
   tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.5.0: {}
@@ -29365,6 +30355,10 @@ snapshots:
     dependencies:
       real-require: 0.1.0
 
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+
   three-mesh-bvh@0.7.8(three@0.169.0):
     dependencies:
       three: 0.169.0
@@ -29402,6 +30396,8 @@ snapshots:
       nan: 2.26.2
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -29634,6 +30630,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ua-is-frozen@0.1.2: {}
+
+  ua-parser-js@1.0.41: {}
 
   ua-parser-js@2.0.9:
     dependencies:
@@ -29939,23 +30937,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.1
@@ -29982,6 +30963,23 @@ snapshots:
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
@@ -30481,10 +31479,15 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
-  x402-fetch@0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  x402-fetch@0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      x402: 0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      x402: 0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -30525,14 +31528,14 @@ snapshots:
       - utf-8-validate
       - ws
 
-  x402@0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  x402@0.6.6(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       wagmi: 2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)
       zod: 3.25.76
@@ -30574,6 +31577,59 @@ snapshots:
       - uploadthing
       - utf-8-validate
       - ws
+
+  x402@0.7.3(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6):
+    dependencies:
+      '@scure/base': 1.2.6
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/wallet-standard-features': 1.3.0
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      viem: 2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      wagmi: 2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.100.9)(@tanstack/react-query@5.100.9(react@19.2.5))(@types/react@18.3.28)(@vercel/functions@2.2.13)(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.48.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - react-native
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- Replace Alchemy Account Kit auth with `PrivyProvider`, `MigrationProvider`, and a compat hook layer (`@/lib/wallet/react`) so existing components keep working.
- Wire smart wallet transactions through `@alchemy/wallet-apis` v5 in non-7702 `sma-b` mode to preserve existing ModularAccountV2 addresses and gas sponsorship.
- Add migration/cleanup runbooks and Privy CSP allowances for production cutover.

## Test plan
- [ ] Set `NEXT_PUBLIC_PRIVY_APP_ID`, `NEXT_PUBLIC_PRIVY_CLIENT_ID`, and Alchemy env vars locally
- [ ] Verify Privy login (email, passkey, Google, Twitch)
- [ ] Send a sponsored transaction on Base (MeToken, swap, or tip)
- [ ] Test Alchemy→Privy migration modal for an imported test user
- [ ] Confirm `pnpm build` passes on Vercel preview


Made with [Cursor](https://cursor.com)