### PR TITLE
Fix Vercel build: AlchemySwapWidget bigint quote types

### DIFF
--- a/components/wallet/swap/AlchemySwapWidget.tsx
+++ b/components/wallet/swap/AlchemySwapWidget.tsx
@@ -249,18 +249,15 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
         fromAmount: amount,
       });
 
-      const result = (await prepareSwapAsync(
+      const result = await prepareSwapAsync(
         buildSwapParams(amount, fromToken, toToken),
-      )) as {
-        quote?: { minimumToAmount: string; feePayment?: { sponsored?: boolean } };
-        rawCalls?: unknown;
-      } | null | undefined;
+      );
 
       if (!result) {
         throw new Error('Failed to prepare swap: No response received');
       }
 
-      if (result.rawCalls) {
+      if ("rawCalls" in result && result.rawCalls) {
         throw new Error('Expected user operation calls, got raw calls');
       }
 
@@ -456,23 +453,19 @@ export function AlchemySwapWidget({ onSwapSuccess, className, hideHeader = false
 
       logger.debug('Requesting fresh quote for execution...');
 
-      const result = (await prepareSwapAsync(
+      const result = await prepareSwapAsync(
         buildSwapParams(swapState.fromAmount, swapState.fromToken, swapState.toToken),
-      )) as {
-        quote?: unknown;
-        rawCalls?: unknown;
-        [key: string]: unknown;
-      } | null | undefined;
+      );
 
       if (!result) {
         throw new Error('Failed to prepare swap: No response received');
       }
 
-      if (result.rawCalls) {
+      if ("rawCalls" in result && result.rawCalls) {
         throw new Error('Expected user operation calls, got raw calls');
       }
 
-      const { quote: _quote, rawCalls: _rawCalls, ...calls } = result;
+      const { quote: _quote, ...calls } = result;
 
       logger.debug('Signing and sending prepared calls...');
       const { preparedCallIds } = await signAndSendPreparedCallsAsync(calls);

--- a/lib/sdk/alchemy/swap-service.ts
+++ b/lib/sdk/alchemy/swap-service.ts
@@ -386,13 +386,13 @@ Original error: ${result.error.message}`;
   }
 
   /**
-   * Convert hex amount to readable format
+   * Convert SDK bigint or hex amount to readable format
    */
-  static parseAmount(hexAmount: Hex, token: TokenSymbol): string {
+  static parseAmount(amount: bigint | Hex | string, token: TokenSymbol): string {
     const decimals = TOKEN_INFO[token].decimals;
-    const amountBigInt = BigInt(hexAmount);
-    const amount = Number(amountBigInt) / Math.pow(10, decimals);
-    return amount.toFixed(6);
+    const amountBigInt = typeof amount === "bigint" ? amount : BigInt(amount);
+    const human = Number(amountBigInt) / 10 ** decimals;
+    return human.toFixed(6);
   }
 }
 

--- a/lib/wallet/react.tsx
+++ b/lib/wallet/react.tsx
@@ -7,6 +7,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePrivy, useLogout as usePrivyLogout } from "@privy-io/react-auth";
 import { useAuthErrorContext } from "./auth-error-context";
 import { requestQuoteV0 } from "@alchemy/wallet-apis/experimental";
+
+export type RequestQuoteV0Result = Awaited<ReturnType<typeof requestQuoteV0>>;
 import type { Address, Hex } from "viem";
 import { useWalletChain } from "./chain-context";
 import { useWalletClientContext } from "./wallet-context";
@@ -285,7 +287,7 @@ export function usePrepareSwap({ client }: { client?: SwapHookClient } = {}) {
   const [isPreparingSwap, setIsPreparingSwap] = useState(false);
 
   const prepareSwapAsync = useCallback(
-    async (params: Record<string, unknown>) => {
+    async (params: Record<string, unknown>): Promise<RequestQuoteV0Result> => {
       if (!client) throw new Error("Smart account client not initialized");
       setIsPreparingSwap(true);
       try {

--- a/lib/wallet/react.tsx
+++ b/lib/wallet/react.tsx
@@ -7,12 +7,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePrivy, useLogout as usePrivyLogout } from "@privy-io/react-auth";
 import { useAuthErrorContext } from "./auth-error-context";
 import { requestQuoteV0 } from "@alchemy/wallet-apis/experimental";
-
-export type RequestQuoteV0Result = Awaited<ReturnType<typeof requestQuoteV0>>;
 import type { Address, Hex } from "viem";
 import { useWalletChain } from "./chain-context";
 import { useWalletClientContext } from "./wallet-context";
 import type { CompatSmartAccountClient, SendUserOperationArgs } from "./smart-wallet-client";
+
+export type RequestQuoteV0Result = Awaited<ReturnType<typeof requestQuoteV0>>;
 
 export type CompatUser = {
   address: Address;


### PR DESCRIPTION
## Summary
- Fix TypeScript build failure in `AlchemySwapWidget` after PR #217 migrated swap quoting to `@alchemy/wallet-apis` v5 (`minimumToAmount` is `bigint`, not hex `string`).
- Broaden `AlchemySwapService.parseAmount` to accept `bigint | Hex | string`.
- Type `prepareSwapAsync` with `RequestQuoteV0Result` and remove unsafe casts in quote/execute paths.

## Test plan
- [x] `yarn build` passes locally (TypeScript + production build)
- [ ] Vercel preview deploy succeeds
- [ ] Swap widget: connect wallet, enter amount, quote loads and swap executes


Made with [Cursor](https://cursor.com)