### PR TITLE
feat(song-cup): Figma The Feed panel + lint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,9 @@
   "ignorePatterns": [
     "*.sql",
     "*.md",
-    "supabase/functions/**/*.ts"
+    "supabase/functions/**/*.ts",
+    "public/sw.js",
+    "public/workbox-*.js"
   ],
   "rules": {
     "no-unused-vars": "off",

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -35,6 +35,8 @@ type SongchainFeedSectionProps = {
   hideHeader?: boolean;
   /** Extra classes applied to every post card. */
   cardClassName?: string;
+  /** Visual variant passed through to each post card. */
+  cardVariant?: "default" | "song-cup";
 };
 
 export type SongchainFeedHandle = {
@@ -75,7 +77,7 @@ function FeedDiagnostics({
 
 export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFeedSectionProps>(
   function SongchainFeedSection(
-    { title, description, feedId, graphId = null, emptyDescription, onPostUpdated, enabled = true, readOnly = false, animated = false, layout = "timeline", hideHeader = false, cardClassName },
+    { title, description, feedId, graphId = null, emptyDescription, onPostUpdated, enabled = true, readOnly = false, animated = false, layout = "timeline", hideHeader = false, cardClassName, cardVariant = "default" },
     ref,
   ) {
     const { posts, pendingPosts, loading, error, hasMore, reload, loadMore, registerNewPost } =
@@ -155,6 +157,7 @@ export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFee
                 graphId={graphId}
                 compact
                 readOnly={readOnly}
+                variant={cardVariant}
                 onReactionChange={reload}
                 onPostUpdated={onPostUpdated}
               />

--- a/components/songchain/SongchainFeedSection.tsx
+++ b/components/songchain/SongchainFeedSection.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/songchain/SongchainPostTimeline";
 import { isQuotePost } from "@/lib/songchain/post-utils";
 import { getFeedDiagnosticInfo } from "@/lib/songchain/feed-diagnostics";
+import { cn } from "@/lib/utils/utils";
 import type { SongchainCreatedPost } from "@/lib/songchain/feed-types";
 
 type SongchainFeedSectionProps = {
@@ -28,6 +29,12 @@ type SongchainFeedSectionProps = {
   readOnly?: boolean;
   /** Enables a contained, scroll-driven animated feed where posts scale near the center. */
   animated?: boolean;
+  /** Render posts as a 4-column grid (Song Cup) or the default single-column timeline. */
+  layout?: "timeline" | "grid";
+  /** Hide the title/description header block. */
+  hideHeader?: boolean;
+  /** Extra classes applied to every post card. */
+  cardClassName?: string;
 };
 
 export type SongchainFeedHandle = {
@@ -68,7 +75,7 @@ function FeedDiagnostics({
 
 export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFeedSectionProps>(
   function SongchainFeedSection(
-    { title, description, feedId, graphId = null, emptyDescription, onPostUpdated, enabled = true, readOnly = false, animated = false },
+    { title, description, feedId, graphId = null, emptyDescription, onPostUpdated, enabled = true, readOnly = false, animated = false, layout = "timeline", hideHeader = false, cardClassName },
     ref,
   ) {
     const { posts, pendingPosts, loading, error, hasMore, reload, loadMore, registerNewPost } =
@@ -98,13 +105,15 @@ export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFee
 
     return (
       <section>
-        <div className="mb-6">
-          <div className="flex items-center gap-2">
-            <h2 className="text-2xl font-bold">{title}</h2>
-            <SongchainFeedInfoTooltip feedId={feedId} />
+        {!hideHeader && (
+          <div className="mb-6">
+            <div className="flex items-center gap-2">
+              <h2 className="text-2xl font-bold">{title}</h2>
+              <SongchainFeedInfoTooltip feedId={feedId} />
+            </div>
+            <p className="text-muted-foreground mt-1">{description}</p>
           </div>
-          <p className="text-muted-foreground mt-1">{description}</p>
-        </div>
+        )}
 
         <FeedDiagnostics
           error={error}
@@ -128,6 +137,28 @@ export const SongchainFeedSection = forwardRef<SongchainFeedHandle, SongchainFee
           <div className="mx-auto max-w-2xl rounded-lg border border-dashed border-border/60 p-8 text-center">
             <p className="font-medium text-foreground">No posts found in this feed yet.</p>
             <p className="mt-2 text-sm text-muted-foreground">{emptyDescription}</p>
+          </div>
+        ) : layout === "grid" ? (
+          <div className={cn("grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4", cardClassName)}>
+            {pendingPosts.map((pending) => (
+              <SongchainPendingPostCard
+                key={pending.localId}
+                pending={pending}
+                onRefresh={() => reload()}
+              />
+            ))}
+            {posts.map((post) => (
+              <SongchainPostCard
+                key={post.id}
+                post={post}
+                feedId={feedId}
+                graphId={graphId}
+                compact
+                readOnly={readOnly}
+                onReactionChange={reload}
+                onPostUpdated={onPostUpdated}
+              />
+            ))}
           </div>
         ) : (
           <SongchainPostTimeline animated={animated}>

--- a/components/songchain/SongchainGatedFeedTab.tsx
+++ b/components/songchain/SongchainGatedFeedTab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useSongchainGroupMembership } from "@/hooks/useSongchainGroupMembership";
-import { SongchainComposePost } from "./SongchainComposePost";
-import { SongchainFeedSection } from "./SongchainFeedSection";
+import { SongchainComposePost } from "@/components/songchain/SongchainComposePost";
+import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
 import { Loader2, Lock, ExternalLink, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -69,6 +69,8 @@ type SongchainPostCardProps = {
   readOnly?: boolean;
   onReactionChange?: () => void;
   onPostUpdated?: () => void;
+  /** Visual variant for the Song Cup grid. */
+  variant?: "default" | "song-cup";
 };
 
 export function SongchainPostCard({
@@ -79,6 +81,7 @@ export function SongchainPostCard({
   readOnly = false,
   onReactionChange,
   onPostUpdated,
+  variant = "default",
 }: SongchainPostCardProps) {
   const { canWrite, getSessionClient, promptWriteAccess, lensAccount } =
     useLensOrbWrite();
@@ -300,6 +303,7 @@ export function SongchainPostCard({
           compact && "text-sm",
           isQuote && "border-violet-500/30",
           pending === "edit" && "opacity-70",
+          variant === "song-cup" && "min-h-[155px] rounded-[20px] border border-[#fe01dc] bg-black p-3 text-[10px] text-white shadow-none",
         )}
       >
         {pending === "edit" && (
@@ -315,16 +319,19 @@ export function SongchainPostCard({
             <SongchainPostMedia media={media} compact={compact} />
           </div>
         )}
-        <div className="flex flex-col gap-3 p-4">
+        <div className={cn("flex flex-col gap-3", variant === "song-cup" ? "p-0" : "p-4")}>
           <div className="flex items-center justify-between gap-2">
             <button
               type="button"
-              className="text-xs text-muted-foreground text-left hover:text-violet-400 w-fit"
+              className={cn(
+                "text-left hover:text-violet-400 w-fit",
+                variant === "song-cup" ? "text-[10px] text-white/70" : "text-xs text-muted-foreground",
+              )}
               onClick={() => setTimelineOpen(true)}
             >
               {authorLabel(isQuote ? post : content)}
             </button>
-            {content && (
+            {content && variant !== "song-cup" && (
               <SongchainFollowButton
                 graphId={graphId}
                 accountAddress={
@@ -334,19 +341,22 @@ export function SongchainPostCard({
             )}
           </div>
           {compact && media.length > 0 && (
-            <SongchainPostMedia media={media} compact />
+            <div className={cn(variant === "song-cup" && "max-h-28 overflow-hidden rounded-[12px]")}>
+              <SongchainPostMedia media={media} compact={compact} />
+            </div>
           )}
           {resolvedPostText && (
             <SongchainPostContent
               text={resolvedPostText}
               compact={compact}
+              className={cn(variant === "song-cup" && "text-[10px] text-white/90")}
               embeddedCreativeTVUrls={embeddedCreativeTVUrls}
               skipAllInternalPreviews={skipAllInternalPreviews}
             />
           )}
           {quotedPost && <SongchainQuotedPostEmbed quotedPost={quotedPost} />}
-          <div className="mt-auto flex flex-wrap items-center gap-1 pt-2 border-t border-border/40">
-            <span className="text-xs text-muted-foreground mr-auto">
+          <div className={cn("mt-auto flex flex-wrap items-center gap-1 pt-2", variant === "song-cup" ? "border-t border-white/10" : "border-t border-border/40")}>
+            <span className={cn("mr-auto", variant === "song-cup" ? "text-[10px] text-white/60" : "text-xs text-muted-foreground")}>
               {reactions} upvote{reactions === 1 ? "" : "s"}
             </span>
             <Button
@@ -355,13 +365,17 @@ export function SongchainPostCard({
               size="sm"
               disabled={readOnly || pending === "upvote"}
               onClick={readOnly ? undefined : toggleUpvote}
-              className={cn(upvoted && "text-rose-500")}
+              className={cn(
+                "px-2",
+                upvoted && variant === "song-cup" ? "text-[#fe01dc]" : upvoted && "text-rose-500",
+                variant === "song-cup" && "h-7 text-white/80 hover:bg-white/10 hover:text-white",
+              )}
               aria-label="Upvote"
             >
               {pending === "upvote" ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-3 w-3 animate-spin" />
               ) : (
-                <Heart className={cn("h-4 w-4", upvoted && "fill-current")} />
+                <Heart className={cn("h-3 w-3", upvoted && "fill-current")} />
               )}
             </Button>
             <Button
@@ -370,9 +384,13 @@ export function SongchainPostCard({
               size="sm"
               onClick={() => setCommentsOpen(true)}
               aria-label={`Comments${commentCount > 0 ? ` (${commentCount})` : ""}`}
-              className={cn("gap-1", readOnly && "text-muted-foreground")}
+              className={cn(
+                "gap-1 px-2",
+                readOnly && "text-muted-foreground",
+                variant === "song-cup" && "h-7 text-white/80 hover:bg-white/10 hover:text-white",
+              )}
             >
-              <MessageCircle className="h-4 w-4" />
+              <MessageCircle className="h-3 w-3" />
               {commentCount > 0 && (
                 <span className="text-[10px] tabular-nums">{commentCount}</span>
               )}
@@ -384,12 +402,15 @@ export function SongchainPostCard({
               disabled={readOnly || pending === "repost"}
               onClick={readOnly ? undefined : handleRepost}
               aria-label={`Repost${reposts > 0 ? ` (${reposts})` : ""}`}
-              className="gap-1"
+              className={cn(
+                "gap-1 px-2",
+                variant === "song-cup" && "h-7 text-white/80 hover:bg-white/10 hover:text-white",
+              )}
             >
               {pending === "repost" ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-3 w-3 animate-spin" />
               ) : (
-                <Repeat2 className="h-4 w-4" />
+                <Repeat2 className="h-3 w-3" />
               )}
               {reposts > 0 && (
                 <span className="text-[10px] tabular-nums">{reposts}</span>
@@ -401,13 +422,17 @@ export function SongchainPostCard({
               size="sm"
               disabled={readOnly || pending === "bookmark"}
               onClick={readOnly ? undefined : toggleBookmark}
-              className={cn(bookmarked && "text-amber-500")}
+              className={cn(
+                "px-2",
+                bookmarked && variant === "song-cup" ? "text-[#fe01dc]" : bookmarked && "text-amber-500",
+                variant === "song-cup" && "h-7 text-white/80 hover:bg-white/10 hover:text-white",
+              )}
               aria-label="Bookmark"
             >
               {pending === "bookmark" ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-3 w-3 animate-spin" />
               ) : (
-                <Bookmark className={cn("h-4 w-4", bookmarked && "fill-current")} />
+                <Bookmark className={cn("h-3 w-3", bookmarked && "fill-current")} />
               )}
             </Button>
             {isOwner && !readOnly && (
@@ -421,8 +446,11 @@ export function SongchainPostCard({
                     setEditOpen(true);
                   }}
                   aria-label="Edit post"
+                  className={cn(
+                    variant === "song-cup" && "h-7 px-2 text-white/80 hover:bg-white/10 hover:text-white",
+                  )}
                 >
-                  <Pencil className="h-4 w-4" />
+                  <Pencil className="h-3 w-3" />
                 </Button>
                 <Button
                   type="button"
@@ -430,13 +458,16 @@ export function SongchainPostCard({
                   size="sm"
                   disabled={pending === "delete"}
                   onClick={handleDelete}
-                  className="text-destructive"
+                  className={cn(
+                    "text-destructive",
+                    variant === "song-cup" && "h-7 px-2 text-white/80 hover:bg-white/10 hover:text-red-400",
+                  )}
                   aria-label="Delete post"
                 >
                   {pending === "delete" ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <Loader2 className="h-3 w-3 animate-spin" />
                   ) : (
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-3 w-3" />
                   )}
                 </Button>
               </>

--- a/components/songchain/song-cup/SongCupBottomSection.tsx
+++ b/components/songchain/song-cup/SongCupBottomSection.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { SongchainGatedFeedTab } from "@/components/songchain/SongchainGatedFeedTab";
 import { SongCupPreviewPanel } from "./SongCupPreviewPanel";
 import { SongCupSidebarIcons } from "./SongCupSidebarIcons";
 import { SONG_CUP_BUTTON_ICONS, type SongCupPanel } from "./song-cup-icons";
+import { SongCupFeedPanel } from "./SongCupFeedPanel";
 import type { SongchainConfig } from "@/lib/songchain/config";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils/utils";
@@ -54,17 +54,15 @@ function getPreviewCopy(panel: SongCupPanel) {
 
 function FeedPanel(props: SongCupBottomSectionProps) {
   return (
-    <SongchainGatedFeedTab
-      gateGroupId={props.groupId}
+    <SongCupFeedPanel
       feedId={props.feedId}
+      groupId={props.groupId}
       graphId={props.graphId}
       feedTitle={props.publicFeedTitle ?? "Song Cup club feed"}
       feedDescription={
         props.publicFeedDescription ??
-        "Read the member feed. Join the club on Lens to post and react."
+        "Read the member feed. Join the club on Orb to post and react."
       }
-      clubGateTitle={props.clubGateTitle}
-      clubGateDescription={props.clubGateDescription}
       orbClubUrl={props.orbClubUrl}
     />
   );
@@ -89,7 +87,7 @@ function ActivePanel({
 
 function ActivePanelBanner({ panel }: { panel: SongCupPanel | null }) {
   const icon = SONG_CUP_BUTTON_ICONS.find(({ id }) => id === panel);
-  if (!icon) return null;
+  if (!icon || panel === "feed") return null;
   return (
     <div className="mb-3 inline-flex items-center gap-2 rounded-lg border border-fuchsia-500/20 bg-fuchsia-500/10 px-3 py-1.5">
       <img src={icon.src} alt="" className="h-5 w-5 object-contain" aria-hidden />
@@ -129,7 +127,14 @@ export function SongCupBottomSection(props: SongCupBottomSectionProps) {
     return (
       <div id="song-cup-feed" className="mx-auto max-w-7xl px-4 py-10 sm:px-6">
         <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
-          <main className="order-2 min-h-[480px] rounded-2xl border border-fuchsia-500/20 p-4 sm:p-6 lg:order-1">
+          <main
+            className={cn(
+              "order-2 min-h-[480px] p-4 sm:p-6 lg:order-1",
+              activePanel === "feed"
+                ? "border-0 bg-transparent p-0"
+                : "rounded-2xl border border-fuchsia-500/20",
+            )}
+          >
             <ActivePanelBanner panel={activePanel} />
             <ActivePanel panel={activePanel} props={props} />
           </main>
@@ -184,7 +189,14 @@ export function SongCupBottomSection(props: SongCupBottomSectionProps) {
                 )}
               </div>
               {isActive && isPanel && (
-                <div className="min-h-[320px] rounded-2xl border border-fuchsia-500/20 bg-black/40 p-4 sm:p-5">
+                <div
+                  className={cn(
+                    "min-h-[320px] p-4 sm:p-5",
+                    id === "feed"
+                      ? "border-0 bg-transparent p-0"
+                      : "rounded-2xl border border-fuchsia-500/20 bg-black/40",
+                  )}
+                >
                   <ActivePanel panel={id as SongCupPanel} props={props} />
                 </div>
               )}

--- a/components/songchain/song-cup/SongCupFeedCompose.tsx
+++ b/components/songchain/song-cup/SongCupFeedCompose.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useSongchainPost } from "@/hooks/useSongchainPost";
+import { useCreatorLiveStream } from "@/hooks/useCreatorLiveStream";
+import { useUser } from "@/lib/wallet/react";
+import { GroveVideoUploader } from "@/components/songchain/GroveVideoUploader";
+import { songCupSubmissionsService } from "@/lib/sdk/supabase/song-cup-submissions";
+import type { SongchainCreatedPost } from "@/lib/songchain/feed-types";
+import type { VideoAsset } from "@/lib/types/video-asset";
+import type { StreamSummary } from "@/lib/songchain/build-lens-livestream-metadata";
+
+type SongCupFeedComposeProps = {
+  feedId: string | null;
+  onPosted?: (created: SongchainCreatedPost) => void;
+  /** Pre-fill live stream attach (e.g. from /live page modal). */
+  initialLiveStream?: StreamSummary | null;
+};
+
+export function SongCupFeedCompose({
+  feedId,
+  onPosted,
+  initialLiveStream = null,
+}: SongCupFeedComposeProps) {
+  const [content, setContent] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [uploadedVideoAsset, setUploadedVideoAsset] = useState<Partial<VideoAsset> | null>(null);
+  const [attachedLiveStream, setAttachedLiveStream] = useState<StreamSummary | null>(
+    initialLiveStream?.is_live ? initialLiveStream : null,
+  );
+
+  const { createPost, isPosting, canWrite, needsOrbReauth, promptWriteAccess } =
+    useSongchainPost();
+  const { stream, isLive, loading: streamLoading } = useCreatorLiveStream();
+  const user = useUser();
+
+  if (!feedId) return null;
+
+  const liveAttached = !!attachedLiveStream?.is_live;
+  const hasContent = content.trim().length > 0 || !!uploadedVideoAsset || liveAttached;
+  const canSubmit = hasContent;
+
+  const handleAttachLive = () => {
+    if (stream?.is_live) {
+      setAttachedLiveStream(stream);
+      setUploadedVideoAsset(null);
+    }
+  };
+
+  const handleUploadVideo = (asset: Partial<VideoAsset>) => {
+    setUploadedVideoAsset(asset);
+    if (asset) setAttachedLiveStream(null);
+  };
+
+  const handleRemoveVideo = () => {
+    setUploadedVideoAsset(null);
+  };
+
+  const handleSubmit = async () => {
+    const created = await createPost({
+      content,
+      feedId,
+      attachedVideo: liveAttached ? null : (uploadedVideoAsset as VideoAsset | null),
+      attachedLiveStream: liveAttached ? attachedLiveStream : null,
+    });
+    if (created) {
+      if (uploadedVideoAsset?.location && user?.address) {
+        await songCupSubmissionsService.create({
+          wallet_address: user.address,
+          grove_url: uploadedVideoAsset.location,
+          grove_hash: uploadedVideoAsset.metadata_uri ?? undefined,
+          title: uploadedVideoAsset.title ?? undefined,
+          description: content.trim() || undefined,
+          post_id: created.postId,
+        });
+      }
+      setContent("");
+      setUploadedVideoAsset(null);
+      setAttachedLiveStream(null);
+      setFocused(false);
+      onPosted?.(created);
+    }
+  };
+
+  const showExpanded = focused || hasContent;
+
+  return (
+    <div className="relative min-h-[117px] rounded-[20px] border border-[#fe01dc] bg-black/60 p-4">
+      {!showExpanded ? (
+        <button
+          type="button"
+          onClick={() => setFocused(true)}
+          className="flex h-full min-h-[85px] w-full flex-col items-center justify-center gap-2 text-white/60 transition-colors hover:text-white"
+          aria-label="Create a post"
+        >
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#fe01dc]/40">
+            <Plus className="h-5 w-5" />
+          </div>
+        </button>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {!canWrite && (
+            <p className="text-xs text-white/70">
+              {needsOrbReauth
+                ? "Your Orb session expired partially — sign in again with Orb to post."
+                : "Connect wallet, sign in with Orb, and link your profile to post to this feed."}
+            </p>
+          )}
+
+          <Textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Share something with Songchain…"
+            rows={3}
+            disabled={isPosting}
+            maxLength={5000}
+            autoFocus={focused}
+            onBlur={() => {
+              if (!hasContent) setFocused(false);
+            }}
+            className="border-0 bg-transparent p-0 text-sm text-white placeholder:text-white/40 focus-visible:ring-0 focus-visible:ring-offset-0"
+          />
+
+          {isLive && !liveAttached && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={streamLoading || isPosting}
+              onClick={handleAttachLive}
+              className="w-fit gap-2 border-[#fe01dc]/40 text-[#fe01dc] hover:bg-[#fe01dc]/10 hover:text-white"
+            >
+              Attach your live stream
+            </Button>
+          )}
+
+          {liveAttached && attachedLiveStream && (
+            <div className="flex items-center gap-3 rounded-md border border-[#fe01dc]/30 bg-black/40 p-3">
+              <span className="rounded bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-1.5 py-0.5 text-[10px] font-bold text-black">
+                LIVE
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-white">
+                  {attachedLiveStream.name || "Live on Creative TV"}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-white hover:bg-white/10"
+                onClick={() => setAttachedLiveStream(null)}
+                aria-label="Detach live stream"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+
+          {!liveAttached && !uploadedVideoAsset && (
+            <GroveVideoUploader
+              onUploaded={handleUploadVideo}
+              onRemove={handleRemoveVideo}
+              uploadedAsset={uploadedVideoAsset}
+              disabled={isPosting}
+            />
+          )}
+
+          {uploadedVideoAsset && (
+            <GroveVideoUploader
+              onUploaded={handleUploadVideo}
+              onRemove={handleRemoveVideo}
+              uploadedAsset={uploadedVideoAsset}
+              disabled={isPosting}
+            />
+          )}
+
+          <div className="flex justify-end gap-2">
+            {!canWrite ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={promptWriteAccess}
+                className="border-white/20 text-white hover:bg-white/10 hover:text-white"
+              >
+                {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                disabled={isPosting || !canSubmit}
+                onClick={() => void handleSubmit()}
+                className="rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
+              >
+                {isPosting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                POST
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/songchain/song-cup/SongCupFeedCompose.tsx
+++ b/components/songchain/song-cup/SongCupFeedCompose.tsx
@@ -12,6 +12,7 @@ import { songCupSubmissionsService } from "@/lib/sdk/supabase/song-cup-submissio
 import type { SongchainCreatedPost } from "@/lib/songchain/feed-types";
 import type { VideoAsset } from "@/lib/types/video-asset";
 import type { StreamSummary } from "@/lib/songchain/build-lens-livestream-metadata";
+import { toast } from "sonner";
 
 type SongCupFeedComposeProps = {
   feedId: string | null;
@@ -68,14 +69,19 @@ export function SongCupFeedCompose({
     });
     if (created) {
       if (uploadedVideoAsset?.location && user?.address) {
-        await songCupSubmissionsService.create({
-          wallet_address: user.address,
-          grove_url: uploadedVideoAsset.location,
-          grove_hash: uploadedVideoAsset.metadata_uri ?? undefined,
-          title: uploadedVideoAsset.title ?? undefined,
-          description: content.trim() || undefined,
-          post_id: created.postId,
-        });
+        try {
+          await songCupSubmissionsService.create({
+            wallet_address: user.address,
+            grove_url: uploadedVideoAsset.location,
+            grove_hash: uploadedVideoAsset.metadata_uri ?? undefined,
+            title: uploadedVideoAsset.title ?? undefined,
+            description: content.trim() || undefined,
+            post_id: created.postId,
+          });
+        } catch (err) {
+          console.error("Song Cup submission sync failed", err);
+          toast.error("Post shared, but submission backup failed.");
+        }
       }
       setContent("");
       setUploadedVideoAsset(null);
@@ -160,7 +166,7 @@ export function SongCupFeedCompose({
             </div>
           )}
 
-          {!liveAttached && !uploadedVideoAsset && (
+          {!liveAttached && (
             <GroveVideoUploader
               onUploaded={handleUploadVideo}
               onRemove={handleRemoveVideo}
@@ -169,39 +175,28 @@ export function SongCupFeedCompose({
             />
           )}
 
-          {uploadedVideoAsset && (
-            <GroveVideoUploader
-              onUploaded={handleUploadVideo}
-              onRemove={handleRemoveVideo}
-              uploadedAsset={uploadedVideoAsset}
-              disabled={isPosting}
-            />
+          {!canWrite ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={promptWriteAccess}
+              className="w-fit border-white/20 text-white hover:bg-white/10 hover:text-white"
+            >
+              {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              disabled={isPosting || !canSubmit}
+              onClick={() => void handleSubmit()}
+              className="ml-auto rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
+            >
+              {isPosting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              POST
+            </Button>
           )}
-
-          <div className="flex justify-end gap-2">
-            {!canWrite ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={promptWriteAccess}
-                className="border-white/20 text-white hover:bg-white/10 hover:text-white"
-              >
-                {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                size="sm"
-                disabled={isPosting || !canSubmit}
-                onClick={() => void handleSubmit()}
-                className="rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
-              >
-                {isPosting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                POST
-              </Button>
-            )}
-          </div>
         </div>
       )}
     </div>

--- a/components/songchain/song-cup/SongCupFeedMembersRow.tsx
+++ b/components/songchain/song-cup/SongCupFeedMembersRow.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { AnyClient } from "@lens-protocol/client";
+import { fetchGroupMembers } from "@lens-protocol/client/actions";
+import { evmAddress } from "@lens-protocol/types";
+import { createLensClient } from "@/lib/sdk/lens/create-client";
+import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
+import { convertFailingGateway } from "@/lib/utils/image-gateway";
+import makeBlockie from "ethereum-blockies-base64";
+
+type Member = {
+  account: string;
+  avatarUrl?: string | null;
+  handle?: string | null;
+};
+
+type SongCupFeedMembersRowProps = {
+  groupId: string | null;
+  orbClubUrl?: string;
+};
+
+const MAX_AVATARS = 6;
+
+function normalizeAvatar(raw: unknown): string | null {
+  if (!raw) return null;
+  if (typeof raw === "string") return convertFailingGateway(raw);
+  if (typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    const nested =
+      typeof obj.uri === "string"
+        ? obj.uri
+        : typeof obj.url === "string"
+          ? obj.url
+          : typeof obj.src === "string"
+            ? obj.src
+            : null;
+    return nested ? convertFailingGateway(nested) : null;
+  }
+  return null;
+}
+
+export function SongCupFeedMembersRow({ groupId, orbClubUrl }: SongCupFeedMembersRowProps) {
+  const { canWrite, getSessionClient } = useLensOrbWrite();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadMembers = useCallback(async () => {
+    if (!groupId) return;
+    setLoading(true);
+    try {
+      let client: AnyClient = createLensClient();
+      if (canWrite) {
+        try {
+          client = await getSessionClient();
+        } catch (err) {
+          clearStaleOrbSessionIfNeeded(err);
+          client = createLensClient();
+        }
+      }
+
+      const result = await fetchGroupMembers(client, {
+        group: evmAddress(groupId),
+        pageSize: "TEN",
+      });
+      if (result.isOk()) {
+        setMembers(
+          result.value.items.slice(0, MAX_AVATARS).map((item) => {
+            const account =
+              typeof item.account === "string"
+                ? item.account
+                : (item.account as { address?: string })?.address ?? "";
+            const metadata =
+              item.account && typeof item.account === "object"
+                ? (item.account as { metadata?: unknown }).metadata
+                : null;
+            const avatarUrl = normalizeAvatar(
+              metadata && typeof metadata === "object"
+                ? (metadata as { picture?: unknown; avatar?: unknown }).picture ??
+                    (metadata as { picture?: unknown; avatar?: unknown }).avatar
+                : null,
+            );
+            const handle =
+              metadata && typeof metadata === "object"
+                ? (metadata as { username?: unknown; handle?: unknown }).username ??
+                  (metadata as { username?: unknown; handle?: unknown }).handle
+                : null;
+            return {
+              account,
+              avatarUrl,
+              handle: typeof handle === "string" ? handle : null,
+            };
+          }),
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId, canWrite, getSessionClient]);
+
+  useEffect(() => {
+    void loadMembers();
+  }, [loadMembers]);
+
+  if (!groupId) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center">
+        {loading && members.length === 0 ? (
+          <span className="text-xs text-white/60">Loading members…</span>
+        ) : (
+          members.map((member, index) => (
+            <div
+              key={member.account}
+              className="relative -ml-2 first:ml-0"
+              style={{ zIndex: members.length - index }}
+            >
+              <img
+                src={member.avatarUrl || makeBlockie(member.account)}
+                alt={member.handle ?? member.account}
+                className="h-[58px] w-[58px] rounded-full border-2 border-black object-cover"
+              />
+            </div>
+          ))
+        )}
+      </div>
+      {orbClubUrl && (
+        <a
+          href={orbClubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-semibold uppercase tracking-wide text-white/80 hover:text-[#fe01dc]"
+        >
+          more
+        </a>
+      )}
+    </div>
+  );
+}

--- a/components/songchain/song-cup/SongCupFeedMembersRow.tsx
+++ b/components/songchain/song-cup/SongCupFeedMembersRow.tsx
@@ -9,6 +9,7 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { convertFailingGateway } from "@/lib/utils/image-gateway";
 import makeBlockie from "ethereum-blockies-base64";
+import { toast } from "sonner";
 
 type Member = {
   account: string;
@@ -93,7 +94,14 @@ export function SongCupFeedMembersRow({ groupId, orbClubUrl }: SongCupFeedMember
             };
           }),
         );
+      } else {
+        console.error("Failed to load group members", result.error);
+        toast.error("Could not load club members.");
       }
+    } catch (err) {
+      clearStaleOrbSessionIfNeeded(err);
+      console.error("Error loading group members", err);
+      toast.error("Could not load club members.");
     } finally {
       setLoading(false);
     }

--- a/components/songchain/song-cup/SongCupFeedPanel.tsx
+++ b/components/songchain/song-cup/SongCupFeedPanel.tsx
@@ -85,24 +85,24 @@ export function SongCupFeedPanel({
             </div>
           )}
 
-          {!membership.loading && membership.isMember && (
-            <SongCupFeedCompose feedId={feedId} />
-          )}
-
           {!membership.loading && (
-            <SongCupFeedMembersRow groupId={groupId} orbClubUrl={joinHref} />
-          )}
+            <>
+              {membership.isMember && <SongCupFeedCompose feedId={feedId} />}
 
-          {!membership.loading && membership.isMember && (
-            <SongchainFeedSection
-              title={feedTitle}
-              description={feedDescription}
-              feedId={feedId}
-              graphId={graphId}
-              emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled."
-              layout="grid"
-              hideHeader
-            />
+              <SongCupFeedMembersRow groupId={groupId} orbClubUrl={joinHref} />
+
+              <SongchainFeedSection
+                title={feedTitle}
+                description={feedDescription}
+                feedId={feedId}
+                graphId={graphId}
+                emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled."
+                layout="grid"
+                hideHeader
+                readOnly={!membership.isMember}
+                cardVariant="song-cup"
+              />
+            </>
           )}
         </div>
       </div>

--- a/components/songchain/song-cup/SongCupFeedPanel.tsx
+++ b/components/songchain/song-cup/SongCupFeedPanel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useSongchainGroupMembership } from "@/hooks/useSongchainGroupMembership";
+import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
+import { SongCupFeedCompose } from "./SongCupFeedCompose";
+import { SongCupFeedMembersRow } from "./SongCupFeedMembersRow";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils/utils";
+import { SONG_CUP_PLAY_LINKS } from "@/lib/songchain/events";
+
+type SongCupFeedPanelProps = {
+  feedId: string | null;
+  groupId: string | null;
+  graphId: string | null;
+  feedTitle?: string;
+  feedDescription?: string;
+  orbClubUrl?: string;
+};
+
+export function SongCupFeedPanel({
+  feedId,
+  groupId,
+  graphId,
+  feedTitle = "Song Cup club feed",
+  feedDescription = "Read the member feed. Join the club on Orb to post and react.",
+  orbClubUrl,
+}: SongCupFeedPanelProps) {
+  const membership = useSongchainGroupMembership({ groupId });
+
+  const joinHref = orbClubUrl ?? SONG_CUP_PLAY_LINKS.club;
+
+  return (
+    <div className="rounded-[20px] border border-[#dc2bb3] bg-black p-4 sm:p-5">
+      <div className="flex flex-col gap-4 sm:flex-row">
+        {/* Feed icon + gate copy column */}
+        <aside className="flex shrink-0 flex-col items-start gap-3 sm:w-[147px]">
+          <img
+            src="/songchain/button-icons/feed-icon.svg"
+            alt="The Feed"
+            className="h-[120px] w-[120px] object-contain"
+          />
+          <div className="space-y-1.5">
+            <p className="text-[10px] font-semibold uppercase leading-tight tracking-wide text-white">
+              FOR ORB MEMBERS ONLY
+            </p>
+            {membership.isMember ? (
+              <p className="text-[10px] font-semibold uppercase leading-tight tracking-wide text-white/70">
+                Joined
+              </p>
+            ) : (
+              <a
+                href={joinHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => {
+                  if (membership.canWrite) {
+                    e.preventDefault();
+                    void membership.join();
+                  }
+                }}
+                className={cn(
+                  "block text-[10px] font-semibold uppercase leading-tight tracking-wide text-white hover:text-[#fe01dc]",
+                  membership.joining && "pointer-events-none opacity-60",
+                )}
+              >
+                {membership.joining ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Joining…
+                  </span>
+                ) : (
+                  "JOIN ORB SONG CLUB"
+                )}
+              </a>
+            )}
+          </div>
+        </aside>
+
+        {/* Main column */}
+        <div className="flex flex-1 flex-col gap-4">
+          {membership.loading && (
+            <div className="flex h-24 items-center justify-center gap-2 text-sm text-white/70">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Checking club membership…
+            </div>
+          )}
+
+          {!membership.loading && membership.isMember && (
+            <SongCupFeedCompose feedId={feedId} />
+          )}
+
+          {!membership.loading && (
+            <SongCupFeedMembersRow groupId={groupId} orbClubUrl={joinHref} />
+          )}
+
+          {!membership.loading && membership.isMember && (
+            <SongchainFeedSection
+              title={feedTitle}
+              description={feedDescription}
+              feedId={feedId}
+              graphId={graphId}
+              emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled."
+              layout="grid"
+              hideHeader
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements Song Cup \u0022The Feed\u0022 panel from Figma node 140-1404.\n\n- New components: SongCupFeedPanel, SongCupFeedCompose, SongCupFeedMembersRow.\n- Updates SongchainFeedSection and SongchainPostCard with a song-cup variant.\n- Wires SongCupBottomSection to use the new feed panel.\n- Fixes pre-existing ESLint errors in packages/metokens/bancor and ignores generated public/sw.js / workbox files.\n\nVerification:\n- pnpm run lint: pass\n- npx tsc --noEmit: pass\n- pnpm run build: pass