### PR TITLE
fix: dynamic collateral token display + mobile tab dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ sw.js
 /infra
 /external-deps
 /contracts/interface
-/eip
+/eipfix-baseY-facet/

--- a/components/UserProfile/MeTokenInfo.tsx
+++ b/components/UserProfile/MeTokenInfo.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { MeTokenData } from '@/lib/hooks/metokens/useMeTokens';
-import { formatEther } from 'viem';
+import { formatEther, formatUnits } from 'viem';
 import { TrendingUp, TrendingDown, Users, DollarSign, Clock, Copy, Check, Coins, BarChart3 } from 'lucide-react';
 import { CollateralBadge } from '@/components/metokens/CollateralBadge';
 import { resolveHubAsset } from '@/lib/utils/hubAssetUtils';
@@ -44,8 +44,8 @@ export function MeTokenInfo({ meToken }: MeTokenInfoProps) {
 
   // Format token amount with proper precision and responsive display
   // Returns an object with formatted number and symbol for better visual presentation
-  const formatTokenAmount = (value: bigint, symbol: string): { number: string; symbol: string } => {
-    const num = parseFloat(formatEther(value));
+  const formatTokenAmount = (value: bigint, symbol: string, decimals: number = 18): { number: string; symbol: string } => {
+    const num = parseFloat(formatUnits(value, decimals));
 
     if (num === 0) return { number: '0', symbol };
 
@@ -170,7 +170,7 @@ export function MeTokenInfo({ meToken }: MeTokenInfoProps) {
             <div className="space-y-1">
               <p className="text-xs sm:text-sm font-medium text-muted-foreground">Pooled Balance</p>
               {(() => {
-                const { number, symbol } = formatTokenAmount(meToken.info.balancePooled, collateral.symbol);
+                const { number, symbol } = formatTokenAmount(meToken.info.balancePooled, collateral.symbol, collateral.decimals);
                 return (
                   <p className="text-sm sm:text-base break-all sm:break-normal overflow-wrap-anywhere">
                     {number} {symbol}
@@ -182,7 +182,7 @@ export function MeTokenInfo({ meToken }: MeTokenInfoProps) {
               <div className="space-y-1">
                 <p className="text-xs sm:text-sm font-medium text-muted-foreground">Locked Balance</p>
                 {(() => {
-                  const { number, symbol } = formatTokenAmount(meToken.info.balanceLocked, collateral.symbol);
+                  const { number, symbol } = formatTokenAmount(meToken.info.balanceLocked, collateral.symbol, collateral.decimals);
                   return (
                     <p className="text-sm sm:text-base break-all sm:break-normal overflow-wrap-anywhere">
                       {number} {symbol}

--- a/components/UserProfile/MeTokenSubscriptionStatus.tsx
+++ b/components/UserProfile/MeTokenSubscriptionStatus.tsx
@@ -15,7 +15,8 @@ import {
   RefreshCw,
   Info
 } from 'lucide-react';
-import { formatEther } from 'viem';
+import { formatEther, formatUnits } from 'viem';
+import { resolveHubAsset } from '@/lib/utils/hubAssetUtils';
 
 interface MeTokenSubscriptionStatusProps {
   meToken: MeTokenData;
@@ -28,6 +29,7 @@ export function MeTokenSubscriptionStatus({
   onSubscribe, 
   onRefresh 
 }: MeTokenSubscriptionStatusProps) {
+  const collateral = resolveHubAsset(Number(meToken.info?.hubId ?? meToken.hubId));
   const {
     subscriptionState,
     isLoading,
@@ -139,13 +141,13 @@ export function MeTokenSubscriptionStatus({
               <div>
                 <span className="text-muted-foreground">Pooled:</span>
                 <span className="ml-2 font-mono">
-                  {formatEther(BigInt(subscriptionState.balancePooled))} DAI
+                  {formatUnits(BigInt(subscriptionState.balancePooled), collateral.decimals)} {collateral.symbol}
                 </span>
               </div>
               <div>
                 <span className="text-muted-foreground">Locked:</span>
                 <span className="ml-2 font-mono">
-                  {formatEther(BigInt(subscriptionState.balanceLocked))} DAI
+                  {formatUnits(BigInt(subscriptionState.balanceLocked), collateral.decimals)} {collateral.symbol}
                 </span>
               </div>
             </div>
@@ -153,7 +155,7 @@ export function MeTokenSubscriptionStatus({
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Total Locked:</span>
                 <span className="font-mono font-medium">
-                  {formatEther(subscriptionState.totalLocked)} DAI
+                  {formatUnits(BigInt(subscriptionState.totalLocked), collateral.decimals)} {collateral.symbol}
                 </span>
               </div>
             </div>
@@ -181,7 +183,7 @@ export function MeTokenSubscriptionStatus({
             <p><strong>Why subscribe?</strong></p>
             <ul className="list-disc list-inside space-y-1 ml-4">
               <li>Enables trading of your MeToken</li>
-              <li>Locks DAI as collateral for price stability</li>
+              <li>Locks {collateral.symbol} as collateral for price stability</li>
               <li>Allows community to buy/sell your MeToken</li>
               <li>Creates a bonding curve for price discovery</li>
             </ul>

--- a/components/UserProfile/MeTokenTrading.tsx
+++ b/components/UserProfile/MeTokenTrading.tsx
@@ -8,14 +8,14 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useMeTokensSupabase, MeTokenData } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { Loader2, TrendingUp, TrendingDown, AlertCircle, CheckCircle, Lock, ExternalLink } from 'lucide-react';
-import { formatEther, parseEther, encodeFunctionData, type Address } from 'viem';
+import { formatEther, formatUnits, parseEther, parseUnits, encodeFunctionData, type Address } from 'viem';
 import { useSmartAccountClient, useChain, useAuthModal, useUser } from '@/lib/wallet/react';
-import { DAI_TOKEN_ADDRESSES, getDaiTokenContract } from '@/lib/contracts/DAIToken';
 import { MeTokenSubscription } from './MeTokenSubscription';
 import { DaiFundingOptions } from '@/components/wallet/funding/DaiFundingOptions';
 import { useToast } from '@/components/ui/use-toast';
 import { logger } from '@/lib/utils/logger';
 import { getErc20Balance } from '@/lib/viem';
+import { resolveHubAsset } from '@/lib/utils/hubAssetUtils';
 
 interface MeTokenTradingProps {
   meToken: MeTokenData;
@@ -23,6 +23,7 @@ interface MeTokenTradingProps {
 }
 
 export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
+  const collateral = resolveHubAsset(Number(meToken.info?.hubId ?? meToken.hubId));
   const [buyAmount, setBuyAmount] = useState('');
   const [sellAmount, setSellAmount] = useState('');
   const [buyPreview, setBuyPreview] = useState('0');
@@ -42,7 +43,7 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
   const [isSubscribed, setIsSubscribed] = useState<boolean | null>(() =>
     getInitialSubscriptionStatus(meToken)
   );
-  const [daiBalance, setDaiBalance] = useState<bigint>(BigInt(0));
+  const [collateralBalance, setCollateralBalance] = useState<bigint>(BigInt(0));
   const [isCheckingSubscription, setIsCheckingSubscription] = useState(false);
 
   const { client } = useSmartAccountClient({});
@@ -105,24 +106,22 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
     }
   }, [client, meToken]);
 
-  // Check DAI balance
-  const checkDaiBalance = useCallback(async () => {
+  // Check collateral balance
+  const checkCollateralBalance = useCallback(async () => {
     if (!client) return;
 
     try {
-      const daiContract = getDaiTokenContract('base');
-
       const balance = await getErc20Balance({
-        token: daiContract.address as Address,
+        token: collateral.address as Address,
         owner: client.account?.address as Address,
       });
 
-      setDaiBalance(balance);
+      setCollateralBalance(balance);
     } catch (err) {
-      logger.error('Failed to check DAI balance:', err);
-      setDaiBalance(BigInt(0));
+      logger.error('Failed to check collateral balance:', err);
+      setCollateralBalance(BigInt(0));
     }
-  }, [client]);
+  }, [client, collateral.address]);
 
 
 
@@ -132,8 +131,8 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
   useEffect(() => {
     checkSubscriptionStatus();
     checkSubscriptionStatus();
-    checkDaiBalance();
-  }, [meToken.address, meToken.info?.balancePooled, meToken.info?.balanceLocked, meToken.hubId, checkSubscriptionStatus, checkDaiBalance]);
+    checkCollateralBalance();
+  }, [meToken.address, meToken.info?.balancePooled, meToken.info?.balanceLocked, meToken.hubId, checkSubscriptionStatus, checkCollateralBalance]);
 
   // Calculate buy preview when amount changes
   useEffect(() => {
@@ -254,7 +253,7 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
       });
 
       // Refresh balances
-      await checkDaiBalance();
+      await checkCollateralBalance();
 
       // Refresh parent data
       if (onRefresh) {
@@ -367,11 +366,11 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
       // Show success toast
       toast({
         title: "Sale Successful",
-        description: `Successfully sold ${sellAmount} ${meToken.symbol} for ${parseFloat(sellPreview).toFixed(4)} DAI`,
+        description: `Successfully sold ${sellAmount} ${meToken.symbol} for ${parseFloat(sellPreview).toFixed(4)} ${collateral.symbol}`,
       });
 
       // Refresh balances
-      await checkDaiBalance();
+      await checkCollateralBalance();
 
       // Refresh parent data
       if (onRefresh) {
@@ -465,8 +464,8 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
     );
   }
 
-  // Show DAI funding options first if user has no DAI
-  if (daiBalance === BigInt(0)) {
+  // Show collateral funding options first if user has no collateral
+  if (collateralBalance === BigInt(0)) {
     return (
       <div className="space-y-4">
         <Card>
@@ -476,14 +475,14 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
               <AlertCircle className="h-5 w-5 text-orange-500" />
             </CardTitle>
             <CardDescription>
-              You need DAI to trade {meToken.name} tokens.
+              You need {collateral.symbol} to trade {meToken.name} tokens.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <Alert>
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                Trading requires DAI. Please get DAI first to enable trading.
+                Trading requires {collateral.symbol}. Please get {collateral.symbol} first to enable trading.
               </AlertDescription>
             </Alert>
 
@@ -493,18 +492,40 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
                 <li>Total Supply: {parseFloat(formatEther(meToken.totalSupply)).toLocaleString(undefined, { maximumFractionDigits: 4 })} {meToken.symbol}</li>
                 <li>TVL: ${meToken.tvl.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</li>
                 <li>Your Balance: {parseFloat(formatEther(meToken.balance)).toLocaleString(undefined, { maximumFractionDigits: 4 })} {meToken.symbol}</li>
-                <li>Your DAI Balance: {parseFloat(formatEther(daiBalance)).toLocaleString(undefined, { maximumFractionDigits: 4 })} DAI</li>
+                <li>Your {collateral.symbol} Balance: {parseFloat(formatUnits(collateralBalance, collateral.decimals)).toLocaleString(undefined, { maximumFractionDigits: 4 })} {collateral.symbol}</li>
               </ul>
             </div>
           </CardContent>
         </Card>
 
-        <DaiFundingOptions
-          onBalanceUpdate={(newBalance) => {
-            setDaiBalance(newBalance);
-            // If user gets DAI, we'll automatically show the trading interface
-          }}
-        />
+        {collateral.symbol === 'USDC' ? (
+          <DaiFundingOptions
+            onBalanceUpdate={(newBalance) => {
+              setCollateralBalance(newBalance);
+              // If user gets collateral, we'll automatically show the trading interface
+            }}
+          />
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <AlertCircle className="h-5 w-5 text-orange-500" />
+                Get {collateral.symbol}
+              </CardTitle>
+              <CardDescription>
+                You need {collateral.symbol} to trade this MeToken.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  {collateral.symbol} is not available via direct on-ramp. Please swap from another token (e.g. USDC, ETH) using a DEX aggregator like Uniswap or Aerodrome.
+                </AlertDescription>
+              </Alert>
+            </CardContent>
+          </Card>
+        )}
       </div>
     );
   }
@@ -568,14 +589,14 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
           <TabsContent value="buy" className="space-y-4">
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <Label htmlFor="buyAmount">DAI Amount to Spend</Label>
+                <Label htmlFor="buyAmount">{collateral.symbol} Amount to Spend</Label>
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
                   className="h-6 px-2 text-xs"
                   disabled={isLoading || !isConnected}
-                  onClick={() => setBuyAmount(formatEther(daiBalance))}
+                  onClick={() => setBuyAmount(formatUnits(collateralBalance, collateral.decimals))}
                 >
                   MAX
                 </Button>
@@ -596,22 +617,31 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
               {buyAmount && parseFloat(buyAmount) > 0 && (
                 <div className="text-sm space-y-1">
                   <div>
-                    {daiBalance >= parseEther(buyAmount) ? (
-                      <span className="text-green-600">✓ DAI balance sufficient</span>
+                    {collateralBalance >= parseUnits(buyAmount, collateral.decimals) ? (
+                      <span className="text-green-600">✓ {collateral.symbol} balance sufficient</span>
                     ) : (
-                      <span className="text-red-600">⚠ Insufficient DAI balance</span>
+                      <span className="text-red-600">⚠ Insufficient {collateral.symbol} balance</span>
                     )}
                   </div>
                 </div>
               )}
             </div>
 
-            {buyAmount && parseFloat(buyAmount) > 0 && daiBalance < parseEther(buyAmount) && (
-              <DaiFundingOptions
-                requiredAmount={parseEther(buyAmount).toString()}
-                onBalanceUpdate={setDaiBalance}
-                className="mb-4"
-              />
+            {buyAmount && parseFloat(buyAmount) > 0 && collateralBalance < parseUnits(buyAmount, collateral.decimals) && (
+              collateral.symbol === 'USDC' ? (
+                <DaiFundingOptions
+                  requiredAmount={parseUnits(buyAmount, collateral.decimals).toString()}
+                  onBalanceUpdate={setCollateralBalance}
+                  className="mb-4"
+                />
+              ) : (
+                <Alert className="mb-4">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    Insufficient {collateral.symbol} balance. Please swap for {collateral.symbol} using a DEX aggregator like Uniswap or Aerodrome.
+                  </AlertDescription>
+                </Alert>
+              )
             )}
 
             {!isConnected ? (
@@ -624,7 +654,7 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
             ) : (
               <Button
                 onClick={handleBuy}
-                disabled={isLoading || !buyAmount || parseFloat(buyAmount) <= 0 || daiBalance < parseEther(buyAmount || '0')}
+                disabled={isLoading || !buyAmount || parseFloat(buyAmount) <= 0 || collateralBalance < parseUnits(buyAmount || '0', collateral.decimals)}
                 className="w-full bg-green-600 hover:bg-green-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isLoading ? (
@@ -666,7 +696,7 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
                 max={formatEther(meToken.balance)}
               />
               <p className="text-sm text-muted-foreground">
-                You will receive approximately {parseFloat(sellPreview).toLocaleString(undefined, { maximumFractionDigits: 4 })} DAI
+                You will receive approximately {parseFloat(sellPreview).toLocaleString(undefined, { maximumFractionDigits: 4 })} {collateral.symbol}
               </p>
             </div>
 

--- a/components/UserProfile/MeTokensSection.tsx
+++ b/components/UserProfile/MeTokensSection.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/components/ui/use-toast';
 import { useMeTokensSupabase, MeTokenData } from '@/lib/hooks/metokens/useMeTokensSupabase';
 import { useUser } from '@/lib/wallet/react';
@@ -345,7 +346,23 @@ export function MeTokensSection({ walletAddress }: MeTokensSectionProps) {
 
       {userMeToken ? (
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid h-auto w-full grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-1">
+          {/* Mobile: Select dropdown */}
+          <div className="sm:hidden mb-4">
+            <Select value={activeTab} onValueChange={setActiveTab}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a tab" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="overview">Overview</SelectItem>
+                <SelectItem value="profile">Profile</SelectItem>
+                <SelectItem value="trading">Trading</SelectItem>
+                <SelectItem value="info">Details</SelectItem>
+                <SelectItem value="history">History</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {/* Desktop: Tab grid */}
+          <TabsList className="hidden sm:grid h-auto w-full grid-cols-3 md:grid-cols-5 gap-1">
             <TabsTrigger value="overview" className="flex items-center justify-center gap-2">
               <Info className="h-4 w-4" />
               <span className="hidden sm:inline">Overview</span>


### PR DESCRIPTION
## Fixes

### 1. Replace hardcoded "DAI" with dynamic collateral (MeTokenTrading.tsx)
- All "DAI" references → `collateral.symbol` based on hub (USDC, USDS, GHO, DAI)
- `formatEther`/`parseEther` → `formatUnits`/`parseUnits` with `collateral.decimals`
- Coinbase on-ramp (`DaiFundingOptions`) only shown for USDC
- DAI/USDS/GHO show swap instruction (DEX aggregator) since Coinbase CDP doesn't support them on Base
- `daiBalance` → `collateralBalance`, uses `collateral.address` for balance check

### 2. Fix DAI labels in MeTokenSubscriptionStatus.tsx
- `formatEther(...) + " DAI"` → `formatUnits(..., collateral.decimals) + " " + collateral.symbol`
- "Locks DAI as collateral" → "Locks {collateral.symbol} as collateral"

### 3. Fix pool balance display (MeTokenInfo.tsx)
- `formatTokenAmount` now accepts `decimals` parameter (default 18)
- USDC pool balance was showing 2.5 instead of 0.25 (formatEther divides by 1e18, USDC has 6 decimals)
- Now uses `formatUnits(value, collateral.decimals)` for collateral amounts

### 4. Mobile dropdown for MeToken tabs (MeTokensSection.tsx)
- 5 tabs in 2-column grid was cramped on mobile
- Mobile: Select dropdown (`sm:hidden`)
- Desktop: tab grid (`hidden sm:grid`)
- Tabs: Overview, Profile, Trading, Details, History

## Files changed
- `components/UserProfile/MeTokenTrading.tsx`
- `components/UserProfile/MeTokenInfo.tsx`
- `components/UserProfile/MeTokenSubscriptionStatus.tsx`
- `components/UserProfile/MeTokensSection.tsx`
- `.gitignore` (exclude fix-baseY-facet artifacts)