### PR TITLE
fix: MeToken toast metadata + initial deposit revert + mint retry

### DIFF
--- a/components/UserProfile/MeTokenSubscription.tsx
+++ b/components/UserProfile/MeTokenSubscription.tsx
@@ -669,6 +669,7 @@ export function MeTokenSubscription({ meToken, onSubscriptionSuccess }: MeTokenS
 
           const isAllowanceError = mintErrorMessage.includes('insufficient allowance') ||
             mintErrorMessage.includes('ERC20') ||
+            mintErrorMessage.includes('execution reverted') ||
             parsedMintError.message.includes('allowance');
 
           if (!isAllowanceError || mintAttempt === maxMintRetries) {

--- a/components/UserProfile/RobustMeTokenCreator.tsx
+++ b/components/UserProfile/RobustMeTokenCreator.tsx
@@ -162,9 +162,11 @@ export function RobustMeTokenCreator({ onMeTokenCreated, onClose }: RobustMeToke
   // Handle successful creation
   useEffect(() => {
     if (state.status === 'success' && state.meTokenAddress) {
+      const tokenName = state.name || name;
+      const tokenSymbol = state.symbol || symbol;
       toast({
         title: 'MeToken Created Successfully!',
-        description: `Your MeToken "${name}" (${symbol}) is ready for trading.`,
+        description: `Your MeToken "${tokenName}" (${tokenSymbol}) is ready for trading.`,
       });
 
       onMeTokenCreated?.(state.meTokenAddress, state.txHash, state.meTokenId);
@@ -181,6 +183,8 @@ export function RobustMeTokenCreator({ onMeTokenCreated, onClose }: RobustMeToke
     state.meTokenAddress,
     state.txHash,
     state.meTokenId,
+    state.name,
+    state.symbol,
     name,
     symbol,
     toast,

--- a/lib/hooks/metokens/useMeTokenCreation.ts
+++ b/lib/hooks/metokens/useMeTokenCreation.ts
@@ -63,6 +63,8 @@ export interface MeTokenCreationState {
   txHash?: string;
   meTokenAddress?: string;
   meTokenId?: string;
+  name?: string;
+  symbol?: string;
   error?: string;
 }
 
@@ -311,7 +313,42 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
           errorMessage.includes('initCode') ||
           errorMessage.includes('account not deployed');
 
-        if (isDeploymentError && meTokenGas.context) {
+        // If the batched approve+subscribe reverts, retry with 0 initial deposit.
+        // The approve+subscribe in a single UserOp can fail because the MeToken
+        // contract's transferFrom may not see the approval within the same batch.
+        // Retrying with 0 deposit creates the token; user can deposit later.
+        const isExecutionRevert =
+          errorMessage.includes('execution reverted') ||
+          errorMessage.includes('0x') && depositAmount > BigInt(0);
+
+        if (isExecutionRevert && depositAmount > BigInt(0)) {
+          logger.debug('🔄 Batched approve+subscribe reverted — retrying with 0 initial deposit...');
+          updateState({
+            status: 'creating_metoken',
+            message: 'Retrying without initial deposit (you can deposit later)...',
+            progress: 45,
+          });
+
+          const zeroDepositCalls = buildMeTokenCreationCalls({
+            collateral,
+            vaultAddress,
+            name,
+            symbol,
+            hubId,
+            depositAmount: BigInt(0),
+          });
+
+          try {
+            operation = await sendMeTokenCreationUserOp({
+              client,
+              calls: zeroDepositCalls,
+              gas: meTokenGas,
+              ethFallback: () => getGasContext('eth'),
+            });
+          } catch (retryError) {
+            throw retryError;
+          }
+        } else if (isDeploymentError && meTokenGas.context) {
           logger.debug('⚠️ Account deployment required — retrying without paymaster...');
           const ethBalance = await getEthBalance(address as `0x${string}`);
           const minGasEth = parseEther('0.001');
@@ -487,6 +524,8 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
           txHash: txHash || undefined,
           meTokenAddress,
           meTokenId,
+          name,
+          symbol,
         });
 
         return;
@@ -499,6 +538,8 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
           progress: 100,
           userOpHash: operation.hash,
           txHash,
+          name,
+          symbol,
         });
       } else {
         updateState({


### PR DESCRIPTION
## Fixes

### 1. Toast notifications showing empty name/symbol `""()`
**Root cause:** `RobustMeTokenCreator` used component state (`name`, `symbol`) in the success `useEffect`, but those got reset to empty strings before the effect fired.

**Fix:** Added `name` and `symbol` to `MeTokenCreationState` in the hook. Success state now carries the token metadata, and the toast reads from `state.name`/`state.symbol` with fallback to component state.

### 2. Initial deposit causing "execution reverted" on MeToken creation
**Root cause:** The batched `approve` + `subscribe` in a single UserOperation fails because the MeToken contract's `transferFrom` may not see the approval within the same batch execution context.

**Fix:** If the batched approve+subscribe fails with "execution reverted", automatically retries with 0 initial deposit (subscribe only). User can deposit collateral later.

### 3. Mint failing with "execution reverted" after approval
**Root cause:** The mint retry logic only caught "insufficient allowance" and "ERC20" errors. "execution reverted" (what the bundler returns when it can't see the approval during gas estimation) was not recognized, causing immediate failure instead of retrying.

**Fix:** Added "execution reverted" to the error detection in `MeTokenSubscription.tsx` so it triggers the existing retry logic (fresh approval + exponential backoff).

## Files changed
- `lib/hooks/metokens/useMeTokenCreation.ts` — added `name`/`symbol` to state + auto-retry on deposit revert
- `components/UserProfile/RobustMeTokenCreator.tsx` — toast uses `state.name`/`state.symbol`
- `components/UserProfile/MeTokenSubscription.tsx` — treat "execution reverted" as retryable