### PR TITLE
fix: address Gemini PR #243 review — 4 issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,5 @@ sw.js
 /infra
 /external-deps
 /contracts/interface
-/eipfix-baseY-facet/
+/eip
+/fix-baseY-facet/

--- a/components/UserProfile/MeTokenTrading.tsx
+++ b/components/UserProfile/MeTokenTrading.tsx
@@ -11,7 +11,7 @@ import { Loader2, TrendingUp, TrendingDown, AlertCircle, CheckCircle, Lock, Exte
 import { formatEther, formatUnits, parseEther, parseUnits, encodeFunctionData, type Address } from 'viem';
 import { useSmartAccountClient, useChain, useAuthModal, useUser } from '@/lib/wallet/react';
 import { MeTokenSubscription } from './MeTokenSubscription';
-import { DaiFundingOptions } from '@/components/wallet/funding/DaiFundingOptions';
+import { FundingOptions } from '@/components/wallet/buy/FundingOptions';
 import { useToast } from '@/components/ui/use-toast';
 import { logger } from '@/lib/utils/logger';
 import { getErc20Balance } from '@/lib/viem';
@@ -129,7 +129,6 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
 
   // Check subscription status on mount and when meToken data changes
   useEffect(() => {
-    checkSubscriptionStatus();
     checkSubscriptionStatus();
     checkCollateralBalance();
   }, [meToken.address, meToken.info?.balancePooled, meToken.info?.balanceLocked, meToken.hubId, checkSubscriptionStatus, checkCollateralBalance]);
@@ -499,12 +498,24 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
         </Card>
 
         {collateral.symbol === 'USDC' ? (
-          <DaiFundingOptions
-            onBalanceUpdate={(newBalance) => {
-              setCollateralBalance(newBalance);
-              // If user gets collateral, we'll automatically show the trading interface
-            }}
-          />
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <AlertCircle className="h-5 w-5 text-orange-500" />
+                Get {collateral.symbol}
+              </CardTitle>
+              <CardDescription>
+                You need {collateral.symbol} to trade {meToken.name} tokens.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FundingOptions
+                asset="USDC"
+                presetFiatAmount={50}
+                onSuccess={() => checkCollateralBalance()}
+              />
+            </CardContent>
+          </Card>
         ) : (
           <Card>
             <CardHeader>
@@ -629,10 +640,10 @@ export function MeTokenTrading({ meToken, onRefresh }: MeTokenTradingProps) {
 
             {buyAmount && parseFloat(buyAmount) > 0 && collateralBalance < parseUnits(buyAmount, collateral.decimals) && (
               collateral.symbol === 'USDC' ? (
-                <DaiFundingOptions
-                  requiredAmount={parseUnits(buyAmount, collateral.decimals).toString()}
-                  onBalanceUpdate={setCollateralBalance}
-                  className="mb-4"
+                <FundingOptions
+                  asset="USDC"
+                  presetFiatAmount={Math.ceil(parseFloat(buyAmount))}
+                  onSuccess={() => checkCollateralBalance()}
                 />
               ) : (
                 <Alert className="mb-4">

--- a/lib/hooks/metokens/useMeTokensSupabase.ts
+++ b/lib/hooks/metokens/useMeTokensSupabase.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useUser, useSmartAccountClient } from '@/lib/wallet/react';
-import { parseEther, formatEther, encodeFunctionData } from 'viem';
+import { parseEther, formatEther, formatUnits, encodeFunctionData } from 'viem';
 import { meTokenSupabaseService, MeToken, MeTokenBalance } from '@/lib/sdk/supabase/metokens';
 import { CreateMeTokenData, UpdateMeTokenData } from '@/lib/sdk/supabase/client';
 import { getMeTokenFactoryContract, METOKEN_FACTORY_ADDRESSES } from '@/lib/contracts/MeTokenFactory';
@@ -1804,11 +1804,35 @@ You can try creating your MeToken with 0 DAI deposit and add liquidity later.`;
         args: [meTokenAddress as `0x${string}`, parseEther(meTokenAmount), address as `0x${string}`],
       });
 
-      const assetsReturned = formatEther(result as bigint);
+      // Determine the collateral token's decimals from the MeToken's hub
+      const meTokenInfo = await publicClient.readContract({
+        address: DIAMOND,
+        abi: METOKEN_ABI,
+        functionName: 'getMeTokenInfo',
+        args: [meTokenAddress as `0x${string}`],
+      }) as any;
+
+      const hubIdNum = Number(meTokenInfo.hubId ?? meTokenInfo[1] ?? 1n);
+      const hubInfo = await publicClient.readContract({
+        address: DIAMOND,
+        abi: METOKEN_ABI,
+        functionName: 'getHubInfo',
+        args: [BigInt(hubIdNum)],
+      }) as any;
+
+      const assetAddress = Array.isArray(hubInfo)
+        ? (hubInfo[7] as string)
+        : ((hubInfo as { asset?: string }).asset ?? (hubInfo as any)[7]);
+
+      const hubAsset = resolveHubAsset(hubIdNum, assetAddress);
+
+      const assetsReturned = formatUnits(result as bigint, hubAsset.decimals);
       logger.debug('✅ calculateAssetsReturned result:', {
         resultWei: (result as bigint).toString(),
         assetsReturned,
-        meTokenAmount
+        meTokenAmount,
+        hubId: hubIdNum,
+        decimals: hubAsset.decimals
       });
 
       return assetsReturned;


### PR DESCRIPTION
Addresses Gemini code review on PR #243.

## Issues fixed

### 1. (High) DaiFundingOptions used for USDC collateral
`DaiFundingOptions` was hardcoded to check DAI balance and buy DAI. Using it for USDC-collateralized MeTokens would show wrong balances and buy the wrong token.

**Fix:** Replace with `FundingOptions` (generic Coinbase CDP on-ramp) with `asset="USDC"`.

### 2. (Medium) .gitignore concatenation bug
Missing newline caused `/eip` + `/fix-baseY-facet/` to merge into `/eipfix-baseY-facet/`, breaking both ignore rules.

**Fix:** Add newline between entries.

### 3. (Medium) Duplicate checkSubscriptionStatus() call
Called twice consecutively in `useEffect` — redundant async blockchain queries.

**Fix:** Remove duplicate call.

### 4. (Medium) calculateAssetsReturned uses wrong decimals
`formatEther` (18 decimals) for all tokens. USDC (6 decimals) sell preview was off by 10^12.

**Fix:** Fetch hub info, resolve collateral decimals, use `formatUnits(result, hubAsset.decimals)`.

## Files changed
- `components/UserProfile/MeTokenTrading.tsx`
- `lib/hooks/metokens/useMeTokensSupabase.ts`
- `.gitignore`