### PR TITLE
fix: filter redundant approve from subscribe call after separate approval

### DIFF
--- a/lib/hooks/metokens/useMeTokenCreation.ts
+++ b/lib/hooks/metokens/useMeTokenCreation.ts
@@ -458,7 +458,7 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
       }
 
       // Build subscribe-only calls (approve already done separately if deposit > 0)
-      const calls = buildMeTokenCreationCalls({
+      let calls = buildMeTokenCreationCalls({
         collateral,
         vaultAddress,
         name,
@@ -466,6 +466,12 @@ export function useMeTokenCreation(): UseMeTokenCreationReturn {
         hubId,
         depositAmount,
       });
+
+      // If we already sent a separate approve, filter it out to avoid
+      // sending a redundant approve+subscribe batch (bundler sync issue)
+      if (depositAmount > BigInt(0)) {
+        calls = calls.filter(call => call.target !== collateral.address);
+      }
 
       logger.debug('📤 MeToken creation gas context:', {
         policyId: meTokenGas.policyId,


### PR DESCRIPTION
Addresses Gemini code review on PR #241.

## Issue
`buildMeTokenCreationCalls` still includes the `approve` call even after we already sent it as a separate UserOperation. The second UserOperation is therefore a redundant `approve + subscribe` batch, which defeats the purpose of separating them and can still trigger bundler gas estimation issues.

## Fix
Filter out the approve call (target === collateral.address) when depositAmount > 0, so only the subscribe call is sent in the second UserOperation.

```typescript
if (depositAmount > BigInt(0)) {
  calls = calls.filter(call => call.target !== collateral.address);
}
```