### PR TITLE
fix(memberships): PR #223 review follow-up

### DIFF
--- a/components/UserProfile/MeTokensSection.tsx
+++ b/components/UserProfile/MeTokensSection.tsx
@@ -353,8 +353,7 @@ export function MeTokensSection({ walletAddress }: MeTokensSectionProps) {
             </TabsTrigger>
             <TabsTrigger value="profile" className="flex items-center justify-center gap-2">
               <User className="h-4 w-4" />
-              <span className="hidden sm:inline">Profile</span>
-              <span className="sm:hidden">Profile</span>
+              <span>Profile</span>
             </TabsTrigger>
             <TabsTrigger value="trading" className="flex items-center justify-center gap-2">
               <TrendingUp className="h-4 w-4" />

--- a/components/account-dropdown/AccountDropdown.tsx
+++ b/components/account-dropdown/AccountDropdown.tsx
@@ -1130,7 +1130,7 @@ export const AccountDropdown = forwardRef<AccountDropdownHandle>(
                               </div>
                               <div className="flex-1 min-w-0">
                                 <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                                  {getPassDisplayName(nft.lockAddress) || nft.lockName}
+                                  {nft.lockAddress ? getPassDisplayName(nft.lockAddress) : nft.lockName}
                                 </p>
                                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                                   Token ID: {nft.tokenId}

--- a/components/account-dropdown/MembershipSection.tsx
+++ b/components/account-dropdown/MembershipSection.tsx
@@ -159,10 +159,10 @@ export function MembershipSection({
                 className="flex items-center justify-between text-xs"
               >
                 <span className="text-muted-foreground">
-                  {MEMBERSHIP_NAMES[address]}
+                  {getPassDisplayName(address)}
                 </span>
                 <span className="font-medium">
-                  {MEMBERSHIP_NAMES[address]}
+                  {getPassDisplayName(address)}
                   {lock?.expirationDuration && (
                     <span className="ml-1 text-muted-foreground">
                       (Expires:{" "}

--- a/components/songchain/LensRewardsCard.tsx
+++ b/components/songchain/LensRewardsCard.tsx
@@ -9,7 +9,7 @@ export function LensRewardsCard() {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 rounded-md border border-violet-500/20 bg-violet-100 px-4 py-3 text-sm text-violet-900">
+      <div className="flex items-center gap-2 rounded-md border border-violet-500/20 bg-violet-500/10 px-4 py-3 text-sm text-violet-200">
         <Loader2 className="h-4 w-4 animate-spin" />
         Checking Lens rewards…
       </div>
@@ -18,9 +18,9 @@ export function LensRewardsCard() {
 
   if (error) {
     return (
-      <div className="rounded-md border border-amber-500/20 bg-amber-100 px-4 py-3 text-sm text-amber-900">
+      <div className="rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
         <p className="font-medium">Rewards unavailable</p>
-        <p className="text-xs text-amber-700">{error}</p>
+        <p className="text-xs text-amber-300">{error}</p>
       </div>
     );
   }
@@ -28,21 +28,21 @@ export function LensRewardsCard() {
   const hasRewards = ghoRewards.length > 0;
 
   return (
-    <div className="rounded-md border border-violet-500/20 bg-violet-100 px-4 py-3 text-sm">
+    <div className="rounded-md border border-violet-500/20 bg-violet-500/10 px-4 py-3 text-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-2">
-          <Gift className="mt-0.5 h-4 w-4 shrink-0 text-violet-700" />
+          <Gift className="mt-0.5 h-4 w-4 shrink-0 text-violet-300" />
           <div>
-            <p className="font-medium text-violet-900">
+            <p className="font-medium text-violet-100">
               {hasRewards ? "Lens rewards earned" : "Lens rewards"}
             </p>
-            <p className="text-violet-800">
+            <p className="text-violet-200">
               {hasRewards
                 ? `You've earned ${totalGho} GHO from Lens Smart Token Distributions.`
                 : "Connect and use your Orb account on Lens to become eligible for GHO rewards."}
             </p>
             {ghoRewards.length > 0 && (
-              <p className="mt-1 text-xs text-violet-700">
+              <p className="mt-1 text-xs text-violet-300">
                 {ghoRewards.length} distribution{ghoRewards.length === 1 ? "" : "s"} · rewards show up in your connected wallet on Lens
               </p>
             )}
@@ -51,7 +51,7 @@ export function LensRewardsCard() {
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 shrink-0 text-violet-700 hover:bg-violet-200"
+          className="h-7 w-7 shrink-0 text-violet-300 hover:bg-violet-500/20"
           onClick={() => void refresh()}
           aria-label="Refresh rewards"
         >

--- a/lib/access/creator-membership.ts
+++ b/lib/access/creator-membership.ts
@@ -10,7 +10,7 @@ export function hasValidCreatorPass(
   memberships: MembershipLike[] | null | undefined
 ): boolean {
   if (!memberships?.length) return false;
-  const creatorLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS_2 || "").toLowerCase();
+  const creatorLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS || "").toLowerCase();
   return memberships.some(
     (m) => m.isValid && m.address.toLowerCase() === creatorLock
   );
@@ -21,7 +21,7 @@ export function hasValidBrandPass(
   memberships: MembershipLike[] | null | undefined
 ): boolean {
   if (!memberships?.length) return false;
-  const brandLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS || "").toLowerCase();
+  const brandLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS_3 || "").toLowerCase();
   return memberships.some(
     (m) => m.isValid && m.address.toLowerCase() === brandLock
   );
@@ -32,7 +32,7 @@ export function hasValidInvestorPass(
   memberships: MembershipLike[] | null | undefined
 ): boolean {
   if (!memberships?.length) return false;
-  const investorLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS_3 || "").toLowerCase();
+  const investorLock = (LOCK_ADDRESSES.BASE_CREATIVE_PASS_2 || "").toLowerCase();
   return memberships.some(
     (m) => m.isValid && m.address.toLowerCase() === investorLock
   );


### PR DESCRIPTION
Addresses the feedback left by Gemini Code Assist on PR #223 before it was merged.

Changes:
- Corrects membership access helpers to match the actual on-chain tiers defined in MembershipHome:
  - Creator pass → BASE_CREATIVE_PASS
  - Brand pass → BASE_CREATIVE_PASS_3
  - Investor pass → BASE_CREATIVE_PASS_2
- Uses case-insensitive getPassDisplayName in MembershipSection instead of direct object lookup.
- Removes redundant responsive spans for the Profile tab in MeTokensSection.
- Fixes AccountDropdown fallback so nft.lockName is shown when lockAddress is missing.
- Restores dark-themed semi-transparent styling in LensRewardsCard.