### PR TITLE
Fix Song Cup Pinata agent chat via WebSocket gateway

### DIFF
--- a/app/api/song-cup/agent/chat/route.ts
+++ b/app/api/song-cup/agent/chat/route.ts
@@ -21,10 +21,15 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const ROUTING_CACHE_TTL_MS = 5 * 60 * 1000;
 let cachedRouting: {
+  cacheKey: string;
   baseUrl: string;
   gatewayToken: string;
   expiresAt: number;
 } | null = null;
+
+function buildRoutingCacheKey(config: ReturnType<typeof getSongCupAgentConfig>): string {
+  return config.agentId ?? config.baseUrl ?? "default";
+}
 
 function clearCachedRouting() {
   cachedRouting = null;
@@ -37,7 +42,12 @@ function chatAbortSignal(requestSignal?: AbortSignal): AbortSignal {
 
 async function resolveRuntimeRouting(config: ReturnType<typeof getSongCupAgentConfig>) {
   const now = Date.now();
-  if (cachedRouting && cachedRouting.expiresAt > now) {
+  const cacheKey = buildRoutingCacheKey(config);
+  if (
+    cachedRouting &&
+    cachedRouting.cacheKey === cacheKey &&
+    cachedRouting.expiresAt > now
+  ) {
     return cachedRouting;
   }
 
@@ -56,7 +66,12 @@ async function resolveRuntimeRouting(config: ReturnType<typeof getSongCupAgentCo
     // gateway.baseUrl points at pinclaw (WebSocket/internal); chat uses the public subdomain.
   }
 
-  cachedRouting = { baseUrl, gatewayToken, expiresAt: now + ROUTING_CACHE_TTL_MS };
+  cachedRouting = {
+    cacheKey,
+    baseUrl,
+    gatewayToken,
+    expiresAt: now + ROUTING_CACHE_TTL_MS,
+  };
   return cachedRouting;
 }
 

--- a/app/api/song-cup/agent/chat/route.ts
+++ b/app/api/song-cup/agent/chat/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { forwardPinataAgentChat } from "@/lib/pinata/chat";
+import {
+  approveAllPendingDevices,
+  ensureAgentRunning,
+  getGatewayToken,
+  PinataApiError,
+  restartAgent,
+} from "@/lib/pinata/api";
+import { mapSongCupAgentError } from "@/lib/pinata/errors";
 import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
 import { getSongCupAgentConfig } from "@/lib/songchain/song-cup/agent-config";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
@@ -10,6 +18,98 @@ interface AgentChatBody {
   session?: string;
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function resolveRuntimeRouting(config: ReturnType<typeof getSongCupAgentConfig>) {
+  let baseUrl = config.baseUrl!;
+  let gatewayToken = config.gatewayToken!;
+
+  if (config.managementJwt && config.agentId) {
+    await ensureAgentRunning(config.managementJwt, config.agentId);
+    try {
+      await approveAllPendingDevices(config.managementJwt, config.agentId);
+    } catch (err) {
+      serverLogger.warn("Song Cup agent device approve-all skipped:", err);
+    }
+    const gateway = await getGatewayToken(config.managementJwt, config.agentId);
+    gatewayToken = gateway.token;
+    // gateway.baseUrl points at pinclaw (WebSocket/internal); chat uses the public subdomain.
+  }
+
+  return { baseUrl, gatewayToken };
+}
+
+async function forwardWithRecovery(options: {
+  baseUrl: string;
+  gatewayToken: string;
+  message: string;
+  session?: string;
+  devicePrivateKeyPem?: string | null;
+  managementJwt?: string | null;
+  agentId?: string | null;
+}) {
+  const {
+    baseUrl,
+    gatewayToken,
+    message,
+    session,
+    devicePrivateKeyPem,
+    managementJwt,
+    agentId,
+  } = options;
+
+  const attempt = () =>
+    forwardPinataAgentChat({
+      baseUrl,
+      gatewayToken,
+      message,
+      session,
+      devicePrivateKeyPem,
+      signal: AbortSignal.timeout(60_000),
+    });
+
+  try {
+    return await attempt();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const isRetryable =
+      msg.toLowerCase().includes("pairing") ||
+      msg.toLowerCase().includes("missing scope") ||
+      msg.toLowerCase().includes("connect failed");
+
+    if (!isRetryable || !managementJwt || !agentId) {
+      throw err;
+    }
+
+    serverLogger.warn("Song Cup agent chat failed — restarting gateway and retrying");
+    await restartAgent(managementJwt, agentId);
+    await approveAllPendingDevices(managementJwt, agentId).catch((approveErr) => {
+      serverLogger.warn("Song Cup agent approve-all after restart failed:", approveErr);
+    });
+
+    const deadline = Date.now() + 20_000;
+    let lastErr: unknown = err;
+    while (Date.now() < deadline) {
+      await sleep(2_000);
+      try {
+        const gateway = await getGatewayToken(managementJwt, agentId);
+        return await forwardPinataAgentChat({
+          baseUrl,
+          gatewayToken: gateway.token,
+          message,
+          session,
+          devicePrivateKeyPem,
+          signal: AbortSignal.timeout(60_000),
+        });
+      } catch (retryErr) {
+        lastErr = retryErr;
+      }
+    }
+
+    throw lastErr;
+  }
+}
+
 export async function POST(request: NextRequest) {
   const botGuard = await requireHumanOrVerifiedBot("song-cup-agent-chat");
   if (!botGuard.allowed) return botGuard.response;
@@ -17,7 +117,15 @@ export async function POST(request: NextRequest) {
   const rl = await rateLimiters.standard(request);
   if (rl) return rl;
 
-  const { enabled, baseUrl, gatewayToken } = getSongCupAgentConfig();
+  const config = getSongCupAgentConfig();
+  const {
+    enabled,
+    baseUrl,
+    gatewayToken,
+    agentId,
+    managementJwt,
+    devicePrivateKeyPem,
+  } = config;
   if (!enabled || !baseUrl || !gatewayToken) {
     return NextResponse.json(
       {
@@ -59,12 +167,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await forwardPinataAgentChat({
-      baseUrl,
-      gatewayToken,
+    const routing = await resolveRuntimeRouting(config);
+
+    const result = await forwardWithRecovery({
+      baseUrl: routing.baseUrl,
+      gatewayToken: routing.gatewayToken,
       message,
       session: body.session,
-      signal: AbortSignal.timeout(30_000),
+      devicePrivateKeyPem,
+      managementJwt,
+      agentId,
     });
 
     return NextResponse.json({
@@ -74,7 +186,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (err) {
     serverLogger.error("Song Cup agent chat failed:", err);
-    const msg = err instanceof Error ? err.message : "Agent unreachable";
-    return NextResponse.json({ success: false, error: msg }, { status: 503 });
+    const error = mapSongCupAgentError(err);
+    return NextResponse.json({ success: false, error }, { status: 503 });
   }
 }

--- a/app/api/song-cup/agent/chat/route.ts
+++ b/app/api/song-cup/agent/chat/route.ts
@@ -4,7 +4,6 @@ import {
   approveAllPendingDevices,
   ensureAgentRunning,
   getGatewayToken,
-  PinataApiError,
   restartAgent,
 } from "@/lib/pinata/api";
 import { mapSongCupAgentError } from "@/lib/pinata/errors";
@@ -20,7 +19,28 @@ interface AgentChatBody {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const ROUTING_CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedRouting: {
+  baseUrl: string;
+  gatewayToken: string;
+  expiresAt: number;
+} | null = null;
+
+function clearCachedRouting() {
+  cachedRouting = null;
+}
+
+function chatAbortSignal(requestSignal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(60_000);
+  return requestSignal ? AbortSignal.any([requestSignal, timeout]) : timeout;
+}
+
 async function resolveRuntimeRouting(config: ReturnType<typeof getSongCupAgentConfig>) {
+  const now = Date.now();
+  if (cachedRouting && cachedRouting.expiresAt > now) {
+    return cachedRouting;
+  }
+
   let baseUrl = config.baseUrl!;
   let gatewayToken = config.gatewayToken!;
 
@@ -36,7 +56,8 @@ async function resolveRuntimeRouting(config: ReturnType<typeof getSongCupAgentCo
     // gateway.baseUrl points at pinclaw (WebSocket/internal); chat uses the public subdomain.
   }
 
-  return { baseUrl, gatewayToken };
+  cachedRouting = { baseUrl, gatewayToken, expiresAt: now + ROUTING_CACHE_TTL_MS };
+  return cachedRouting;
 }
 
 async function forwardWithRecovery(options: {
@@ -47,6 +68,7 @@ async function forwardWithRecovery(options: {
   devicePrivateKeyPem?: string | null;
   managementJwt?: string | null;
   agentId?: string | null;
+  signal?: AbortSignal;
 }) {
   const {
     baseUrl,
@@ -56,20 +78,21 @@ async function forwardWithRecovery(options: {
     devicePrivateKeyPem,
     managementJwt,
     agentId,
+    signal,
   } = options;
 
-  const attempt = () =>
+  const attempt = (token: string) =>
     forwardPinataAgentChat({
       baseUrl,
-      gatewayToken,
+      gatewayToken: token,
       message,
       session,
       devicePrivateKeyPem,
-      signal: AbortSignal.timeout(60_000),
+      signal: chatAbortSignal(signal),
     });
 
   try {
-    return await attempt();
+    return await attempt(gatewayToken);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const isRetryable =
@@ -81,6 +104,7 @@ async function forwardWithRecovery(options: {
       throw err;
     }
 
+    clearCachedRouting();
     serverLogger.warn("Song Cup agent chat failed — restarting gateway and retrying");
     await restartAgent(managementJwt, agentId);
     await approveAllPendingDevices(managementJwt, agentId).catch((approveErr) => {
@@ -90,17 +114,13 @@ async function forwardWithRecovery(options: {
     const deadline = Date.now() + 20_000;
     let lastErr: unknown = err;
     while (Date.now() < deadline) {
+      if (signal?.aborted) {
+        throw new Error("Pinata agent chat timed out or was aborted");
+      }
       await sleep(2_000);
       try {
         const gateway = await getGatewayToken(managementJwt, agentId);
-        return await forwardPinataAgentChat({
-          baseUrl,
-          gatewayToken: gateway.token,
-          message,
-          session,
-          devicePrivateKeyPem,
-          signal: AbortSignal.timeout(60_000),
-        });
+        return await attempt(gateway.token);
       } catch (retryErr) {
         lastErr = retryErr;
       }
@@ -177,6 +197,7 @@ export async function POST(request: NextRequest) {
       devicePrivateKeyPem,
       managementJwt,
       agentId,
+      signal: request.signal,
     });
 
     return NextResponse.json({

--- a/app/api/song-cup/agent/health/route.ts
+++ b/app/api/song-cup/agent/health/route.ts
@@ -3,6 +3,7 @@ import {
   getAgentDetailsResponse,
   PinataApiError,
   resolveAgentRuntimeStatus,
+  resolvePinataAgentGatewayWsUrl,
 } from "@/lib/pinata/api";
 import { getSongCupAgentConfig } from "@/lib/songchain/song-cup/agent-config";
 
@@ -51,7 +52,7 @@ export async function GET() {
     agentId,
     baseUrl,
     chatTransport: "websocket",
-    chatPath: "wss://{agentId}.agents.pinata.cloud/chat",
+    chatPath: agentId ? resolvePinataAgentGatewayWsUrl(agentId) : null,
     hasManagementJwt: Boolean(managementJwt),
     hasDeviceKey: Boolean(devicePrivateKeyPem),
     processStatus,

--- a/app/api/song-cup/agent/health/route.ts
+++ b/app/api/song-cup/agent/health/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import {
+  getAgentDetailsResponse,
+  PinataApiError,
+  resolveAgentRuntimeStatus,
+} from "@/lib/pinata/api";
+import { getSongCupAgentConfig } from "@/lib/songchain/song-cup/agent-config";
+
+export async function GET() {
+  const config = getSongCupAgentConfig();
+  const {
+    enabled,
+    agentId,
+    baseUrl,
+    gatewayToken,
+    managementJwt,
+    devicePrivateKeyPem,
+  } = config;
+
+  if (!enabled || !baseUrl || !gatewayToken) {
+    return NextResponse.json({
+      success: true,
+      configured: false,
+      chatTransport: "websocket",
+      hint: "Set SONG_CUP_PINATA_AGENT_ID and SONG_CUP_PINATA_GATEWAY_TOKEN.",
+    });
+  }
+
+  let processStatus: string | null = null;
+  let managementOk = false;
+  let managementError: string | null = null;
+
+  if (managementJwt && agentId) {
+    try {
+      const details = await getAgentDetailsResponse(managementJwt, agentId);
+      processStatus = resolveAgentRuntimeStatus(details);
+      managementOk = true;
+    } catch (err) {
+      managementError =
+        err instanceof PinataApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "management API error";
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    configured: true,
+    agentId,
+    baseUrl,
+    chatTransport: "websocket",
+    chatPath: "wss://{agentId}.agents.pinata.cloud/chat",
+    hasManagementJwt: Boolean(managementJwt),
+    hasDeviceKey: Boolean(devicePrivateKeyPem),
+    processStatus,
+    managementOk,
+    managementError,
+  });
+}

--- a/app/api/twin/chat/route.ts
+++ b/app/api/twin/chat/route.ts
@@ -124,7 +124,9 @@ export async function POST(request: NextRequest) {
         gatewayToken: routing.gatewayToken,
         message,
         session,
-        signal: AbortSignal.timeout(60_000),
+        signal: request.signal
+          ? AbortSignal.any([request.signal, AbortSignal.timeout(60_000)])
+          : AbortSignal.timeout(60_000),
       });
       return NextResponse.json({ success: true, reply: result.reply || "(no reply)" });
     } catch (err) {

--- a/app/api/twin/chat/route.ts
+++ b/app/api/twin/chat/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/sdk/supabase/server";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { forwardPinataAgentChat } from "@/lib/pinata/chat";
+import { resolveServerDevicePrivateKeyPem } from "@/lib/pinata/device-identity";
 
 interface TwinChatBody {
   creatorAddress?: string;
@@ -124,6 +125,7 @@ export async function POST(request: NextRequest) {
         gatewayToken: routing.gatewayToken,
         message,
         session,
+        devicePrivateKeyPem: resolveServerDevicePrivateKeyPem(),
         signal: request.signal
           ? AbortSignal.any([request.signal, AbortSignal.timeout(60_000)])
           : AbortSignal.timeout(60_000),

--- a/app/api/twin/chat/route.ts
+++ b/app/api/twin/chat/route.ts
@@ -3,6 +3,7 @@ import { supabaseService } from "@/lib/sdk/supabase/service";
 import { createClient } from "@/lib/sdk/supabase/server";
 import { serverLogger } from "@/lib/utils/logger";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { forwardPinataAgentChat } from "@/lib/pinata/chat";
 
 interface TwinChatBody {
   creatorAddress?: string;
@@ -49,8 +50,7 @@ async function loadRouting(creatorAddress: string): Promise<TwinRouting | null> 
 
 /**
  * Walk a JSONL response and concatenate the text from every `content_delta`
- * event. Other event types (tool_use_start, thinking_delta, etc.) are
- * intentionally dropped — the viewer chat panel only renders the reply text.
+ * event. Kept for legacy HTTP endpoints; Pinata agents use WebSocket chat.
  */
 function extractReplyFromJsonl(body: string): string {
   const lines = body.split("\n");
@@ -115,7 +115,24 @@ export async function POST(request: NextRequest) {
 
   const url = routing.legacyEndpoint
     ? routing.legacyEndpoint
-    : `${routing.baseUrl}/chat`;
+    : routing.baseUrl;
+
+  if (!routing.legacyEndpoint && routing.gatewayToken) {
+    try {
+      const result = await forwardPinataAgentChat({
+        baseUrl: routing.baseUrl,
+        gatewayToken: routing.gatewayToken,
+        message,
+        session,
+        signal: AbortSignal.timeout(60_000),
+      });
+      return NextResponse.json({ success: true, reply: result.reply || "(no reply)" });
+    } catch (err) {
+      serverLogger.error("Twin gateway chat failed:", err);
+      const msg = err instanceof Error ? err.message : "Twin endpoint unreachable";
+      return NextResponse.json({ success: false, error: msg }, { status: 503 });
+    }
+  }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/app/api/twin/chat/route.ts
+++ b/app/api/twin/chat/route.ts
@@ -128,7 +128,11 @@ export async function POST(request: NextRequest) {
           ? AbortSignal.any([request.signal, AbortSignal.timeout(60_000)])
           : AbortSignal.timeout(60_000),
       });
-      return NextResponse.json({ success: true, reply: result.reply || "(no reply)" });
+      return NextResponse.json({
+        success: true,
+        reply: result.reply || "(no reply)",
+        ...(result.session ? { session: result.session } : {}),
+      });
     } catch (err) {
       serverLogger.error("Twin gateway chat failed:", err);
       const msg = err instanceof Error ? err.message : "Twin endpoint unreachable";

--- a/app/api/twin/connect/route.ts
+++ b/app/api/twin/connect/route.ts
@@ -8,6 +8,8 @@ import {
   getAgentDetails,
   getGatewayToken,
   PinataApiError,
+  resolvePinataAgentGatewayWsUrl,
+  resolvePinataAgentPublicBaseUrl,
 } from "@/lib/pinata/api";
 import { requireWalletAuthFor, WalletAuthError } from "@/lib/auth/require-wallet";
 
@@ -99,14 +101,17 @@ export async function POST(request: NextRequest) {
     !!agent.snapshotCid &&
     template.snapshotCid === agent.snapshotCid;
 
+  const publicBaseUrl = resolvePinataAgentPublicBaseUrl(agentId);
+  const wsUrl = resolvePinataAgentGatewayWsUrl(agentId);
+
   const supabase = supabaseService ?? (await createClient());
   const payload = {
     owner_address: ownerAddress.toLowerCase(),
     twin_enabled: true,
     twin_pinata_agent_id: agentId,
     twin_pinata_gateway_token: gateway.token,
-    twin_pinata_base_url: gateway.baseUrl,
-    twin_pinata_ws_url: gateway.wsUrl,
+    twin_pinata_base_url: publicBaseUrl,
+    twin_pinata_ws_url: wsUrl,
     twin_pinata_snapshot_cid: agent.snapshotCid,
     twin_pinata_agent_name: agent.name,
     twin_pinata_connected_at: new Date().toISOString(),
@@ -130,7 +135,7 @@ export async function POST(request: NextRequest) {
     verified,
     agentName: agent.name,
     agentStatus: agent.status,
-    baseUrl: gateway.baseUrl,
-    wsUrl: gateway.wsUrl,
+    baseUrl: publicBaseUrl,
+    wsUrl,
   });
 }

--- a/env.example
+++ b/env.example
@@ -62,10 +62,16 @@ NEXT_PUBLIC_SONG_CUP_GRAPH_ID=0x51f4905F86402Bcfa015b445f73E3dEfF995a279
 # SONG_CUP_GRAPH_ID=
 
 # Song Cup Pinata agent (hero search bar on /songchain/song-cup)
+# Chat uses WebSocket (wss://{agentId}.agents.pinata.cloud/chat), same as `pinata agents chat`.
 # Gateway token: agent Danger page or GET /v0/agents/{agentId}/gateway-token (Pinata JWT).
+# PINATA_JWT (server-only) refreshes gateway token, restarts stopped agents, and auto-approves device pairing.
+# SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM: stable Ed25519 PKCS#8 PEM so Vercel can reconnect without re-pairing each cold start.
+# Generate once: node -e "const c=require('crypto');const {privateKey}=c.generateKeyPairSync('ed25519');console.log(privateKey.export({type:'pkcs8',format:'pem'}))"
 SONG_CUP_PINATA_AGENT_ID=xoqb797x
 # SONG_CUP_PINATA_BASE_URL=https://xoqb797x.agents.pinata.cloud
 # SONG_CUP_PINATA_GATEWAY_TOKEN=
+# PINATA_JWT=
+# SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM=
 
 # Song Cup Predict — Orb event games API (server-only)
 # Set ORB_EVENT_GAMES_MOCK=true for local dev with bundled fixture data.

--- a/env.example
+++ b/env.example
@@ -66,12 +66,14 @@ NEXT_PUBLIC_SONG_CUP_GRAPH_ID=0x51f4905F86402Bcfa015b445f73E3dEfF995a279
 # Gateway token: agent Danger page or GET /v0/agents/{agentId}/gateway-token (Pinata JWT).
 # PINATA_JWT (server-only) refreshes gateway token, restarts stopped agents, and auto-approves device pairing.
 # SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM: stable Ed25519 PKCS#8 PEM so Vercel can reconnect without re-pairing each cold start.
+# PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM: shared server key for twin chat (falls back to SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM).
 # Generate once: node -e "const c=require('crypto');const {privateKey}=c.generateKeyPairSync('ed25519');console.log(privateKey.export({type:'pkcs8',format:'pem'}))"
 SONG_CUP_PINATA_AGENT_ID=xoqb797x
 # SONG_CUP_PINATA_BASE_URL=https://xoqb797x.agents.pinata.cloud
 # SONG_CUP_PINATA_GATEWAY_TOKEN=
 # PINATA_JWT=
 # SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM=
+# PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM=
 
 # Song Cup Predict — Orb event games API (server-only)
 # Set ORB_EVENT_GAMES_MOCK=true for local dev with bundled fixture data.

--- a/lib/pinata/api.ts
+++ b/lib/pinata/api.ts
@@ -18,6 +18,8 @@
 
 const PINATA_AGENTS_BASE = "https://agents.pinata.cloud";
 
+export const PINATA_AGENT_HOST_SUFFIX = ".agents.pinata.cloud";
+
 export const CREATIVE_TWIN_TEMPLATE_SLUG = "creative-ai-digital-twin";
 
 /**
@@ -56,6 +58,13 @@ export interface PinataAgent {
   status: "starting" | "running" | "not_running" | string;
 }
 
+export type PinataProcessStatus = "starting" | "running" | "not_running" | string;
+
+export interface PinataAgentDetailsResponse {
+  agent: PinataAgent;
+  processStatus?: PinataProcessStatus;
+}
+
 export interface PinataGatewayToken {
   token: string;
   wsUrl: string;
@@ -73,7 +82,7 @@ type PinataFetchInit = Parameters<typeof fetch>[1] & { jwt?: string };
 
 async function pinataFetch<T>(
   path: string,
-  init: PinataFetchInit = {}
+  init: PinataFetchInit = {},
 ): Promise<T> {
   const { jwt, headers, ...rest } = init;
   const res = await fetch(`${PINATA_AGENTS_BASE}${path}`, {
@@ -88,10 +97,28 @@ async function pinataFetch<T>(
     const body = await res.text().catch(() => "");
     throw new PinataApiError(
       res.status,
-      `Pinata API ${path} → ${res.status}${body ? `: ${body.slice(0, 300)}` : ""}`
+      `Pinata API ${path} → ${res.status}${body ? `: ${body.slice(0, 300)}` : ""}`,
     );
   }
   return (await res.json()) as T;
+}
+
+export function resolvePinataAgentPublicBaseUrl(agentId: string): string {
+  return `https://${agentId}${PINATA_AGENT_HOST_SUFFIX}`;
+}
+
+export function resolvePinataAgentGatewayWsUrl(agentId: string): string {
+  return `wss://${agentId}${PINATA_AGENT_HOST_SUFFIX}/chat`;
+}
+
+export function resolveAgentRuntimeStatus(
+  details: PinataAgentDetailsResponse,
+): PinataProcessStatus {
+  return details.processStatus ?? details.agent.status ?? "unknown";
+}
+
+export function isAgentRuntimeRunning(status: PinataProcessStatus): boolean {
+  return status === "running";
 }
 
 /**
@@ -107,7 +134,7 @@ export async function listPublicTemplates(): Promise<PinataTemplate[]> {
     return templateCache.value;
   }
   const data = await pinataFetch<{ templates: PinataTemplate[] }>(
-    "/v0/public-templates"
+    "/v0/public-templates",
   );
   templateCache = { value: data.templates ?? [], expiresAt: now + TEMPLATE_TTL_MS };
   return templateCache.value;
@@ -118,31 +145,99 @@ export async function findCreativeTwinTemplate(): Promise<PinataTemplate | null>
   return all.find((t) => t.slug === CREATIVE_TWIN_TEMPLATE_SLUG) ?? null;
 }
 
-export async function getAgentDetails(
+export async function getAgentDetailsResponse(
   jwt: string,
-  agentId: string
-): Promise<PinataAgent> {
+  agentId: string,
+): Promise<PinataAgentDetailsResponse> {
   if (!jwt) throw new Error("Pinata JWT is required");
   if (!agentId) throw new Error("agentId is required");
-  const data = await pinataFetch<{ agent: PinataAgent }>(
+  const data = await pinataFetch<PinataAgentDetailsResponse>(
     `/v0/agents/${encodeURIComponent(agentId)}`,
-    { jwt, method: "GET" }
+    { jwt, method: "GET" },
   );
   if (!data?.agent) {
     throw new Error("Pinata returned no agent for that id");
   }
+  return data;
+}
+
+export async function getAgentDetails(
+  jwt: string,
+  agentId: string,
+): Promise<PinataAgent> {
+  const data = await getAgentDetailsResponse(jwt, agentId);
   return data.agent;
 }
 
 export async function getGatewayToken(
   jwt: string,
-  agentId: string
+  agentId: string,
 ): Promise<PinataGatewayToken> {
   if (!jwt) throw new Error("Pinata JWT is required");
   if (!agentId) throw new Error("agentId is required");
   return pinataFetch<PinataGatewayToken>(
     `/v0/agents/${encodeURIComponent(agentId)}/gateway-token`,
-    { jwt, method: "GET" }
+    { jwt, method: "GET" },
+  );
+}
+
+export async function restartAgent(
+  jwt: string,
+  agentId: string,
+): Promise<void> {
+  if (!jwt) throw new Error("Pinata JWT is required");
+  if (!agentId) throw new Error("agentId is required");
+  await pinataFetch<unknown>(
+    `/v0/agents/${encodeURIComponent(agentId)}/restart`,
+    { jwt, method: "POST" },
+  );
+}
+
+export async function approveAllPendingDevices(
+  jwt: string,
+  agentId: string,
+): Promise<void> {
+  if (!jwt) throw new Error("Pinata JWT is required");
+  if (!agentId) throw new Error("agentId is required");
+  await pinataFetch<unknown>(
+    `/v0/agents/${encodeURIComponent(agentId)}/devices/approve-all`,
+    { jwt, method: "POST" },
+  );
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Ensure the agent gateway is running before forwarding chat. Restarts stopped
+ * agents and waits briefly for the OpenClaw gateway handler to come up.
+ */
+export async function ensureAgentRunning(
+  jwt: string,
+  agentId: string,
+  options: { maxWaitMs?: number } = {},
+): Promise<PinataAgentDetailsResponse> {
+  const maxWaitMs = options.maxWaitMs ?? 20_000;
+  let details = await getAgentDetailsResponse(jwt, agentId);
+  let status = resolveAgentRuntimeStatus(details);
+
+  if (isAgentRuntimeRunning(status)) {
+    return details;
+  }
+
+  await restartAgent(jwt, agentId);
+
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    await sleep(1_500);
+    details = await getAgentDetailsResponse(jwt, agentId);
+    status = resolveAgentRuntimeStatus(details);
+    if (isAgentRuntimeRunning(status)) {
+      return details;
+    }
+  }
+
+  throw new Error(
+    `Pinata agent is ${status}. Start or restart it in the Pinata dashboard (Danger → Restart Gateway), then try again.`,
   );
 }
 

--- a/lib/pinata/chat.ts
+++ b/lib/pinata/chat.ts
@@ -1,6 +1,13 @@
 /**
- * Shared helpers for Pinata agent chat (JSONL streaming responses).
+ * Pinata agent chat — OpenClaw gateway over WebSocket (same path as `pinata agents chat`).
+ * Bare HTTP POST /chat is not available on Pinata agent subdomains.
  */
+
+import {
+  gatewayWebSocketChat,
+  resolveGatewayChatWsUrl,
+  type GatewayChatResult,
+} from "@/lib/pinata/gateway-ws";
 
 export function extractReplyFromJsonl(body: string): string {
   const lines = body.split("\n");
@@ -23,68 +30,49 @@ export function extractReplyFromJsonl(body: string): string {
   return parts.join("");
 }
 
-export type PinataChatResult = {
-  reply: string;
-  session?: string;
-};
+export type PinataChatResult = GatewayChatResult;
 
 export async function forwardPinataAgentChat(options: {
   baseUrl: string;
   gatewayToken: string;
   message: string;
   session?: string;
+  devicePrivateKeyPem?: string | null;
   signal?: AbortSignal;
+  timeoutMs?: number;
 }): Promise<PinataChatResult> {
-  const { baseUrl, gatewayToken, message, session, signal } = options;
-  const url = `${baseUrl.replace(/\/+$/, "")}/chat`;
-
-  const upstream = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${gatewayToken}`,
-    },
-    body: JSON.stringify({
-      message,
-      ...(session ? { session } : {}),
-    }),
+  const {
+    baseUrl,
+    gatewayToken,
+    message,
+    session,
+    devicePrivateKeyPem,
     signal,
-  });
+    timeoutMs,
+  } = options;
 
-  if (!upstream.ok) {
-    const text = await upstream.text().catch(() => "");
-    throw new Error(
-      `Pinata agent returned ${upstream.status}${text ? `: ${text.slice(0, 300)}` : ""}`,
-    );
-  }
+  const wsUrl = resolveGatewayChatWsUrl(baseUrl, gatewayToken);
 
-  const contentType = upstream.headers.get("content-type") || "";
-  const raw = await upstream.text();
-
-  if (
-    contentType.includes("ndjson") ||
-    contentType.includes("event-stream") ||
-    /\n\s*\{/.test(raw)
-  ) {
-    return { reply: extractReplyFromJsonl(raw) };
-  }
-
-  if (contentType.includes("application/json")) {
-    try {
-      const json = JSON.parse(raw) as {
-        reply?: string;
-        message?: string;
-        content?: string;
-        session?: string;
-      };
-      return {
-        reply: json.reply ?? json.message ?? json.content ?? "",
-        session: json.session,
-      };
-    } catch {
-      return { reply: raw };
+  try {
+    return await gatewayWebSocketChat({
+      wsUrl,
+      gatewayToken,
+      message,
+      session,
+      devicePrivateKeyPem,
+      signal,
+      timeoutMs: timeoutMs ?? 60_000,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.toLowerCase().includes("missing scope")) {
+      throw new Error(
+        `${msg} The gateway token connected but lacks write scope — approve the server device in Pinata (Danger → Devices) or refresh SONG_CUP_PINATA_GATEWAY_TOKEN.`,
+      );
     }
+    if (msg.toLowerCase().includes("pairing")) {
+      throw new Error(msg);
+    }
+    throw err instanceof Error ? err : new Error(msg);
   }
-
-  return { reply: raw };
 }

--- a/lib/pinata/device-identity.ts
+++ b/lib/pinata/device-identity.ts
@@ -10,11 +10,7 @@ export type PinataDeviceIdentity = {
 };
 
 function base64UrlEncode(buf: Buffer): string {
-  return buf
-    .toString("base64")
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replace(/=+$/g, "");
+  return buf.toString("base64url");
 }
 
 function derivePublicKeyRaw(publicKeyPem: string): Buffer {

--- a/lib/pinata/device-identity.ts
+++ b/lib/pinata/device-identity.ts
@@ -118,3 +118,17 @@ export function resolveDeviceIdentity(
   }
   return generateDeviceIdentity();
 }
+
+/** Stable server-side Ed25519 PEM for gateway pairing (shared across Pinata agents). */
+export function resolveServerDevicePrivateKeyPem(
+  preferred?: string | null,
+): string | null {
+  const explicit = preferred?.trim();
+  if (explicit) return explicit;
+  return (
+    process.env.PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM?.trim() ||
+    process.env.SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM?.trim() ||
+    process.env.PINATA_TWIN_DEVICE_PRIVATE_KEY_PEM?.trim() ||
+    null
+  );
+}

--- a/lib/pinata/device-identity.ts
+++ b/lib/pinata/device-identity.ts
@@ -1,0 +1,124 @@
+import crypto from "node:crypto";
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+export type PinataDeviceIdentity = {
+  deviceId: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+  publicKeyRawBase64Url: string;
+};
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/g, "");
+}
+
+function derivePublicKeyRaw(publicKeyPem: string): Buffer {
+  const spki = crypto
+    .createPublicKey(publicKeyPem)
+    .export({ type: "spki", format: "der" }) as Buffer;
+  if (
+    spki.length === ED25519_SPKI_PREFIX.length + 32 &&
+    spki.subarray(0, ED25519_SPKI_PREFIX.length).equals(ED25519_SPKI_PREFIX)
+  ) {
+    return spki.subarray(ED25519_SPKI_PREFIX.length);
+  }
+  return spki;
+}
+
+export function normalizeDeviceMetadataForAuth(value?: string | null): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/[A-Z]/g, (char) =>
+    String.fromCharCode(char.charCodeAt(0) + 32),
+  );
+}
+
+export function buildDeviceAuthPayloadV3(params: {
+  deviceId: string;
+  clientId: string;
+  clientMode: string;
+  role: string;
+  scopes: string[];
+  signedAtMs: number;
+  token?: string | null;
+  nonce: string;
+  platform?: string | null;
+  deviceFamily?: string | null;
+}): string {
+  const scopes = params.scopes.join(",");
+  const token = params.token ?? "";
+  return [
+    "v3",
+    params.deviceId,
+    params.clientId,
+    params.clientMode,
+    params.role,
+    scopes,
+    String(params.signedAtMs),
+    token,
+    params.nonce,
+    normalizeDeviceMetadataForAuth(params.platform),
+    normalizeDeviceMetadataForAuth(params.deviceFamily),
+  ].join("|");
+}
+
+export function signDevicePayload(
+  privateKeyPem: string,
+  payload: string,
+): string {
+  const sig = crypto.sign(
+    null,
+    Buffer.from(payload, "utf8"),
+    crypto.createPrivateKey(privateKeyPem),
+  );
+  return base64UrlEncode(sig);
+}
+
+export function generateDeviceIdentity(): PinataDeviceIdentity {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  const raw = derivePublicKeyRaw(publicKeyPem);
+  const deviceId = crypto.createHash("sha256").update(raw).digest("hex");
+  return {
+    deviceId,
+    publicKeyPem,
+    privateKeyPem,
+    publicKeyRawBase64Url: base64UrlEncode(raw),
+  };
+}
+
+export function loadDeviceIdentityFromPrivateKeyPem(
+  privateKeyPem: string,
+): PinataDeviceIdentity {
+  const privateKey = crypto.createPrivateKey(privateKeyPem.trim());
+  const publicKey = crypto.createPublicKey(privateKey);
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+  const normalizedPrivateKeyPem = privateKey.export({
+    type: "pkcs8",
+    format: "pem",
+  }) as string;
+  const raw = derivePublicKeyRaw(publicKeyPem);
+  const deviceId = crypto.createHash("sha256").update(raw).digest("hex");
+  return {
+    deviceId,
+    publicKeyPem,
+    privateKeyPem: normalizedPrivateKeyPem,
+    publicKeyRawBase64Url: base64UrlEncode(raw),
+  };
+}
+
+export function resolveDeviceIdentity(
+  privateKeyPem?: string | null,
+): PinataDeviceIdentity {
+  if (privateKeyPem?.trim()) {
+    return loadDeviceIdentityFromPrivateKeyPem(privateKeyPem);
+  }
+  return generateDeviceIdentity();
+}

--- a/lib/pinata/errors.ts
+++ b/lib/pinata/errors.ts
@@ -16,7 +16,7 @@ export function mapSongCupAgentError(err: unknown): string {
 
   const msg = err instanceof Error ? err.message : "Agent unreachable";
 
-  if (msg.includes("Pinata agent chat timed out")) {
+  if (msg.toLowerCase().includes("pinata agent chat timed out")) {
     return `${msg} The agent may still be starting — try again in a few seconds.`;
   }
 

--- a/lib/pinata/errors.ts
+++ b/lib/pinata/errors.ts
@@ -1,0 +1,32 @@
+import { PinataApiError } from "@/lib/pinata/api";
+
+export function mapSongCupAgentError(err: unknown): string {
+  if (err instanceof PinataApiError) {
+    if (err.status === 401) {
+      return "Pinata JWT was rejected. Regenerate your API key and update PINATA_JWT on Vercel.";
+    }
+    if (err.status === 503) {
+      return "Pinata management API is unavailable. Copy a fresh gateway token from the agent Danger tab into SONG_CUP_PINATA_GATEWAY_TOKEN, then redeploy.";
+    }
+    if (err.status === 404) {
+      return "Song Cup Pinata agent was not found. Check SONG_CUP_PINATA_AGENT_ID and your Pinata account.";
+    }
+    return err.message;
+  }
+
+  const msg = err instanceof Error ? err.message : "Agent unreachable";
+
+  if (msg.includes("Pinata agent chat timed out")) {
+    return `${msg} The agent may still be starting — try again in a few seconds.`;
+  }
+
+  if (msg.toLowerCase().includes("pairing")) {
+    return msg;
+  }
+
+  if (msg.toLowerCase().includes("missing scope")) {
+    return msg;
+  }
+
+  return msg;
+}

--- a/lib/pinata/gateway-ws.ts
+++ b/lib/pinata/gateway-ws.ts
@@ -76,6 +76,23 @@ function parsePairingRequestId(error: GatewayFrame["error"]): string | null {
   return match?.[1] ?? null;
 }
 
+function resolveSessionFromChatPayload(
+  payload: Record<string, unknown>,
+  fallback: string,
+): string {
+  for (const key of ["session", "sessionKey", "session_key"] as const) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return fallback;
+}
+
+function isChatMessageComplete(payload: Record<string, unknown>): boolean {
+  return payload.done === true || payload.finished === true;
+}
+
 function isPairingRequired(error: GatewayFrame["error"]): boolean {
   if (!error) return false;
   const code = (error.code ?? "").toUpperCase();
@@ -283,10 +300,10 @@ async function connectAndChat(options: {
           const delta = payload.delta as { text?: string } | undefined;
           if (typeof delta?.text === "string") parts.push(delta.text);
         }
-        if (type === "message" && payload.done) {
+        if (type === "message" && isChatMessageComplete(payload)) {
           finish(undefined, {
             reply: parts.join("") || "(no reply)",
-            session,
+            session: resolveSessionFromChatPayload(payload, session),
           });
         }
       }

--- a/lib/pinata/gateway-ws.ts
+++ b/lib/pinata/gateway-ws.ts
@@ -106,6 +106,15 @@ async function connectAndChat(options: {
   } = options;
 
   return new Promise((resolve, reject) => {
+    if (typeof WebSocket === "undefined") {
+      reject(
+        new Error(
+          "WebSocket is not defined in this environment. Upgrade to Node.js 22+ or polyfill globalThis.WebSocket.",
+        ),
+      );
+      return;
+    }
+
     const ws = new WebSocket(wsUrl);
 
     let settled = false;
@@ -142,10 +151,21 @@ async function connectAndChat(options: {
       finish(new Error("Pinata gateway WebSocket connection failed"));
     });
 
+    ws.addEventListener("close", (event) => {
+      if (settled) return;
+      finish(
+        new Error(
+          `Pinata gateway WebSocket connection closed (code: ${event.code}${event.reason ? `: ${event.reason}` : ""})`,
+        ),
+      );
+    });
+
     ws.addEventListener("message", (event) => {
       let frame: GatewayFrame;
       try {
-        frame = JSON.parse(String(event.data)) as GatewayFrame;
+        const parsed: unknown = JSON.parse(String(event.data));
+        if (!parsed || typeof parsed !== "object") return;
+        frame = parsed as GatewayFrame;
       } catch {
         return;
       }

--- a/lib/pinata/gateway-ws.ts
+++ b/lib/pinata/gateway-ws.ts
@@ -3,6 +3,7 @@
  * HTTP POST {baseUrl}/chat is not exposed on Pinata agents; chat is WS-only.
  */
 
+import crypto from "node:crypto";
 import {
   buildDeviceAuthPayloadV3,
   resolveDeviceIdentity,
@@ -252,7 +253,11 @@ async function connectAndChat(options: {
             type: "req",
             id: chatReqId,
             method: "chat.send",
-            params: { sessionKey: session, message },
+            params: {
+              sessionKey: session,
+              message,
+              idempotencyKey: crypto.randomUUID(),
+            },
           }),
         );
         return;

--- a/lib/pinata/gateway-ws.ts
+++ b/lib/pinata/gateway-ws.ts
@@ -1,0 +1,303 @@
+/**
+ * OpenClaw gateway chat over WebSocket (Pinata CLI uses the same transport).
+ * HTTP POST {baseUrl}/chat is not exposed on Pinata agents; chat is WS-only.
+ */
+
+import {
+  buildDeviceAuthPayloadV3,
+  resolveDeviceIdentity,
+  signDevicePayload,
+  type PinataDeviceIdentity,
+} from "@/lib/pinata/device-identity";
+
+export const GATEWAY_CLIENT_ID = "gateway-client";
+export const GATEWAY_CLIENT_MODE = "backend";
+export const GATEWAY_OPERATOR_SCOPES = [
+  "operator.read",
+  "operator.write",
+] as const;
+
+const PROTOCOL_VERSION = 3;
+const DEFAULT_SESSION = "agent:main:song-cup";
+
+type GatewayFrame = {
+  type?: string;
+  id?: string;
+  event?: string;
+  ok?: boolean;
+  error?: {
+    code?: string;
+    message?: string;
+    details?: Record<string, unknown>;
+  };
+  payload?: Record<string, unknown>;
+};
+
+export type GatewayChatOptions = {
+  /** e.g. wss://{agentId}.agents.pinata.cloud/chat */
+  wsUrl: string;
+  gatewayToken: string;
+  message: string;
+  session?: string;
+  devicePrivateKeyPem?: string | null;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type GatewayChatResult = {
+  reply: string;
+  session?: string;
+};
+
+function buildWsUrl(baseUrl: string, gatewayToken: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  const wsBase = trimmed.replace(/^https:/i, "wss:").replace(/^http:/i, "ws:");
+  const url = new URL(`${wsBase}/chat`);
+  url.searchParams.set("token", gatewayToken);
+  return url.toString();
+}
+
+export function resolveGatewayChatWsUrl(
+  baseUrl: string,
+  gatewayToken: string,
+): string {
+  return buildWsUrl(baseUrl, gatewayToken);
+}
+
+function parsePairingRequestId(error: GatewayFrame["error"]): string | null {
+  if (!error) return null;
+  const details = error.details;
+  const fromDetails =
+    typeof details?.requestId === "string" ? details.requestId : null;
+  if (fromDetails) return fromDetails;
+  const msg = error.message ?? "";
+  const match = msg.match(/requestId[=:\s]+([a-zA-Z0-9-]+)/i);
+  return match?.[1] ?? null;
+}
+
+function isPairingRequired(error: GatewayFrame["error"]): boolean {
+  if (!error) return false;
+  const code = (error.code ?? "").toUpperCase();
+  const msg = (error.message ?? "").toLowerCase();
+  return (
+    code.includes("PAIR") ||
+    msg.includes("pairing required") ||
+    msg.includes("pair required")
+  );
+}
+
+async function connectAndChat(options: {
+  wsUrl: string;
+  gatewayToken: string;
+  message: string;
+  session: string;
+  deviceIdentity: PinataDeviceIdentity;
+  signal?: AbortSignal;
+  timeoutMs: number;
+}): Promise<GatewayChatResult> {
+  const {
+    wsUrl,
+    gatewayToken,
+    message,
+    session,
+    deviceIdentity,
+    signal,
+    timeoutMs,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+
+    let settled = false;
+    const parts: string[] = [];
+    let reqId = 1;
+    let connectReqId: string | null = null;
+    let chatReqId: string | null = null;
+
+    const finish = (err?: Error, result?: GatewayChatResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      if (err) reject(err);
+      else resolve(result ?? { reply: parts.join("") || "(no reply)", session });
+    };
+
+    const onAbort = () => {
+      finish(new Error("Pinata agent chat timed out or was aborted"));
+    };
+
+    const timer = setTimeout(() => {
+      finish(new Error(`Pinata agent chat timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    signal?.addEventListener("abort", onAbort);
+
+    ws.addEventListener("error", () => {
+      finish(new Error("Pinata gateway WebSocket connection failed"));
+    });
+
+    ws.addEventListener("message", (event) => {
+      let frame: GatewayFrame;
+      try {
+        frame = JSON.parse(String(event.data)) as GatewayFrame;
+      } catch {
+        return;
+      }
+
+      if (frame.event === "connect.challenge") {
+        const nonce =
+          typeof frame.payload?.nonce === "string" ? frame.payload.nonce : "";
+        if (!nonce) {
+          finish(new Error("Pinata gateway connect challenge missing nonce"));
+          return;
+        }
+
+        const signedAtMs = Date.now();
+        const scopes = [...GATEWAY_OPERATOR_SCOPES];
+        const authPayload = buildDeviceAuthPayloadV3({
+          deviceId: deviceIdentity.deviceId,
+          clientId: GATEWAY_CLIENT_ID,
+          clientMode: GATEWAY_CLIENT_MODE,
+          role: "operator",
+          scopes,
+          signedAtMs,
+          token: gatewayToken,
+          nonce,
+          platform: process.platform,
+          deviceFamily: null,
+        });
+
+        connectReqId = String(reqId++);
+        ws.send(
+          JSON.stringify({
+            type: "req",
+            id: connectReqId,
+            method: "connect",
+            params: {
+              minProtocol: PROTOCOL_VERSION,
+              maxProtocol: PROTOCOL_VERSION,
+              client: {
+                id: GATEWAY_CLIENT_ID,
+                version: "1.0.0",
+                platform: process.platform,
+                mode: GATEWAY_CLIENT_MODE,
+              },
+              role: "operator",
+              scopes,
+              caps: [],
+              commands: [],
+              permissions: {},
+              auth: { token: gatewayToken },
+              locale: "en-US",
+              userAgent: "crtv3-song-cup/1.0.0",
+              device: {
+                id: deviceIdentity.deviceId,
+                publicKey: deviceIdentity.publicKeyRawBase64Url,
+                signature: signDevicePayload(
+                  deviceIdentity.privateKeyPem,
+                  authPayload,
+                ),
+                signedAt: signedAtMs,
+                nonce,
+              },
+            },
+          }),
+        );
+        return;
+      }
+
+      if (frame.type === "res" && connectReqId && frame.id === connectReqId) {
+        if (!frame.ok) {
+          const err = new Error(
+            frame.error?.message ??
+              `Pinata gateway connect failed (${frame.error?.code ?? "unknown"})`,
+          );
+          (err as Error & { pairingRequired?: boolean; requestId?: string }).pairingRequired =
+            isPairingRequired(frame.error);
+          (err as Error & { pairingRequired?: boolean; requestId?: string }).requestId =
+            parsePairingRequestId(frame.error) ?? undefined;
+          finish(err);
+          return;
+        }
+
+        chatReqId = String(reqId++);
+        ws.send(
+          JSON.stringify({
+            type: "req",
+            id: chatReqId,
+            method: "chat.send",
+            params: { sessionKey: session, message },
+          }),
+        );
+        return;
+      }
+
+      if (frame.type === "res" && chatReqId && frame.id === chatReqId) {
+        if (!frame.ok) {
+          finish(
+            new Error(
+              frame.error?.message ??
+                `Pinata chat.send failed (${frame.error?.code ?? "unknown"})`,
+            ),
+          );
+          return;
+        }
+        return;
+      }
+
+      if (frame.type === "event" && frame.event === "chat") {
+        const payload = frame.payload ?? {};
+        const type = payload.type;
+        if (type === "content_delta") {
+          const delta = payload.delta as { text?: string } | undefined;
+          if (typeof delta?.text === "string") parts.push(delta.text);
+        }
+        if (type === "message" && payload.done) {
+          finish(undefined, {
+            reply: parts.join("") || "(no reply)",
+            session,
+          });
+        }
+      }
+    });
+  });
+}
+
+export async function gatewayWebSocketChat(
+  options: GatewayChatOptions,
+): Promise<GatewayChatResult> {
+  const wsUrl = options.wsUrl.includes("://")
+    ? options.wsUrl
+    : resolveGatewayChatWsUrl(options.wsUrl, options.gatewayToken);
+  const session = options.session?.trim() || DEFAULT_SESSION;
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const deviceIdentity = resolveDeviceIdentity(options.devicePrivateKeyPem);
+
+  try {
+    return await connectAndChat({
+      wsUrl,
+      gatewayToken: options.gatewayToken,
+      message: options.message,
+      session,
+      deviceIdentity,
+      signal: options.signal,
+      timeoutMs,
+    });
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err as Error & { pairingRequired?: boolean }).pairingRequired
+    ) {
+      throw new Error(
+        `${err.message} Approve the pending device in Pinata (Danger → Devices) or set PINATA_JWT so the server can auto-approve pairing.`,
+      );
+    }
+    throw err;
+  }
+}

--- a/lib/songchain/song-cup/agent-config.ts
+++ b/lib/songchain/song-cup/agent-config.ts
@@ -1,11 +1,18 @@
+import {
+  PINATA_AGENT_HOST_SUFFIX,
+  resolvePinataAgentPublicBaseUrl,
+} from "@/lib/pinata/api";
+
 export type SongCupAgentConfig = {
   enabled: boolean;
   agentId: string | null;
   baseUrl: string | null;
   gatewayToken: string | null;
+  /** Pinata management JWT — used to verify/restart the agent before chat. */
+  managementJwt: string | null;
+  /** Stable Ed25519 device key (PKCS#8 PEM) for OpenClaw gateway pairing. */
+  devicePrivateKeyPem: string | null;
 };
-
-const PINATA_AGENT_HOST_SUFFIX = ".agents.pinata.cloud";
 
 function resolveSongCupAgentBaseUrl(): string | null {
   const explicit = process.env.SONG_CUP_PINATA_BASE_URL?.trim();
@@ -14,7 +21,7 @@ function resolveSongCupAgentBaseUrl(): string | null {
   const agentId = process.env.SONG_CUP_PINATA_AGENT_ID?.trim();
   if (!agentId) return null;
 
-  return `https://${agentId}${PINATA_AGENT_HOST_SUFFIX}`;
+  return resolvePinataAgentPublicBaseUrl(agentId);
 }
 
 /**
@@ -27,10 +34,17 @@ export function getSongCupAgentConfig(): SongCupAgentConfig {
   const agentId = process.env.SONG_CUP_PINATA_AGENT_ID?.trim() || null;
   const baseUrl = resolveSongCupAgentBaseUrl();
   const gatewayToken = process.env.SONG_CUP_PINATA_GATEWAY_TOKEN?.trim() || null;
+  const managementJwt = process.env.PINATA_JWT?.trim() || null;
+  const devicePrivateKeyPem =
+    process.env.SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM?.trim() || null;
   return {
     enabled: Boolean(baseUrl && gatewayToken),
     agentId,
     baseUrl,
     gatewayToken,
+    managementJwt,
+    devicePrivateKeyPem,
   };
 }
+
+export { PINATA_AGENT_HOST_SUFFIX };

--- a/lib/songchain/song-cup/agent-config.ts
+++ b/lib/songchain/song-cup/agent-config.ts
@@ -2,6 +2,7 @@ import {
   PINATA_AGENT_HOST_SUFFIX,
   resolvePinataAgentPublicBaseUrl,
 } from "@/lib/pinata/api";
+import { resolveServerDevicePrivateKeyPem } from "@/lib/pinata/device-identity";
 
 export type SongCupAgentConfig = {
   enabled: boolean;
@@ -35,8 +36,9 @@ export function getSongCupAgentConfig(): SongCupAgentConfig {
   const baseUrl = resolveSongCupAgentBaseUrl();
   const gatewayToken = process.env.SONG_CUP_PINATA_GATEWAY_TOKEN?.trim() || null;
   const managementJwt = process.env.PINATA_JWT?.trim() || null;
-  const devicePrivateKeyPem =
-    process.env.SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM?.trim() || null;
+  const devicePrivateKeyPem = resolveServerDevicePrivateKeyPem(
+    process.env.SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM,
+  );
   return {
     enabled: Boolean(baseUrl && gatewayToken),
     agentId,


### PR DESCRIPTION
## Summary
- Switch Pinata agent chat from HTTP `POST /chat` (404) to OpenClaw WebSocket gateway at `wss://{agentId}.agents.pinata.cloud/chat`, matching `pinata agents chat`.
- Add Ed25519 device identity signing and stable `SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM` support for gateway pairing.
- Add management API helpers (restart, approve devices, gateway token refresh) plus post-restart retry polling in the Song Cup chat route.
- Add `GET /api/song-cup/agent/health` probe and clearer error mapping for 401/503/pairing/scope failures.
- Update twin connect/chat routes to use public agent URLs and shared WebSocket forwarder.

## Test plan
- [ ] Confirm Vercel env: `SONG_CUP_PINATA_AGENT_ID`, `SONG_CUP_PINATA_GATEWAY_TOKEN`, `SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM`, `PINATA_JWT`
- [ ] Deploy and hit `GET /api/song-cup/agent/health` — expect `chatTransport: "websocket"`, `hasDeviceKey: true`
- [ ] Approve pending server device in Pinata Danger → Devices (first request)
- [ ] POST `/api/song-cup/agent/chat` with `{ "message": "hi" }` — expect `success: true`
- [ ] Test Song Cup search bar on `/songchain/song-cup`


Made with [Cursor](https://cursor.com)