### PR TITLE
Fix wallet UX, market stat freshness, and static hero video

### DIFF
--- a/app/api/market/tokens/route.ts
+++ b/app/api/market/tokens/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/sdk/supabase/server';
 import { meTokenSupabaseService } from '@/lib/sdk/supabase/metokens';
 import { formatEther } from 'viem';
 import { getMeTokenProtocolInfo, getMeTokenInfoFromBlockchain, getBulkMeTokenInfo } from '@/lib/utils/metokenUtils';
+import { isActiveMarketToken } from '@/lib/metokens/syncMeTokenMarketData';
 import { serverLogger } from '@/lib/utils/logger';
 
 export interface MarketToken {
@@ -257,16 +258,12 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Identify tokens that need fresh data
-    const tokensToRefresh = allTokens.filter(t => useFreshData || t.total_supply === '0' || t.tvl === 0);
-
-    // Refresh data if needed
-    if (tokensToRefresh.length > 0) {
-      const addresses = tokensToRefresh.map(t => t.address);
+    // Always refresh TVL/price from blockchain so stats reflect recent trades
+    if (allTokens.length > 0) {
+      const addresses = allTokens.map((t) => t.address);
       const bulkData = await getBulkMeTokenInfo(addresses);
 
-      // Update tokens with fresh data and calculate prices
-      allTokens = allTokens.map(token => {
+      allTokens = allTokens.map((token) => {
         const fresh = bulkData[token.address];
 
         if (fresh) {
@@ -275,33 +272,22 @@ export async function GET(request: NextRequest) {
             tvl: fresh.tvl,
             price: fresh.price,
             total_supply: fresh.totalSupply,
-            market_cap: fresh.tvl
+            market_cap: fresh.tvl,
           };
         }
 
-        // If no fresh data found (or not successfully fetched), fall back to calculating price from existing data
         const totalSupply = BigInt(token.total_supply || 0);
         const price = totalSupply > 0n ? token.tvl / parseFloat(formatEther(totalSupply)) : 0;
 
         return {
           ...token,
-          price
+          price,
         };
-      });
-    } else {
-      // Just calculate prices for all tokens based on Supabase data
-      allTokens = allTokens.map(token => {
-        const totalSupply = BigInt(token.total_supply || 0);
-        const price = totalSupply > 0n ? token.tvl / parseFloat(formatEther(totalSupply)) : 0;
-        return { ...token, price };
       });
     }
 
-    // Filter out tokens with negligible value (Price < 0.01 AND TVL < 0.01 AND Market Cap < 0.01)
-    allTokens = allTokens.filter(token => {
-      // Keep token if ANY of these metrics is at least 0.01
-      return token.price >= 0.01 || token.tvl >= 0.01 || token.market_cap >= 0.01;
-    });
+    // Hide liquidated / zero-liquidity tokens from the market
+    allTokens = allTokens.filter((token) => isActiveMarketToken(token.tvl));
 
     // Apply search filter if provided
     if (search) {
@@ -566,12 +552,17 @@ export async function GET(request: NextRequest) {
       const totalTvl = allTokens.reduce((sum, token) => sum + token.tvl, 0);
       const totalVolume24h = allTokens.reduce((sum, token) => sum + (token.volume_24h || 0), 0);
 
-      // Top gainers and losers (by price change)
-      const sortedByChange = [...allTokens].sort(
-        (a, b) => (b.price_change_24h || 0) - (a.price_change_24h || 0)
-      );
-      const topGainers = sortedByChange.slice(0, 5);
-      const topLosers = sortedByChange.slice(-5).reverse();
+      // Top gainers: positive changes only (floor at 0%)
+      const topGainers = [...allTokens]
+        .filter((t) => (t.price_change_24h ?? 0) > 0)
+        .sort((a, b) => (b.price_change_24h ?? 0) - (a.price_change_24h ?? 0))
+        .slice(0, 5);
+
+      // Top losers: negative changes only (ceiling at 0%)
+      const topLosers = [...allTokens]
+        .filter((t) => (t.price_change_24h ?? 0) < 0)
+        .sort((a, b) => (a.price_change_24h ?? 0) - (b.price_change_24h ?? 0))
+        .slice(0, 5);
 
       stats = {
         total_tokens: total,
@@ -596,8 +587,8 @@ export async function GET(request: NextRequest) {
     // Add caching headers for Vercel Edge Cache
     // Shorter cache for search queries or fresh data requests, longer for standard queries
     const cacheDuration = search || useFreshData
-      ? "public, s-maxage=10, stale-while-revalidate=30" // Short cache for dynamic queries
-      : "public, s-maxage=60, stale-while-revalidate=300"; // Longer cache for standard queries
+      ? "no-store, no-cache, must-revalidate"
+      : "public, s-maxage=30, stale-while-revalidate=60";
 
     response.headers.set("Cache-Control", cacheDuration);
 

--- a/app/api/market/tokens/route.ts
+++ b/app/api/market/tokens/route.ts
@@ -264,7 +264,7 @@ export async function GET(request: NextRequest) {
       const bulkData = await getBulkMeTokenInfo(addresses);
 
       allTokens = allTokens.map((token) => {
-        const fresh = bulkData[token.address];
+        const fresh = bulkData ? bulkData[token.address] : undefined;
 
         if (fresh) {
           return {

--- a/app/api/metokens/[address]/transactions/route.ts
+++ b/app/api/metokens/[address]/transactions/route.ts
@@ -7,6 +7,7 @@ import { requireWalletAuthFor, WalletAuthError } from '@/lib/auth/require-wallet
 import { isValidEthAddress } from '@/lib/auth/validate-address';
 import { verifyMeTokenTransaction } from '@/lib/metokens/verifyMeTokenTransaction';
 import { TransactionVerificationError } from '@/lib/chain/verifyTransactionReceipt';
+import { syncMeTokenMarketData } from '@/lib/metokens/syncMeTokenMarketData';
 
 // GET /api/metokens/[address]/transactions - Get MeToken transactions
 export async function GET(
@@ -228,6 +229,16 @@ export async function POST(
     };
 
     const result = await meTokenSupabaseService.recordTransaction(transactionData);
+
+    // Keep TVL/supply in sync after trades so market stats and charts update
+    const tradeTypes = ['mint', 'burn', 'buy', 'sell'];
+    if (tradeTypes.includes(transaction_type)) {
+      try {
+        await syncMeTokenMarketData(address);
+      } catch (syncErr) {
+        serverLogger.warn('Post-trade market sync failed (non-critical):', syncErr);
+      }
+    }
 
     return NextResponse.json({ data: result }, { status: 201 });
   } catch (error) {

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -104,12 +104,8 @@ export default function MarketPage() {
       {/* Quick Trade Dialog */}
       <QuickTradeDialog
         open={quickTradeOpen}
-        onOpenChange={(open) => {
-          setQuickTradeOpen(open);
-          if (!open) {
-            handleTradeComplete();
-          }
-        }}
+        onOpenChange={setQuickTradeOpen}
+        onTradeComplete={handleTradeComplete}
         token={selectedToken}
       />
     </div>

--- a/components/Market/MarketStats.tsx
+++ b/components/Market/MarketStats.tsx
@@ -44,6 +44,16 @@ export function MarketStats({ stats, loading }: MarketStatsProps) {
     return `$${value.toFixed(2)}`;
   };
 
+  const formatGainerChange = (change?: number) => {
+    const value = Math.max(change ?? 0, 0);
+    return value > 0 ? `+${value.toFixed(2)}%` : '0.00%';
+  };
+
+  const formatLoserChange = (change?: number) => {
+    const value = Math.min(change ?? 0, 0);
+    return value < 0 ? `${value.toFixed(2)}%` : '0.00%';
+  };
+
   return (
     <div className="space-y-6">
       {/* Main Stats Grid */}
@@ -139,7 +149,7 @@ export function MarketStats({ stats, loading }: MarketStatsProps) {
                     </div>
                     <div className="text-right flex-shrink-0">
                       <p className="text-sm font-semibold text-green-600 dark:text-green-400">
-                        +{(token.price_change_24h || 0).toFixed(2)}%
+                        {formatGainerChange(token.price_change_24h)}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         ${token.price.toFixed(4)}
@@ -196,7 +206,7 @@ export function MarketStats({ stats, loading }: MarketStatsProps) {
                     </div>
                     <div className="text-right flex-shrink-0">
                       <p className="text-sm font-semibold text-red-600 dark:text-red-400">
-                        {(token.price_change_24h || 0).toFixed(2)}%
+                        {formatLoserChange(token.price_change_24h)}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         ${token.price.toFixed(4)}

--- a/components/Market/QuickTradeDialog.tsx
+++ b/components/Market/QuickTradeDialog.tsx
@@ -33,12 +33,14 @@ interface QuickTradeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   token: MarketToken | null;
+  onTradeComplete?: () => void;
 }
 
 export function QuickTradeDialog({
   open,
   onOpenChange,
   token,
+  onTradeComplete,
 }: QuickTradeDialogProps) {
   const [mode, setMode] = useState<'buy' | 'sell'>('buy');
   const [amount, setAmount] = useState('');
@@ -250,6 +252,7 @@ export function QuickTradeDialog({
       // Refresh balances
       await checkDaiBalance();
       await checkMeTokenBalance();
+      onTradeComplete?.();
 
       // Close dialog after a short delay
       setTimeout(() => {
@@ -325,6 +328,7 @@ export function QuickTradeDialog({
 
       await checkDaiBalance();
       await checkMeTokenBalance();
+      onTradeComplete?.();
 
       setTimeout(() => {
         onOpenChange(false);
@@ -480,9 +484,27 @@ export function QuickTradeDialog({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="amount">
-              {mode === 'buy' ? 'DAI Amount' : `${token.symbol} Amount`}
-            </Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="amount">
+                {mode === 'buy' ? 'DAI Amount' : `${token.symbol} Amount`}
+              </Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                disabled={isLoading || !isConnected}
+                onClick={() => {
+                  if (mode === 'buy') {
+                    setAmount(formatEther(daiBalance));
+                  } else {
+                    setAmount(formatEther(meTokenBalance));
+                  }
+                }}
+              >
+                MAX
+              </Button>
+            </div>
             <div className="relative">
               {mode === 'buy' && (
                 <div className="absolute left-3 top-1/2 -translate-y-1/2 z-10">

--- a/components/SendTransaction.tsx
+++ b/components/SendTransaction.tsx
@@ -41,6 +41,11 @@ import { USDC_TOKEN_ADDRESSES, USDC_TOKEN_DECIMALS } from "@/lib/contracts/USDCT
 import { DAI_TOKEN_ADDRESSES, DAI_TOKEN_DECIMALS } from "@/lib/contracts/DAIToken";
 import { logger } from '@/lib/utils/logger';
 import { appendBuilderCode } from "@/lib/utils/builder-code";
+import {
+  formatSendError,
+  getMaxEthSendAmount,
+  normalizeRecipientAddress,
+} from "@/lib/utils/sendHelpers";
 
 
 // Token configuration
@@ -142,6 +147,14 @@ export default function SendTransaction() {
       return;
     }
 
+    const normalizedRecipient = normalizeRecipientAddress(recipient);
+    if (!normalizedRecipient) {
+      const errorMsg = "Please enter a valid Ethereum recipient address (0x...)";
+      toast.error(errorMsg);
+      setError(errorMsg);
+      return;
+    }
+
     if (!amount || parseFloat(amount) <= 0) {
       const errorMsg = "Please enter a valid amount";
       toast.error(errorMsg);
@@ -172,7 +185,7 @@ export default function SendTransaction() {
 
         operation = await client!.sendUserOperation({
           uo: {
-            target: recipient as Address,
+            target: normalizedRecipient,
             data: appendBuilderCode("0x" as Hex),
             value: valueInWei,
           },
@@ -185,7 +198,7 @@ export default function SendTransaction() {
         const transferCalldata = encodeFunctionData({
           abi: parseAbi(["function transfer(address,uint256) returns (bool)"]),
           functionName: "transfer",
-          args: [recipient as Address, tokenAmount],
+          args: [normalizedRecipient, tokenAmount],
         });
 
         logger.debug('Sending ERC-20 transfer:', {
@@ -219,7 +232,7 @@ export default function SendTransaction() {
       fetchBalances();
     } catch (error) {
       logger.error("Error preparing transaction:", error);
-      const errorMsg = `Error preparing transaction: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      const errorMsg = formatSendError(error);
       toast.error(errorMsg);
       setError(errorMsg);
     } finally {
@@ -230,10 +243,8 @@ export default function SendTransaction() {
   const handleMaxAmount = () => {
     const balance = balances[selectedToken];
     if (parseFloat(balance) > 0) {
-      // For ETH, leave a small buffer for gas
       if (selectedToken === 'ETH') {
-        const bufferAmount = parseFloat(balance) - 0.001; // Leave 0.001 ETH for gas
-        setAmount(bufferAmount > 0 ? bufferAmount.toFixed(6) : '0');
+        setAmount(getMaxEthSendAmount(balance));
       } else {
         setAmount(balance);
       }

--- a/components/SendTransaction.tsx
+++ b/components/SendTransaction.tsx
@@ -44,6 +44,7 @@ import { appendBuilderCode } from "@/lib/utils/builder-code";
 import {
   formatSendError,
   getMaxEthSendAmount,
+  validateSendBalance,
   normalizeRecipientAddress,
 } from "@/lib/utils/sendHelpers";
 
@@ -162,14 +163,11 @@ export default function SendTransaction() {
       return;
     }
 
-    // Check balance
-    const availableBalance = parseFloat(balances[selectedToken]);
-    const requestedAmount = parseFloat(amount);
-    
-    if (requestedAmount > availableBalance) {
-      const errorMsg = `Insufficient balance. You have ${availableBalance} ${selectedToken}, but trying to send ${requestedAmount} ${selectedToken}`;
-      toast.error(errorMsg);
-      setError(errorMsg);
+    // Check balance (ETH reserves gas buffer)
+    const balanceError = validateSendBalance(selectedToken, amount, balances[selectedToken]);
+    if (balanceError) {
+      toast.error(balanceError);
+      setError(balanceError);
       return;
     }
 

--- a/components/UserProfile/MeTokenTrading.tsx
+++ b/components/UserProfile/MeTokenTrading.tsx
@@ -569,7 +569,19 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
 
           <TabsContent value="buy" className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="buyAmount">DAI Amount to Spend</Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="buyAmount">DAI Amount to Spend</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  disabled={isLoading || !isConnected}
+                  onClick={() => setBuyAmount(formatEther(daiBalance))}
+                >
+                  MAX
+                </Button>
+              </div>
               <Input
                 id="buyAmount"
                 type="number"
@@ -631,7 +643,19 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
 
           <TabsContent value="sell" className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="sellAmount">{meToken.symbol} Amount to Sell</Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="sellAmount">{meToken.symbol} Amount to Sell</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  disabled={isLoading || !isConnected || meToken.balance <= 0n}
+                  onClick={() => setSellAmount(formatEther(meToken.balance))}
+                >
+                  MAX
+                </Button>
+              </div>
               <Input
                 id="sellAmount"
                 type="number"

--- a/components/Videos/VideoMeTokenBuyDialog.tsx
+++ b/components/Videos/VideoMeTokenBuyDialog.tsx
@@ -614,9 +614,27 @@ export function VideoMeTokenBuyDialog({
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="amount">
-                  {mode === 'buy' ? 'DAI Amount' : `${meToken.symbol} Amount`}
-                </Label>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="amount">
+                    {mode === 'buy' ? 'DAI Amount' : `${meToken.symbol} Amount`}
+                  </Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    disabled={isLoading || !isConnected}
+                    onClick={() => {
+                      if (mode === 'buy') {
+                        setAmount(formatEther(daiBalance));
+                      } else {
+                        setAmount(formatEther(meTokenBalance));
+                      }
+                    }}
+                  >
+                    MAX
+                  </Button>
+                </div>
                 <div className="relative">
                   {mode === 'buy' && (
                     <div className="absolute left-3 top-1/2 -translate-y-1/2 z-10">

--- a/components/Videos/VideoThumbnail.tsx
+++ b/components/Videos/VideoThumbnail.tsx
@@ -199,7 +199,6 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
       vid.addEventListener('timeupdate', handleTimeUpdate);
 
       vid.muted = true;
-      setIsMuted(true);
       vid.play().catch((err) => {
         if (err instanceof Error && err.name === 'AbortError') {
           return;
@@ -225,6 +224,13 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
       };
     }
   }, [isPreviewing]);
+
+  // Keep preview video muted state in sync with toggle
+  useEffect(() => {
+    if (previewVideoRef.current) {
+      previewVideoRef.current.muted = isMuted;
+    }
+  }, [isMuted, isPreviewing]);
 
   // Intersection Observer to reset states when out of view
   const setupObserver = React.useCallback((element: HTMLDivElement | null) => {
@@ -283,6 +289,7 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
 
   const handleMouseEnter = () => {
     if (enablePreview && !showPlayer) {
+      setIsMuted(true);
       setIsPreviewing(true);
     }
   };
@@ -290,7 +297,14 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
   const handleMouseLeave = () => {
     if (enablePreview && !showPlayer) {
       setIsPreviewing(false);
+      setIsMuted(true);
     }
+  };
+
+  const handleToggleMute = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsMuted((prev) => !prev);
   };
 
   // Find MP4 source for preview
@@ -341,9 +355,14 @@ const VideoThumbnail: React.FC<VideoThumbnailProps> = ({
             muted={isMuted} // Controlled by state
             loop={false} // Managed manually for 10s loop
           />
-          <div className="absolute bottom-2 right-2 p-1 bg-black/50 rounded-full">
+          <button
+            type="button"
+            className="absolute bottom-2 right-2 z-20 rounded-full bg-black/50 p-1 transition-colors hover:bg-black/70"
+            onClick={handleToggleMute}
+            aria-label={isMuted ? 'Unmute preview' : 'Mute preview'}
+          >
             {isMuted ? <VolumeX className="w-4 h-4 text-white" /> : <Volume2 className="w-4 h-4 text-white" />}
-          </div>
+          </button>
         </div>
       ) : null}
 

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -109,6 +109,7 @@ import { appendBuilderCode } from "@/lib/utils/builder-code";
 import {
   formatSendError,
   getMaxEthSendAmount,
+  validateSendBalance,
   normalizeRecipientAddress,
 } from "@/lib/utils/sendHelpers";
 import { useToast } from "@/components/ui/use-toast";
@@ -639,15 +640,17 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
         });
       } else {
         // Send token (existing logic)
-        // Check balance
-        const availableBalance = parseFloat(tokenBalances[selectedToken]);
-        const requestedAmount = parseFloat(sendAmount);
-
-        if (requestedAmount > availableBalance) {
+        // Check balance (ETH reserves gas buffer)
+        const balanceError = validateSendBalance(
+          selectedToken,
+          sendAmount,
+          tokenBalances[selectedToken],
+        );
+        if (balanceError) {
           toast({
             variant: "destructive",
             title: "Insufficient Balance",
-            description: `You have ${availableBalance} ${selectedToken}, but trying to send ${requestedAmount} ${selectedToken}`,
+            description: balanceError,
           });
           setIsSending(false);
           return;

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -106,6 +106,11 @@ import { parseEther, type Address, type Hex, encodeFunctionData, parseAbi, parse
 import { logger } from "@/lib/utils/logger";
 import { deferAfterOverlayClose } from "@/lib/utils/radixLayerFocus";
 import { appendBuilderCode } from "@/lib/utils/builder-code";
+import {
+  formatSendError,
+  getMaxEthSendAmount,
+  normalizeRecipientAddress,
+} from "@/lib/utils/sendHelpers";
 import { useToast } from "@/components/ui/use-toast";
 import { ToastAction } from "@/components/ui/toast";
 import { USDC_TOKEN_ADDRESSES, USDC_TOKEN_DECIMALS } from "@/lib/contracts/USDCToken";
@@ -566,6 +571,16 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
   const handleSend = async () => {
     if (!client || !recipientAddress) return;
 
+    const normalizedRecipient = normalizeRecipientAddress(recipientAddress);
+    if (!normalizedRecipient) {
+      toast({
+        variant: "destructive",
+        title: "Invalid Address",
+        description: "Please enter a valid Ethereum recipient address (0x...).",
+      });
+      return;
+    }
+
     // Validate based on send type
     if (sendType === 'token' && !sendAmount) {
       toast({
@@ -604,7 +619,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
           functionName: "safeTransferFrom",
           args: [
             smartAccountAddress as Address,
-            recipientAddress as Address,
+            normalizedRecipient,
             BigInt(selectedNFT.tokenId),
           ],
         });
@@ -651,7 +666,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
 
           operation = await client!.sendUserOperation({
             uo: {
-              target: recipientAddress as `0x${string}`,
+              target: normalizedRecipient,
               data: appendBuilderCode("0x" as Hex),
               value: valueInWei,
             },
@@ -675,7 +690,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
           const transferCalldata = encodeFunctionData({
             abi: parseAbi(["function transfer(address,uint256) returns (bool)"]),
             functionName: "transfer",
-            args: [recipientAddress as Address, tokenAmount],
+            args: [normalizedRecipient, tokenAmount],
           });
 
           logger.debug('Sending ERC-20 transfer:', {
@@ -734,10 +749,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
       toast({
         variant: "destructive",
         title: "Transaction Failed",
-        description:
-          error instanceof Error
-            ? error.message
-            : "Failed to initiate transaction.",
+        description: formatSendError(error),
       });
     } finally {
       // Ensure sending state is always reset, even if an error occurs
@@ -798,6 +810,45 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
       throw error;
     }
   };
+
+  const renderSendDialogFooter = () => (
+    <div className="flex flex-col sm:flex-row gap-3 border-t pt-3 mt-1 shrink-0">
+      <Button
+        variant="outline"
+        className="w-full sm:w-auto sm:order-2 min-h-[44px] touch-manipulation"
+        onClick={() => {
+          setIsDialogOpen(false);
+          setSelectedNFT(null);
+          setSendType('token');
+        }}
+      >
+        Cancel
+      </Button>
+      <Button
+        className="w-full sm:flex-1 sm:order-1 min-h-[44px] touch-manipulation"
+        onClick={handleSend}
+        disabled={
+          isSending ||
+          !recipientAddress ||
+          (sendType === 'token' && !sendAmount) ||
+          (sendType === 'nft' && !selectedNFT)
+        }
+      >
+        {isSending ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            <span className="hidden sm:inline">{sendType === 'nft' ? 'Sending NFT...' : `Sending ${selectedToken}...`}</span>
+            <span className="sm:hidden">Sending...</span>
+          </>
+        ) : (
+          <>
+            <Send className="mr-2 h-4 w-4" />
+            {sendType === 'nft' ? 'Send NFT' : `Send ${selectedToken}`}
+          </>
+        )}
+      </Button>
+    </div>
+  );
 
   const getDialogContent = () => {
     switch (dialogAction) {
@@ -910,7 +961,13 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                       </div>
                       <button
                         type="button"
-                        onClick={() => setSendAmount(tokenBalances[selectedToken])}
+                        onClick={() => {
+                          if (selectedToken === 'ETH') {
+                            setSendAmount(getMaxEthSendAmount(tokenBalances.ETH));
+                          } else {
+                            setSendAmount(tokenBalances[selectedToken]);
+                          }
+                        }}
                         className="text-blue-600 hover:text-blue-700 dark:text-blue-400 font-medium px-3 py-1.5 rounded text-xs min-h-[32px] touch-manipulation"
                       >
                         MAX
@@ -997,7 +1054,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               )}
 
               {/* Recipient Address */}
-              <div className="space-y-3">
+              <div className="space-y-3 pb-2">
                 <label className="text-sm font-medium text-gray-900 dark:text-gray-100">Recipient Address</label>
                 <input
                   type="text"
@@ -1007,44 +1064,6 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                   value={recipientAddress}
                   onChange={(e) => setRecipientAddress(e.target.value)}
                 />
-              </div>
-
-              {/* Action Buttons */}
-              <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                <Button
-                  variant="outline"
-                  className="w-full sm:w-auto sm:order-2 min-h-[44px] touch-manipulation"
-                  onClick={() => {
-                    setIsDialogOpen(false);
-                    setSelectedNFT(null);
-                    setSendType('token');
-                  }}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  className="w-full sm:flex-1 sm:order-1 min-h-[44px] touch-manipulation"
-                  onClick={handleSend}
-                  disabled={
-                    isSending ||
-                    !recipientAddress ||
-                    (sendType === 'token' && !sendAmount) ||
-                    (sendType === 'nft' && !selectedNFT)
-                  }
-                >
-                  {isSending ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      <span className="hidden sm:inline">{sendType === 'nft' ? 'Sending NFT...' : `Sending ${selectedToken}...`}</span>
-                      <span className="sm:hidden">Sending...</span>
-                    </>
-                  ) : (
-                    <>
-                      <Send className="mr-2 h-4 w-4" />
-                      {sendType === 'nft' ? 'Send NFT' : `Send ${selectedToken}`}
-                    </>
-                  )}
-                </Button>
               </div>
             </div>
           </div>
@@ -1699,8 +1718,8 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
           }
         }}
       >
-        <DialogContent className="w-[95vw] max-w-[425px] max-h-[95vh] sm:max-h-[90vh] overflow-hidden p-4 sm:p-6 rounded-lg">
-          <DialogHeader className="pb-4 pr-8 sm:pr-12">
+        <DialogContent className="flex w-[95vw] max-w-[425px] max-h-[min(85dvh,640px)] flex-col overflow-hidden p-4 sm:p-6 rounded-lg">
+          <DialogHeader className="shrink-0 pb-4 pr-8 sm:pr-12">
             <DialogTitle className="text-lg sm:text-xl">
               {dialogAction.charAt(0).toUpperCase() + dialogAction.slice(1)}
             </DialogTitle>
@@ -1721,10 +1740,11 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
               </button>
             </DialogClose>
           </DialogHeader>
-          <div className="flex flex-col overflow-hidden">
-            <div className="space-y-4 overflow-y-auto flex-1 pr-1 sm:pr-2">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] pr-1 sm:pr-2">
               {getDialogContent()}
             </div>
+            {dialogAction === "send" && renderSendDialogFooter()}
           </div>
         </DialogContent>
       </Dialog>

--- a/components/home-page/TopVideos.tsx
+++ b/components/home-page/TopVideos.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { TrendingUpIcon } from "lucide-react";
 import VideoThumbnail from "@/components/Videos/VideoThumbnail";
-import { HERO_VIDEO_ASSET_ID } from "@/context/context";
+import { HERO_VIDEO_ASSET_ID, LIVEPEER_HERO_PLAYBACK_ID } from "@/context/context";
 import { logger } from "@/lib/utils/logger";
 import { mapInBatches } from "@/lib/utils/map-in-batches";
 
@@ -65,8 +65,10 @@ export function TopVideos() {
 
         // Filter out the hero video from the trending list
         const filteredVideos = trendingVideos.filter(
-          (video) => video.asset_id !== HERO_VIDEO_ASSET_ID
-        ).slice(0, 10); // Take top 10 after filtering
+          (video) =>
+            video.asset_id !== HERO_VIDEO_ASSET_ID &&
+            video.playback_id !== LIVEPEER_HERO_PLAYBACK_ID,
+        ).slice(0, 10);
 
         if (filteredVideos.length === 0) {
           logger.warn("No trending videos found after filtering hero video");

--- a/components/wallet/swap/AlchemySwapWidget.tsx
+++ b/components/wallet/swap/AlchemySwapWidget.tsx
@@ -254,7 +254,11 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
       )) as {
         quote?: { minimumToAmount: string; feePayment?: { sponsored?: boolean } };
         rawCalls?: unknown;
-      };
+      } | null | undefined;
+
+      if (!result) {
+        throw new Error('Failed to prepare swap: No response received');
+      }
 
       if (result.rawCalls) {
         throw new Error('Expected user operation calls, got raw calls');
@@ -458,7 +462,11 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
         quote?: unknown;
         rawCalls?: unknown;
         [key: string]: unknown;
-      };
+      } | null | undefined;
+
+      if (!result) {
+        throw new Error('Failed to prepare swap: No response received');
+      }
 
       if (result.rawCalls) {
         throw new Error('Expected user operation calls, got raw calls');

--- a/components/wallet/swap/AlchemySwapWidget.tsx
+++ b/components/wallet/swap/AlchemySwapWidget.tsx
@@ -8,14 +8,41 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Loader2, ArrowRightLeft, CheckCircle, XCircle, ExternalLink, DollarSign } from 'lucide-react';
 import Image from 'next/image';
-import { useSmartAccountClient, useChain } from '@/lib/wallet/react';
+import { useSmartAccountClient, useChain, usePrepareSwap, useSignAndSendPreparedCalls } from '@/lib/wallet/react';
 import { type Hex, type Address, parseEther, formatEther, encodeFunctionData, erc20Abi, parseUnits, maxUint256 } from 'viem';
-import { alchemySwapService, AlchemySwapService, type TokenSymbol, BASE_TOKENS, TOKEN_INFO, SWAP_UI_TOKENS, emptyTokenBalances, emptyTokenPrices } from '@/lib/sdk/alchemy/swap-service';
+import { AlchemySwapService, type TokenSymbol, BASE_TOKENS, TOKEN_INFO, SWAP_UI_TOKENS, emptyTokenBalances, emptyTokenPrices } from '@/lib/sdk/alchemy/swap-service';
 import { priceService, PriceService } from '@/lib/sdk/alchemy/price-service';
 import { CurrencyConverter } from '@/lib/utils/currency-converter';
 import { logger } from '@/lib/utils/logger';
 import { getTokenIcon } from '@/lib/utils/token-icons';
-import { swapActions } from "@alchemy/wallet-apis/experimental";
+
+function formatSwapError(error: unknown): string {
+  const errorStr = error instanceof Error ? error.message : String(error);
+  const lower = errorStr.toLowerCase();
+
+  if (
+    lower.includes('typed signature') ||
+    lower.includes('signpreparedcalls') ||
+    lower.includes('secp256k1') ||
+    lower.includes('eoa signature') ||
+    lower.includes('not a function')
+  ) {
+    return 'Swap could not be signed. Please try again or contact support if this persists.';
+  }
+  if (errorStr.includes('AA23')) {
+    return 'Transaction validation failed (AA23). Check balances and gas.';
+  }
+  if (errorStr.includes('Multicall3')) {
+    return 'Swap failed (Multicall3). Ensure you have sufficient token balance and your account is deployed.';
+  }
+  if (errorStr.includes('User rejected')) {
+    return 'User rejected the request.';
+  }
+  if (errorStr.includes('raw calls')) {
+    return 'Swap route is unavailable for smart accounts. Try a different token pair.';
+  }
+  return errorStr || 'Swap execution failed';
+}
 
 const ERC20_BALANCE_ABI = [{
   name: 'balanceOf',
@@ -48,6 +75,31 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
 
   const { address, client } = useSmartAccountClient({});
   const { chain } = useChain();
+  const { prepareSwapAsync, isPreparingSwap } = usePrepareSwap({ client });
+  const { signAndSendPreparedCallsAsync, isSigningAndSendingPreparedCalls } =
+    useSignAndSendPreparedCalls({ client });
+
+  const buildSwapParams = (amount: string, fromToken: TokenSymbol, toToken: TokenSymbol) => {
+    const paymasterPolicyId = process.env.NEXT_PUBLIC_ALCHEMY_PAYMASTER_POLICY_ID?.replace(
+      /^["']|["']$/g,
+      '',
+    );
+
+    return {
+      from: address as Address,
+      fromToken: BASE_TOKENS[fromToken],
+      toToken: BASE_TOKENS[toToken],
+      fromAmount: AlchemySwapService.formatAmount(amount, fromToken),
+      slippage: '0x32',
+      ...(paymasterPolicyId
+        ? {
+            capabilities: {
+              paymasterService: { policyId: paymasterPolicyId },
+            },
+          }
+        : {}),
+    };
+  };
 
   const [swapState, setSwapState] = useState<SwapState>({
     fromToken: 'ETH',
@@ -182,7 +234,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
   }, [address, client]);
 
   const fetchQuote = async (amount: string, fromToken: TokenSymbol, toToken: TokenSymbol) => {
-    if (!amount || parseFloat(amount) <= 0 || !address) {
+    if (!amount || parseFloat(amount) <= 0 || !address || !client) {
       setSwapState(prev => ({ ...prev, fromAmount: amount, quote: null, error: null }));
       return;
     }
@@ -190,34 +242,35 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
     try {
       setSwapState(prev => ({ ...prev, isLoading: true, error: null }));
 
-      const fromAmountHex = AlchemySwapService.formatAmount(amount, fromToken);
-
       logger.debug('Requesting swap quote:', {
         from: address,
         fromToken,
         toToken,
         fromAmount: amount,
-        fromAmountHex,
       });
 
-      const quoteResponse = await alchemySwapService.requestSwapQuote({
-        from: address as Address,
-        fromToken,
-        toToken,
-        fromAmount: fromAmountHex,
-      });
+      const result = (await prepareSwapAsync(
+        buildSwapParams(amount, fromToken, toToken),
+      )) as {
+        quote?: { minimumToAmount: string; feePayment?: { sponsored?: boolean } };
+        rawCalls?: unknown;
+      };
 
-      if (quoteResponse.result?.quote) {
+      if (result.rawCalls) {
+        throw new Error('Expected user operation calls, got raw calls');
+      }
+
+      if (result.quote?.minimumToAmount) {
         const toAmount = AlchemySwapService.parseAmount(
-          quoteResponse.result.quote.minimumToAmount,
-          toToken
+          result.quote.minimumToAmount,
+          toToken,
         );
 
         setSwapState(prev => ({
           ...prev,
           fromAmount: amount,
           toAmount,
-          quote: quoteResponse.result,
+          quote: result.quote,
           isLoading: false,
         }));
       } else {
@@ -229,7 +282,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
         ...prev,
         isLoading: false,
         quote: null,
-        error: error instanceof Error ? error.message : 'Failed to get quote',
+        error: formatSwapError(error),
       }));
     }
   };
@@ -392,100 +445,75 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
 
 
   const handleExecuteSwap = async () => {
-    if (!address || !client) return;
+    if (!address || !client || !swapState.fromAmount) return;
 
     try {
       setSwapState(prev => ({ ...prev, isSwapping: true, error: null }));
 
-
-      // Extend the client with swap actions
-      const swapClient = (client as any).extend(swapActions);
-
       logger.debug('Requesting fresh quote for execution...');
 
-      const fromAmountHex = AlchemySwapService.formatAmount(swapState.fromAmount, swapState.fromToken);
+      const result = (await prepareSwapAsync(
+        buildSwapParams(swapState.fromAmount, swapState.fromToken, swapState.toToken),
+      )) as {
+        quote?: unknown;
+        rawCalls?: unknown;
+        [key: string]: unknown;
+      };
 
-      // Request a fresh quote using the SDK
-      // This ensures we have the correct object structure for sign/send
-      const { quote, ...calls } = await swapClient.requestQuoteV0({
-        from: address,
-        fromToken: BASE_TOKENS[swapState.fromToken],
-        toToken: BASE_TOKENS[swapState.toToken],
-        fromAmount: fromAmountHex,
-        slippage: "0x32", // 0.5% (50 bps)
-      });
-
-      logger.debug('Quote received:', quote);
-
-      // Verify calls are not raw (we expect UserOperations)
-      if (calls.rawCalls) {
-        throw new Error("Expected user operation calls, got raw calls");
+      if (result.rawCalls) {
+        throw new Error('Expected user operation calls, got raw calls');
       }
 
-      // Sign the prepared calls
-      logger.debug('Signing prepared calls...');
-      const signedCalls = await swapClient.signPreparedCalls(calls);
+      const { quote: _quote, rawCalls: _rawCalls, ...calls } = result;
 
-      // Send the prepared calls
-      logger.debug('Sending prepared calls...');
-      const { preparedCallIds } = await swapClient.sendPreparedCalls(signedCalls);
+      logger.debug('Signing and sending prepared calls...');
+      const { preparedCallIds } = await signAndSendPreparedCallsAsync(calls);
 
       if (!preparedCallIds || preparedCallIds.length === 0) {
-        throw new Error("No prepared call IDs returned");
+        throw new Error('No prepared call IDs returned');
       }
 
       const callId = preparedCallIds[0];
       logger.debug('Swap initiated, Call ID:', callId);
 
-      // Wait for the call to resolve
-      logger.debug('Waiting for call status...');
-      const callStatusResult = await swapClient.waitForCallsStatus({
-        id: callId,
-      });
+      const callStatusResult = await client.waitForCallsStatus({ id: callId });
 
-      // Filter through success or failure cases
-      if (callStatusResult.status === "success" && callStatusResult.receipts && callStatusResult.receipts[0]) {
+      if (
+        callStatusResult.status === 'success' &&
+        callStatusResult.receipts &&
+        callStatusResult.receipts[0]
+      ) {
         const txHash = callStatusResult.receipts[0].transactionHash;
         logger.debug('Swap confirmed! TxHash:', txHash);
 
         setSwapState(prev => ({
           ...prev,
-          transactionHash: txHash,
+          transactionHash: txHash ?? null,
           isSwapping: false,
         }));
 
         onSwapSuccess?.();
       } else {
         logger.error('Swap failed status:', callStatusResult);
-        throw new Error(
-          `Transaction failed with status ${callStatusResult.status}`
-        );
+        throw new Error(`Transaction failed with status ${callStatusResult.status}`);
       }
-
     } catch (error) {
       logger.error('Swap failed:', error);
       setIsApprovingToken(false);
 
-      let userMessage = 'Swap execution failed';
-      const errorStr = error instanceof Error ? error.message : String(error);
-
-      if (errorStr.includes('AA23')) {
-        userMessage = 'Transaction validation failed (AA23). Check balances and gas.';
-      } else if (errorStr.includes('Multicall3')) {
-        userMessage = 'Swap failed (Multicall3). This often means the Swap Validation failed. Ensure you have USDC/ETH and the account is properly deployed.';
-      } else if (errorStr.includes('User rejected')) {
-        userMessage = 'User rejected the request.';
-      } else {
-        userMessage = errorStr;
-      }
-
       setSwapState(prev => ({
         ...prev,
-        error: userMessage,
+        error: formatSwapError(error),
         isSwapping: false,
       }));
     }
   };
+
+  const isSwapBusy =
+    swapState.isLoading ||
+    swapState.isSwapping ||
+    isPreparingSwap ||
+    isSigningAndSendingPreparedCalls;
 
   const canExecuteSwap =
     swapState.fromAmount &&
@@ -493,6 +521,8 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
     swapState.quote &&
     !swapState.isLoading &&
     !swapState.isSwapping &&
+    !isPreparingSwap &&
+    !isSigningAndSendingPreparedCalls &&
     swapState.fromToken !== swapState.toToken;
 
   // Show loading state while wallet is connecting
@@ -585,7 +615,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
                 size="sm"
                 onClick={handleMaxAmount}
                 className="h-6 px-2 text-xs"
-                disabled={swapState.isLoading || swapState.isSwapping || !address}
+                disabled={isSwapBusy || !address}
               >
                 MAX
               </Button>
@@ -595,7 +625,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
                 size="sm"
                 onClick={handleInputModeToggle}
                 className="h-6 px-2 text-xs"
-                disabled={swapState.isLoading || swapState.isSwapping}
+                disabled={isSwapBusy}
               >
                 <DollarSign className={`h-3 w-3 mr-1 ${inputMode === 'usd' ? 'text-green-600' : ''}`} />
                 {inputMode === 'usd' ? 'USD' : swapState.fromToken}
@@ -644,7 +674,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
                     : handleFromAmountChange(e.target.value)
                 }
                 className={inputMode === 'usd' ? 'pl-6 pr-20 h-10' : 'pr-20 h-10'}
-                disabled={swapState.isLoading || swapState.isSwapping}
+                disabled={isSwapBusy}
               />
               {inputMode === 'usd' && (
                 <div className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
@@ -690,7 +720,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
                     variant="outline"
                     size="sm"
                     onClick={() => handlePresetAmount(amount)}
-                    disabled={swapState.isLoading || swapState.isSwapping || !address}
+                    disabled={isSwapBusy || !address}
                     className="flex-1 h-8 text-xs"
                   >
                     ${amount}
@@ -716,7 +746,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
             variant="outline"
             size="sm"
             onClick={handleSwapTokens}
-            disabled={swapState.isLoading || swapState.isSwapping}
+            disabled={isSwapBusy}
           >
             <ArrowRightLeft className="h-4 w-4" />
           </Button>
@@ -827,7 +857,7 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               Approving {swapState.fromToken}...
             </>
-          ) : swapState.isSwapping ? (
+          ) : isSwapBusy ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               Executing Swap...

--- a/context/context.ts
+++ b/context/context.ts
@@ -73,9 +73,12 @@ export const LIVEPEER_FEATURED_PLAYBACK_ID = "5c2bzf537qbq0r7o";
  * Livepeer integration constants
  * These IDs connect to specific assets hosted on Livepeer's platform
  * CAUTION: Changing these values will affect what media is displayed to users
+ *
+ * Hero video uses LIVEPEER_HERO_PLAYBACK_ID directly (not the app video library)
+ * so the homepage hero keeps working even if the asset is removed from Supabase.
  */
-export const LIVEPEER_HERO_PLAYBACK_ID = "cb8ekf9y8kaatrpu"; // Default playback ID for hero section video (fallback)
-export const HERO_VIDEO_ASSET_ID = "cb8eabe3-ed26-4a9a-91a5-949712f85030"; // Asset ID for hero section video
+export const LIVEPEER_HERO_PLAYBACK_ID = "15ebvaxzii695zae"; // Creative intro — static hero playback ID
+export const HERO_VIDEO_ASSET_ID = "15eb360c-698f-48f2-aabe-d46cd5f8d181"; // Livepeer asset ID (discover/trending exclusion)
 
 // URLS
 export const API_BASE_URL = "https://api.poap.tech";

--- a/lib/hooks/livepeer/useHeroPlaybackSource.ts
+++ b/lib/hooks/livepeer/useHeroPlaybackSource.ts
@@ -1,44 +1,29 @@
 import { getSrc } from "@livepeer/react/external";
 import { Src } from "@livepeer/react";
-import { LIVEPEER_HERO_PLAYBACK_ID, HERO_VIDEO_ASSET_ID } from "../../../context/context";
+import { LIVEPEER_HERO_PLAYBACK_ID } from "../../../context/context";
 import { logger } from '@/lib/utils/logger';
-
 
 export type HeroPlaybackSource = {
   src: Src[];
   playbackId: string;
 };
 
+/**
+ * Resolves playback sources for the homepage hero intro video.
+ * Uses the static LIVEPEER_HERO_PLAYBACK_ID from context — not the app video library —
+ * so the hero keeps working if the asset is removed from Supabase.
+ */
 export const getHeroPlaybackSource = async (): Promise<HeroPlaybackSource | null> => {
   try {
-    // First, try to fetch the asset by asset ID via our API route (server-side, avoids CORS)
-    let playbackId: string | null = null;
+    const playbackId = LIVEPEER_HERO_PLAYBACK_ID;
 
-    if (HERO_VIDEO_ASSET_ID) {
-      try {
-        const response = await fetch(`/api/livepeer/asset/${HERO_VIDEO_ASSET_ID}`);
-        if (response.ok) {
-          const assetResponse = await response.json();
-          if (assetResponse?.asset?.playbackId) {
-            playbackId = assetResponse.asset.playbackId;
-          }
-        } else {
-          logger.warn(`Failed to fetch hero video asset: ${response.status} ${response.statusText}`);
-        }
-      } catch (error) {
-        logger.warn("Error fetching hero video asset by ID, falling back to default playback ID:", error);
-      }
-    }
-
-    // Fallback to default playback ID if asset fetch failed
-    if (!playbackId) {
-      playbackId = LIVEPEER_HERO_PLAYBACK_ID;
-    }
-
-    // Fetch playback info via our API route (server-side, avoids CORS)
-    const playbackResponse = await fetch(`/api/livepeer/playback-info?playbackId=${playbackId}`);
+    const playbackResponse = await fetch(
+      `/api/livepeer/playback-info?playbackId=${encodeURIComponent(playbackId)}`,
+    );
     if (!playbackResponse.ok) {
-      throw new Error(`Failed to fetch playback info: ${playbackResponse.status} ${playbackResponse.statusText}`);
+      throw new Error(
+        `Failed to fetch playback info: ${playbackResponse.status} ${playbackResponse.statusText}`,
+      );
     }
 
     const playbackInfo = await playbackResponse.json();
@@ -48,7 +33,7 @@ export const getHeroPlaybackSource = async (): Promise<HeroPlaybackSource | null
     }
     return { src, playbackId };
   } catch (error) {
-    logger.error("Error fetching playback source:", error);
+    logger.error("Error fetching hero playback source:", error);
     return null;
   }
 };

--- a/lib/hooks/market/useMarketData.ts
+++ b/lib/hooks/market/useMarketData.ts
@@ -66,7 +66,7 @@ export function useMarketData(options: UseMarketDataOptions = {}): UseMarketData
   });
   const [currentPage, setCurrentPage] = useState(0);
 
-  const fetchMarketData = useCallback(async (isBackground = false) => {
+  const fetchMarketData = useCallback(async (isBackground = false, useFresh = false) => {
     if (!isBackground) {
       setLoading(true);
       setError(null);
@@ -83,7 +83,14 @@ export function useMarketData(options: UseMarketDataOptions = {}): UseMarketData
         includeStats: 'true',
       });
 
-      const response = await fetch(`/api/market/tokens?${params.toString()}`);
+      if (useFresh) {
+        params.set('fresh', 'true');
+        params.set('_t', Date.now().toString());
+      }
+
+      const response = await fetch(`/api/market/tokens?${params.toString()}`, {
+        cache: useFresh ? 'no-store' : 'default',
+      });
 
       if (!response.ok) {
         throw new Error(`Failed to fetch market data: ${response.statusText}`);
@@ -180,7 +187,7 @@ export function useMarketData(options: UseMarketDataOptions = {}): UseMarketData
   }, []);
 
   const refresh = useCallback(async () => {
-    await fetchMarketData();
+    await fetchMarketData(false, true);
   }, [fetchMarketData]);
 
   // Debounce ref for global refresh
@@ -214,9 +221,8 @@ export function useMarketData(options: UseMarketDataOptions = {}): UseMarketData
 
       globalRefreshTimeoutRef.current = setTimeout(() => {
         logger.debug('⚡ Triggering global market data refresh from real-time event');
-        // Pass true to indicate this is a background refresh (no loading spinner)
-        fetchMarketData(true);
-      }, 5000); // 5 second debounce
+        fetchMarketData(true, true);
+      }, 2000);
 
     } catch (error) {
       logger.error('Failed to fetch fresh token data:', error);

--- a/lib/metokens/syncMeTokenMarketData.ts
+++ b/lib/metokens/syncMeTokenMarketData.ts
@@ -1,0 +1,82 @@
+import { createPublicClient, http, formatEther, parseAbi } from 'viem';
+import { baseMainnet } from '@/lib/utils/chains/base';
+import { getMeTokenProtocolInfo } from '@/lib/utils/metokenUtils';
+import { createServiceClient } from '@/lib/sdk/supabase/service';
+import { serverLogger } from '@/lib/utils/logger';
+
+const ERC20_ABI = parseAbi(['function totalSupply() view returns (uint256)']);
+
+export const MIN_ACTIVE_MARKET_TVL = 0.1;
+
+export interface SyncedMeTokenMarketData {
+  tvl: number;
+  total_supply: string;
+  price: number;
+}
+
+/**
+ * Fetch live TVL/supply from chain and persist to Supabase.
+ * Called after trades so market stats and charts reflect on-chain state.
+ */
+export async function syncMeTokenMarketData(
+  address: string
+): Promise<SyncedMeTokenMarketData | null> {
+  const meTokenAddress = address.toLowerCase() as `0x${string}`;
+
+  try {
+    const publicClient = createPublicClient({
+      chain: baseMainnet,
+      transport: http(
+        process.env.NEXT_PUBLIC_ALCHEMY_RPC_URL || process.env.NEXT_PUBLIC_BASE_RPC_URL
+      ),
+    });
+
+    const [protocolInfo, totalSupply] = await Promise.all([
+      getMeTokenProtocolInfo(meTokenAddress),
+      publicClient.readContract({
+        address: meTokenAddress,
+        abi: ERC20_ABI,
+        functionName: 'totalSupply',
+      }) as Promise<bigint>,
+    ]);
+
+    if (!protocolInfo) {
+      serverLogger.warn(`syncMeTokenMarketData: no protocol info for ${meTokenAddress}`);
+      return null;
+    }
+
+    const balancePooled = BigInt(protocolInfo.balancePooled || 0);
+    const balanceLocked = BigInt(protocolInfo.balanceLocked || 0);
+    const tvl = parseFloat(formatEther(balancePooled + balanceLocked));
+    const supply = parseFloat(formatEther(totalSupply));
+    const price = supply > 0 ? tvl / supply : 0;
+
+    const supabase = createServiceClient();
+    const { error } = await supabase
+      .from('metokens')
+      .update({
+        tvl,
+        total_supply: totalSupply.toString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('address', meTokenAddress);
+
+    if (error) {
+      serverLogger.error(`syncMeTokenMarketData: failed to update ${meTokenAddress}:`, error);
+      return null;
+    }
+
+    return {
+      tvl,
+      total_supply: totalSupply.toString(),
+      price,
+    };
+  } catch (error) {
+    serverLogger.error(`syncMeTokenMarketData: error for ${meTokenAddress}:`, error);
+    return null;
+  }
+}
+
+export function isActiveMarketToken(tvl: number): boolean {
+  return tvl >= MIN_ACTIVE_MARKET_TVL;
+}

--- a/lib/utils/metokenUtils.ts
+++ b/lib/utils/metokenUtils.ts
@@ -365,93 +365,112 @@ export async function getMeTokenProtocolInfo(meTokenAddress: string): Promise<{
 }
 
 /**
- * Get MeToken information for multiple tokens in a single RPC call (multicall)
- * This significantly reduces RPC usage compared to calling getMeTokenInfoFromBlockchain individually
+ * Get MeToken information for multiple tokens in batched RPC multicalls.
+ * Large address lists are chunked to avoid RPC timeouts and rate limits.
  * @param meTokenAddresses - Array of MeToken contract addresses
  * @returns Map of address -> combined token info
  */
-export async function getBulkMeTokenInfo(meTokenAddresses: string[]): Promise<Record<string, {
+const BULK_METOKEN_BATCH_SIZE = 20;
+
+type BulkMeTokenInfo = Record<string, {
   totalSupply: string;
   owner: string;
   tvl: number;
   price: number;
-} | null>> {
+} | null>;
+
+async function fetchBulkMeTokenInfoBatch(meTokenAddresses: string[]): Promise<BulkMeTokenInfo> {
   if (meTokenAddresses.length === 0) return {};
 
-  try {
-    logger.debug(`📦 Bulk fetching info for ${meTokenAddresses.length} MeTokens...`);
+  const ERC20_ABI = parseAbi([
+    'function totalSupply() view returns (uint256)',
+  ]);
 
-    // ERC20 ABI for basic token info
-    const ERC20_ABI = parseAbi([
-      'function totalSupply() view returns (uint256)'
-    ]);
+  const DIAMOND_ADDRESS = METOKEN_DIAMOND_BASE;
+  const DIAMOND_ABI = parseAbi([
+    'struct MeTokenInfo { address owner; uint256 hubId; uint256 balancePooled; uint256 balanceLocked; uint256 startTime; uint256 endTime; uint256 targetHubId; address migration; }',
+    'function getMeTokenInfo(address meToken) view returns (MeTokenInfo)',
+  ]);
 
-    // Diamond ABI
-    const DIAMOND_ADDRESS = METOKEN_DIAMOND_BASE;
-    const DIAMOND_ABI = parseAbi([
-      'struct MeTokenInfo { address owner; uint256 hubId; uint256 balancePooled; uint256 balanceLocked; uint256 startTime; uint256 endTime; uint256 targetHubId; address migration; }',
-      'function getMeTokenInfo(address meToken) view returns (MeTokenInfo)'
-    ]);
+  const calls = [];
 
-    // Construct all calls into a single array
-    const calls = [];
-
-    // Add totalSupply calls
-    for (const address of meTokenAddresses) {
-      calls.push({
-        address: address as `0x${string}`,
-        abi: ERC20_ABI,
-        functionName: 'totalSupply'
-      });
-    }
-
-    // Add Diamond info calls
-    for (const address of meTokenAddresses) {
-      calls.push({
-        address: DIAMOND_ADDRESS as `0x${string}`,
-        abi: DIAMOND_ABI,
-        functionName: 'getMeTokenInfo',
-        args: [address as `0x${string}`]
-      });
-    }
-
-    // Execute single multicall
-    const results = await publicClient.multicall({ contracts: calls });
-
-    const parsedResults: Record<string, any> = {};
-    const count = meTokenAddresses.length;
-
-    // Process results
-    for (let i = 0; i < count; i++) {
-      const address = meTokenAddresses[i];
-      // results[i] is totalSupply, results[i + count] is diamond info
-      const supplyResult = results[i] as { status: string, result: any };
-      const diamondResult = results[i + count] as { status: string, result: any };
-
-      if (supplyResult.status === 'success' && diamondResult.status === 'success') {
-        const totalSupply = supplyResult.result as bigint;
-        const info = diamondResult.result as any;
-
-        const balancePooled = BigInt(info.balancePooled || 0);
-        const balanceLocked = BigInt(info.balanceLocked || 0);
-        const totalBalance = balancePooled + balanceLocked;
-
-        const tvl = parseFloat(formatEther(totalBalance));
-        const supplyLog = parseFloat(formatEther(totalSupply));
-        const price = supplyLog > 0 ? tvl / supplyLog : 0;
-
-        parsedResults[address] = {
-          totalSupply: totalSupply.toString(),
-          owner: info.owner,
-          tvl,
-          price
-        };
-      }
-    }
-
-    return parsedResults;
-  } catch (err) {
-    logger.error('❌ Failed to bulk fetch MeToken info:', err);
-    return {};
+  for (const address of meTokenAddresses) {
+    calls.push({
+      address: address as `0x${string}`,
+      abi: ERC20_ABI,
+      functionName: 'totalSupply',
+    });
   }
+
+  for (const address of meTokenAddresses) {
+    calls.push({
+      address: DIAMOND_ADDRESS as `0x${string}`,
+      abi: DIAMOND_ABI,
+      functionName: 'getMeTokenInfo',
+      args: [address as `0x${string}`],
+    });
+  }
+
+  const results = await publicClient.multicall({ contracts: calls });
+
+  const parsedResults: BulkMeTokenInfo = {};
+  const count = meTokenAddresses.length;
+
+  for (let i = 0; i < count; i++) {
+    const address = meTokenAddresses[i];
+    const supplyResult = results[i] as { status: string; result: unknown };
+    const diamondResult = results[i + count] as { status: string; result: unknown };
+
+    if (supplyResult.status === 'success' && diamondResult.status === 'success') {
+      const totalSupply = supplyResult.result as bigint;
+      const info = diamondResult.result as {
+        owner: string;
+        balancePooled?: bigint;
+        balanceLocked?: bigint;
+      };
+
+      const balancePooled = BigInt(info.balancePooled || 0);
+      const balanceLocked = BigInt(info.balanceLocked || 0);
+      const totalBalance = balancePooled + balanceLocked;
+
+      const tvl = parseFloat(formatEther(totalBalance));
+      const supplyLog = parseFloat(formatEther(totalSupply));
+      const price = supplyLog > 0 ? tvl / supplyLog : 0;
+
+      parsedResults[address] = {
+        totalSupply: totalSupply.toString(),
+        owner: info.owner,
+        tvl,
+        price,
+      };
+    }
+  }
+
+  return parsedResults;
+}
+
+export async function getBulkMeTokenInfo(meTokenAddresses: string[]): Promise<BulkMeTokenInfo> {
+  if (meTokenAddresses.length === 0) return {};
+
+  logger.debug(`📦 Bulk fetching info for ${meTokenAddresses.length} MeTokens...`);
+
+  const merged: BulkMeTokenInfo = {};
+
+  for (let i = 0; i < meTokenAddresses.length; i += BULK_METOKEN_BATCH_SIZE) {
+    const batch = meTokenAddresses.slice(i, i + BULK_METOKEN_BATCH_SIZE);
+    const batchNumber = Math.floor(i / BULK_METOKEN_BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(meTokenAddresses.length / BULK_METOKEN_BATCH_SIZE);
+
+    try {
+      const batchResults = await fetchBulkMeTokenInfoBatch(batch);
+      Object.assign(merged, batchResults);
+    } catch (err) {
+      logger.error(
+        `❌ Failed bulk fetch batch ${batchNumber}/${totalBatches} (${batch.length} tokens):`,
+        err,
+      );
+    }
+  }
+
+  return merged;
 }

--- a/lib/utils/sendHelpers.ts
+++ b/lib/utils/sendHelpers.ts
@@ -15,10 +15,45 @@ export function formatSendError(error: unknown): string {
   return `${parsed.message}. ${parsed.suggestion}`;
 }
 
-export function getMaxEthSendAmount(balance: string, buffer = 0.001): string {
+export const ETH_SEND_GAS_BUFFER = 0.001;
+
+export function getMaxEthSendAmount(balance: string, buffer = ETH_SEND_GAS_BUFFER): string {
+  const max = getMaxSendableAmount('ETH', balance, buffer);
+  return max.toFixed(6);
+}
+
+/** Max sendable amount; ETH reserves a gas buffer, other tokens use full balance. */
+export function getMaxSendableAmount(
+  token: string,
+  balance: string,
+  buffer = ETH_SEND_GAS_BUFFER,
+): number {
   const available = parseFloat(balance);
-  if (available <= 0) return '0';
-  if (buffer <= 0) return available.toFixed(6);
-  const max = available - buffer;
-  return max > 0 ? max.toFixed(6) : '0';
+  if (Number.isNaN(available) || available <= 0) return 0;
+  if (token === 'ETH') {
+    const max = available - buffer;
+    return max > 0 ? max : 0;
+  }
+  return available;
+}
+
+/** Returns an error message when amount exceeds sendable balance, otherwise null. */
+export function validateSendBalance(
+  token: string,
+  amount: string,
+  balance: string,
+): string | null {
+  const requested = parseFloat(amount);
+  if (Number.isNaN(requested) || requested <= 0) {
+    return 'Please enter a valid amount';
+  }
+
+  const maxSendable = getMaxSendableAmount(token, balance);
+  if (requested <= maxSendable) return null;
+
+  if (token === 'ETH' && maxSendable < parseFloat(balance)) {
+    return `Leave at least ${ETH_SEND_GAS_BUFFER} ETH for gas (max send: ${maxSendable.toFixed(6)} ETH).`;
+  }
+
+  return `Insufficient balance. You have ${balance} ${token}, but trying to send ${amount} ${token}`;
 }

--- a/lib/utils/sendHelpers.ts
+++ b/lib/utils/sendHelpers.ts
@@ -1,0 +1,24 @@
+import { getAddress, isAddress, type Address } from 'viem';
+import { parseBundlerError } from '@/lib/utils/bundlerErrorParser';
+
+export function normalizeRecipientAddress(input: string): Address | null {
+  const trimmed = input.trim();
+  if (!isAddress(trimmed)) return null;
+  return getAddress(trimmed);
+}
+
+export function formatSendError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Failed to initiate transaction.';
+  }
+  const parsed = parseBundlerError(error);
+  return `${parsed.message}. ${parsed.suggestion}`;
+}
+
+export function getMaxEthSendAmount(balance: string, buffer = 0.001): string {
+  const available = parseFloat(balance);
+  if (available <= 0) return '0';
+  if (buffer <= 0) return available.toFixed(6);
+  const max = available - buffer;
+  return max > 0 ? max.toFixed(6) : '0';
+}


### PR DESCRIPTION
## Summary
- Improve wallet send and swap flows with recipient validation, clearer bundler/signature errors, ETH MAX gas buffer, and an iOS-friendly scroll layout with sticky footer.
- Refresh market data after MeToken trades by syncing on-chain TVL, filtering inactive tokens (min $0.10 TVL), fixing gainers/losers formatting, and adding MAX buttons to buy/sell dialogs.
- Pin the homepage hero to a static Livepeer playback ID so library deletions do not break the intro video, and make discover hover preview mute toggles functional.

## Test plan
- [ ] Send ETH on desktop and iPhone: invalid address shows error, MAX leaves gas buffer, bundler failures show readable message, modal scrolls with sticky Send/Cancel
- [ ] Swap tokens via wallet modal: prepare/sign flow completes; signature rejection shows friendly error
- [ ] Buy/sell MeTokens from market, profile, and video dialogs: MAX fills balance, market stats refresh after trade, zero-TVL tokens disappear
- [ ] Market page: gainers show positive % only, losers show negative % only
- [ ] Homepage hero video plays; hero excluded from trending list
- [ ] Discover page: hover preview mute button toggles audio


Made with [Cursor](https://cursor.com)