### PR TITLE
fix: resolve Creative Twin template by Pinata org template ID

### DIFF
--- a/app/api/twin/template/route.ts
+++ b/app/api/twin/template/route.ts
@@ -1,21 +1,34 @@
 import { NextResponse } from "next/server";
-import { findCreativeTwinTemplate } from "@/lib/pinata/api";
+import {
+  CREATIVE_TWIN_TEMPLATE_URL,
+  findCreativeTwinTemplate,
+} from "@/lib/pinata/api";
 import { serverLogger } from "@/lib/utils/logger";
 
 /**
- * Returns the live Creative AI Digital Twin template metadata pulled from the
- * Pinata public-templates catalog. Cached server-side for 1 hour.
+ * Returns Creative AI Digital Twin *template* metadata (org template ID, not
+ * a deployed agent). Prefers GET /v0/templates/id/{id} via PINATA_JWT, with
+ * public-marketplace slug as fallback. Cached server-side for 1 hour.
  */
 export async function GET() {
   try {
     const template = await findCreativeTwinTemplate();
     if (!template) {
       return NextResponse.json(
-        { success: false, error: "Template not found in Pinata catalog" },
+        {
+          success: false,
+          error:
+            "Twin template not found. Ensure PINATA_JWT can read template tmernpdi, or publish it to the marketplace.",
+          deployUrl: CREATIVE_TWIN_TEMPLATE_URL,
+        },
         { status: 404 }
       );
     }
-    return NextResponse.json({ success: true, template });
+    return NextResponse.json({
+      success: true,
+      template,
+      deployUrl: CREATIVE_TWIN_TEMPLATE_URL,
+    });
   } catch (err) {
     serverLogger.error("twin/template fetch failed:", err);
     return NextResponse.json(

--- a/app/api/twin/template/route.ts
+++ b/app/api/twin/template/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import {
+  CREATIVE_TWIN_TEMPLATE_ID,
   CREATIVE_TWIN_TEMPLATE_URL,
   findCreativeTwinTemplate,
 } from "@/lib/pinata/api";
@@ -18,7 +19,7 @@ export async function GET() {
         {
           success: false,
           error:
-            "Twin template not found. Ensure PINATA_JWT can read template tmernpdi, or publish it to the marketplace.",
+            `Twin template not found. Ensure PINATA_JWT can read template ${CREATIVE_TWIN_TEMPLATE_ID} (slug creative-ai-digital-twin), or publish it to the marketplace.`,
           deployUrl: CREATIVE_TWIN_TEMPLATE_URL,
         },
         { status: 404 }
@@ -35,6 +36,7 @@ export async function GET() {
       {
         success: false,
         error: err instanceof Error ? err.message : "Failed to fetch template",
+        deployUrl: CREATIVE_TWIN_TEMPLATE_URL,
       },
       { status: 502 }
     );

--- a/components/UserProfile/DigitalTwinSection.tsx
+++ b/components/UserProfile/DigitalTwinSection.tsx
@@ -450,9 +450,21 @@ export function DigitalTwinSection({
                     )}
                   </div>
                 ) : templateError ? (
-                  <p className="text-xs text-muted-foreground">
-                    Couldn't load template metadata: {templateError}
-                  </p>
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">
+                      Couldn't load template metadata: {templateError}
+                    </p>
+                    {!status?.connected && (
+                      <a
+                        href={deployUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                      >
+                        <ExternalLink className="h-3 w-3" /> Deploy this template on Pinata
+                      </a>
+                    )}
+                  </div>
                 ) : (
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
                     <Loader2 className="h-3 w-3 animate-spin" /> Loading template…

--- a/components/UserProfile/DigitalTwinSection.tsx
+++ b/components/UserProfile/DigitalTwinSection.tsx
@@ -74,19 +74,21 @@ interface ConnectionStatus {
   agentSnapshotCid?: string | null;
 }
 
-const PINATA_MARKETPLACE_URL = "https://agents.pinata.cloud/marketplace";
+/** Org template page (template ID tmernpdi) — not a deployed agent URL. */
+const PINATA_TWIN_TEMPLATE_URL =
+  "https://agents.pinata.cloud/org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS/templates/tmernpdi";
 const PINATA_API_KEYS_URL = "https://app.pinata.cloud/developers/api-keys";
 
 /**
  * Profile-page section for connecting an external Creative AI Digital Twin
  * deployed on Pinata. Two paths:
  *
- *  1) Onboarding: shows the live template card, a Deploy CTA pointing at the
- *     Pinata marketplace, and a checklist of secrets the creator will need.
- *  2) Connect: agent ID + Pinata JWT one-shot exchange. The JWT is sent once
- *     to /api/twin/connect, traded for the per-agent gateway token + URLs,
- *     then forgotten. After that the proxy at /api/twin/chat uses the stored
- *     token directly, with no further creator action needed.
+ *  1) Onboarding: shows the live *template* card, a Deploy CTA pointing at
+ *     the org template page, and a checklist of secrets the creator will need.
+ *  2) Connect: the creator's *agent* ID + Pinata JWT one-shot exchange. The
+ *     JWT is sent once to /api/twin/connect, traded for the per-agent gateway
+ *     token + URLs, then forgotten. After that the proxy at /api/twin/chat
+ *     uses the stored token directly, with no further creator action needed.
  *
  * The avatar GLB URL is independent of the Pinata connection — a creator can
  * upload a custom GLB without connecting an agent (chat panel just won't
@@ -107,6 +109,7 @@ export function DigitalTwinSection({
 
   const [template, setTemplate] = useState<TemplateState | null>(null);
   const [templateError, setTemplateError] = useState<string | null>(null);
+  const [deployUrl, setDeployUrl] = useState(PINATA_TWIN_TEMPLATE_URL);
 
   const [status, setStatus] = useState<ConnectionStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(true);
@@ -153,7 +156,7 @@ export function DigitalTwinSection({
     };
   }, [ownerAddress, initialProfile]);
 
-  // Live template metadata from Pinata.
+  // Live template metadata from Pinata (template ID, not agent ID).
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -161,6 +164,9 @@ export function DigitalTwinSection({
         const res = await fetch("/api/twin/template");
         const json = await res.json();
         if (cancelled) return;
+        if (typeof json.deployUrl === "string" && json.deployUrl) {
+          setDeployUrl(json.deployUrl);
+        }
         if (!json.success) {
           setTemplateError(json.error || "Template fetch failed");
           return;
@@ -434,7 +440,7 @@ export function DigitalTwinSection({
 
                     {!status?.connected && (
                       <a
-                        href={PINATA_MARKETPLACE_URL}
+                        href={deployUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"

--- a/env.example
+++ b/env.example
@@ -76,6 +76,8 @@ SONG_CUP_PINATA_AGENT_ID=xoqb797x
 # PINATA_JWT=
 # Creative Twin template (not an agent ID). Defaults to tmernpdi / org template URL.
 # CREATIVE_TWIN_TEMPLATE_ID=tmernpdi
+# CREATIVE_TWIN_TEMPLATE_ORG=org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS
+# Optional full override; if unset, URL is built from ORG + ID above.
 # CREATIVE_TWIN_TEMPLATE_URL=https://agents.pinata.cloud/org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS/templates/tmernpdi
 # SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM=
 # PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM=

--- a/env.example
+++ b/env.example
@@ -65,7 +65,8 @@ NEXT_PUBLIC_SONG_CUP_GRAPH_ID=0x51f4905F86402Bcfa015b445f73E3dEfF995a279
 # Song Cup Pinata agent (hero search bar on /songchain/song-cup)
 # Chat uses WebSocket (wss://{agentId}.agents.pinata.cloud/chat), same as `pinata agents chat`.
 # Gateway token: agent Danger page or GET /v0/agents/{agentId}/gateway-token (Pinata JWT).
-# PINATA_JWT (server-only) refreshes gateway token, restarts stopped agents, and auto-approves device pairing.
+# PINATA_JWT (server-only) refreshes gateway token, restarts stopped agents, auto-approves device pairing,
+# and reads the org Creative Twin *template* (GET /v0/templates/id/{id}) for /api/twin/template.
 # SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM: stable Ed25519 PKCS#8 PEM so Vercel can reconnect without re-pairing each cold start.
 # PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM: shared server key for twin chat (falls back to SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM).
 # Generate once: node -e "const c=require('crypto');const {privateKey}=c.generateKeyPairSync('ed25519');console.log(privateKey.export({type:'pkcs8',format:'pem'}))"
@@ -73,6 +74,9 @@ SONG_CUP_PINATA_AGENT_ID=xoqb797x
 # SONG_CUP_PINATA_BASE_URL=https://xoqb797x.agents.pinata.cloud
 # SONG_CUP_PINATA_GATEWAY_TOKEN=
 # PINATA_JWT=
+# Creative Twin template (not an agent ID). Defaults to tmernpdi / org template URL.
+# CREATIVE_TWIN_TEMPLATE_ID=tmernpdi
+# CREATIVE_TWIN_TEMPLATE_URL=https://agents.pinata.cloud/org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS/templates/tmernpdi
 # SONG_CUP_PINATA_DEVICE_PRIVATE_KEY_PEM=
 # PINATA_SERVER_DEVICE_PRIVATE_KEY_PEM=
 

--- a/lib/pinata/api.ts
+++ b/lib/pinata/api.ts
@@ -38,10 +38,19 @@ export const CREATIVE_TWIN_TEMPLATE_SLUG = "creative-ai-digital-twin";
 export const CREATIVE_TWIN_TEMPLATE_ID =
   process.env.CREATIVE_TWIN_TEMPLATE_ID?.trim() || "tmernpdi";
 
-/** Direct deploy / template page (org-scoped, not the public marketplace). */
+/** Pinata org segment used when building the default template page URL. */
+const CREATIVE_TWIN_TEMPLATE_ORG =
+  process.env.CREATIVE_TWIN_TEMPLATE_ORG?.trim() ||
+  "org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS";
+
+/**
+ * Direct deploy / template page (org-scoped, not the public marketplace).
+ * Derived from CREATIVE_TWIN_TEMPLATE_ID unless CREATIVE_TWIN_TEMPLATE_URL is set,
+ * so ID-only overrides stay consistent with the deploy CTA.
+ */
 export const CREATIVE_TWIN_TEMPLATE_URL =
   process.env.CREATIVE_TWIN_TEMPLATE_URL?.trim() ||
-  "https://agents.pinata.cloud/org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS/templates/tmernpdi";
+  `https://agents.pinata.cloud/${CREATIVE_TWIN_TEMPLATE_ORG}/templates/${CREATIVE_TWIN_TEMPLATE_ID}`;
 
 /**
  * Subset of the Template schema we render in the UI. The full schema has many

--- a/lib/pinata/api.ts
+++ b/lib/pinata/api.ts
@@ -2,8 +2,10 @@
  * Server-only Pinata Agents API client.
  *
  * Endpoints we use:
- *  - `GET /v0/templates/id/{templateId}` (PINATA_JWT) — org template metadata
- *    for the Creative AI Digital Twin onboarding card + snapshotCid.
+ *  - `GET /v0/templates/id/{templateId}` / `GET /v0/templates/{slug}`
+ *    (PINATA_JWT) — org template metadata for the Creative AI Digital Twin
+ *    onboarding card + snapshotCid (id `tmernpdi`, slug
+ *    `creative-ai-digital-twin`).
  *  - `GET /v0/public-templates` (no auth) — marketplace fallback if the org
  *    template is later published under CREATIVE_TWIN_TEMPLATE_SLUG.
  *  - `GET /v0/agents/{agentId}` (Pinata JWT) — fetch the agent's name + the
@@ -260,13 +262,38 @@ export async function getTemplateById(
   jwt?: string,
 ): Promise<PinataTemplate | null> {
   if (!templateId) return null;
+  return fetchAuthenticatedTemplate(
+    `/v0/templates/id/${encodeURIComponent(templateId)}`,
+    jwt,
+  );
+}
+
+/**
+ * Fetch a template by slug (e.g. `creative-ai-digital-twin`).
+ * Requires PINATA_JWT for org/unpublished templates.
+ */
+export async function getTemplateBySlug(
+  slug: string,
+  jwt?: string,
+): Promise<PinataTemplate | null> {
+  if (!slug) return null;
+  return fetchAuthenticatedTemplate(
+    `/v0/templates/${encodeURIComponent(slug)}`,
+    jwt,
+  );
+}
+
+async function fetchAuthenticatedTemplate(
+  path: string,
+  jwt?: string,
+): Promise<PinataTemplate | null> {
   const token = jwt?.trim() || process.env.PINATA_JWT?.trim();
   if (!token) return null;
   try {
-    const data = await pinataFetch<unknown>(
-      `/v0/templates/id/${encodeURIComponent(templateId)}`,
-      { jwt: token, method: "GET" },
-    );
+    const data = await pinataFetch<unknown>(path, {
+      jwt: token,
+      method: "GET",
+    });
     return normalizeTemplate(data);
   } catch (err) {
     if (
@@ -283,9 +310,9 @@ export async function getTemplateById(
 }
 
 /**
- * Resolve the Creative Twin *template* (not a deployed agent). Prefers the
- * org template ID via PINATA_JWT, then public marketplace slug, then a
- * static fallback so the deploy CTA still points at tmernpdi.
+ * Resolve the Creative Twin *template* (not a deployed agent). Prefers org
+ * template ID, then slug `creative-ai-digital-twin` (auth + public catalog),
+ * then a static fallback so the deploy CTA still points at tmernpdi.
  */
 export async function findCreativeTwinTemplate(): Promise<PinataTemplate | null> {
   const now = Date.now();
@@ -294,7 +321,9 @@ export async function findCreativeTwinTemplate(): Promise<PinataTemplate | null>
   }
 
   let template =
-    (await getTemplateById(CREATIVE_TWIN_TEMPLATE_ID).catch(() => null)) ?? null;
+    (await getTemplateById(CREATIVE_TWIN_TEMPLATE_ID).catch(() => null)) ??
+    (await getTemplateBySlug(CREATIVE_TWIN_TEMPLATE_SLUG).catch(() => null)) ??
+    null;
 
   if (!template) {
     const all = await listPublicTemplates().catch(() => [] as PinataTemplate[]);

--- a/lib/pinata/api.ts
+++ b/lib/pinata/api.ts
@@ -149,6 +149,8 @@ let publicTemplateCache: { value: PinataTemplate[]; expiresAt: number } | null =
 let twinTemplateCache: { value: PinataTemplate | null; expiresAt: number } | null =
   null;
 const TEMPLATE_TTL_MS = 60 * 60 * 1000;
+/** Short TTL so a Pinata outage does not pin the static fallback for an hour. */
+const FALLBACK_TEMPLATE_TTL_MS = 30 * 1000;
 
 function normalizeTemplate(raw: unknown): PinataTemplate | null {
   if (!raw || typeof raw !== "object") return null;
@@ -234,11 +236,16 @@ export async function listPublicTemplates(): Promise<PinataTemplate[]> {
   if (publicTemplateCache && publicTemplateCache.expiresAt > now) {
     return publicTemplateCache.value;
   }
-  const data = await pinataFetch<{ templates: PinataTemplate[] }>(
+  const data = await pinataFetch<{ templates: unknown[] }>(
     "/v0/public-templates",
   );
+  const templates = Array.isArray(data?.templates)
+    ? data.templates
+        .map(normalizeTemplate)
+        .filter((t): t is PinataTemplate => t !== null)
+    : [];
   publicTemplateCache = {
-    value: data.templates ?? [],
+    value: templates,
     expiresAt: now + TEMPLATE_TTL_MS,
   };
   return publicTemplateCache.value;
@@ -297,11 +304,15 @@ export async function findCreativeTwinTemplate(): Promise<PinataTemplate | null>
       null;
   }
 
+  const isFallback = !template;
   if (!template) {
     template = creativeTwinTemplateFallback();
   }
 
-  twinTemplateCache = { value: template, expiresAt: now + TEMPLATE_TTL_MS };
+  twinTemplateCache = {
+    value: template,
+    expiresAt: now + (isFallback ? FALLBACK_TEMPLATE_TTL_MS : TEMPLATE_TTL_MS),
+  };
   return template;
 }
 

--- a/lib/pinata/api.ts
+++ b/lib/pinata/api.ts
@@ -1,14 +1,20 @@
 /**
  * Server-only Pinata Agents API client.
  *
- * Three endpoints we use:
- *  - `GET /v0/public-templates` (no auth) — discover the Creative AI Digital
- *    Twin template for the onboarding card and its snapshotCid.
+ * Endpoints we use:
+ *  - `GET /v0/templates/id/{templateId}` (PINATA_JWT) — org template metadata
+ *    for the Creative AI Digital Twin onboarding card + snapshotCid.
+ *  - `GET /v0/public-templates` (no auth) — marketplace fallback if the org
+ *    template is later published under CREATIVE_TWIN_TEMPLATE_SLUG.
  *  - `GET /v0/agents/{agentId}` (Pinata JWT) — fetch the agent's name + the
  *    snapshotCid we compare against the template for the verified badge.
  *  - `GET /v0/agents/{agentId}/gateway-token` (Pinata JWT) — exchange the
  *    creator's JWT for the per-agent gateway token + base URLs that we
  *    persist and use to forward chat requests later.
+ *
+ * Template ID (`tmernpdi`) is the Pinata *template*, not a deployed agent.
+ * Creators deploy their own agent from that template, then connect with
+ * their agent ID + JWT.
  *
  * The Pinata JWT is held in memory only — passed to these functions and
  * discarded after the connect flow completes. Only the per-agent gateway
@@ -20,7 +26,20 @@ const PINATA_AGENTS_BASE = "https://agents.pinata.cloud";
 
 export const PINATA_AGENT_HOST_SUFFIX = ".agents.pinata.cloud";
 
+/** Marketplace / public-catalog slug (used only as a fallback lookup key). */
 export const CREATIVE_TWIN_TEMPLATE_SLUG = "creative-ai-digital-twin";
+
+/**
+ * Org template ID for Creative AI Digital Twin.
+ * Override with CREATIVE_TWIN_TEMPLATE_ID if Pinata reissues the template.
+ */
+export const CREATIVE_TWIN_TEMPLATE_ID =
+  process.env.CREATIVE_TWIN_TEMPLATE_ID?.trim() || "tmernpdi";
+
+/** Direct deploy / template page (org-scoped, not the public marketplace). */
+export const CREATIVE_TWIN_TEMPLATE_URL =
+  process.env.CREATIVE_TWIN_TEMPLATE_URL?.trim() ||
+  "https://agents.pinata.cloud/org_3Ar9vPhBBqDLVh1GlNO9kFTsGlS/templates/tmernpdi";
 
 /**
  * Subset of the Template schema we render in the UI. The full schema has many
@@ -125,24 +144,165 @@ export function isAgentRuntimeRunning(status: PinataProcessStatus): boolean {
  * Public templates list. Cached in-process for 1 hour to avoid pounding the
  * upstream catalog on every page load.
  */
-let templateCache: { value: PinataTemplate[]; expiresAt: number } | null = null;
+let publicTemplateCache: { value: PinataTemplate[]; expiresAt: number } | null =
+  null;
+let twinTemplateCache: { value: PinataTemplate | null; expiresAt: number } | null =
+  null;
 const TEMPLATE_TTL_MS = 60 * 60 * 1000;
+
+function normalizeTemplate(raw: unknown): PinataTemplate | null {
+  if (!raw || typeof raw !== "object") return null;
+  const t = raw as Record<string, unknown> & {
+    template?: Record<string, unknown>;
+  };
+  const candidate = (t.template ?? t) as Record<string, unknown>;
+  const templateId =
+    (typeof candidate.templateId === "string" && candidate.templateId) ||
+    (typeof candidate.id === "string" && candidate.id) ||
+    null;
+  const snapshotCid =
+    (typeof candidate.snapshotCid === "string" && candidate.snapshotCid) ||
+    (typeof candidate.snapshot_cid === "string" && candidate.snapshot_cid) ||
+    null;
+  if (!templateId || !snapshotCid) return null;
+  return {
+    templateId,
+    name:
+      (typeof candidate.name === "string" && candidate.name) ||
+      "Creative AI Digital Twin",
+    slug:
+      (typeof candidate.slug === "string" && candidate.slug) ||
+      CREATIVE_TWIN_TEMPLATE_SLUG,
+    description:
+      (typeof candidate.description === "string" && candidate.description) ||
+      "",
+    longDescription:
+      typeof candidate.longDescription === "string"
+        ? candidate.longDescription
+        : null,
+    authorName:
+      (typeof candidate.authorName === "string" && candidate.authorName) ||
+      "Creative",
+    authorLogoUrl:
+      typeof candidate.authorLogoUrl === "string"
+        ? candidate.authorLogoUrl
+        : null,
+    authorUrl:
+      typeof candidate.authorUrl === "string" ? candidate.authorUrl : null,
+    category:
+      (typeof candidate.category === "string" && candidate.category) || "other",
+    snapshotCid,
+    defaultVibe:
+      typeof candidate.defaultVibe === "string" ? candidate.defaultVibe : null,
+    defaultEmoji:
+      typeof candidate.defaultEmoji === "string"
+        ? candidate.defaultEmoji
+        : null,
+    requiredSecrets: Array.isArray(candidate.requiredSecrets)
+      ? (candidate.requiredSecrets as PinataTemplate["requiredSecrets"])
+      : [],
+    isFree: candidate.isFree !== false,
+    version: typeof candidate.version === "number" ? candidate.version : 1,
+  };
+}
+
+/** Minimal card when Pinata auth is unavailable; deploy CTA still works. */
+function creativeTwinTemplateFallback(): PinataTemplate {
+  return {
+    templateId: CREATIVE_TWIN_TEMPLATE_ID,
+    name: "Creative AI Digital Twin",
+    slug: CREATIVE_TWIN_TEMPLATE_SLUG,
+    description:
+      "Deploy this Pinata template, then paste your agent ID and JWT below to connect.",
+    longDescription: null,
+    authorName: "Creative",
+    authorLogoUrl: null,
+    authorUrl: CREATIVE_TWIN_TEMPLATE_URL,
+    category: "other",
+    // Empty until a live fetch succeeds — verified badge stays off.
+    snapshotCid: "",
+    defaultVibe: null,
+    defaultEmoji: "🤖",
+    requiredSecrets: [],
+    isFree: true,
+    version: 1,
+  };
+}
 
 export async function listPublicTemplates(): Promise<PinataTemplate[]> {
   const now = Date.now();
-  if (templateCache && templateCache.expiresAt > now) {
-    return templateCache.value;
+  if (publicTemplateCache && publicTemplateCache.expiresAt > now) {
+    return publicTemplateCache.value;
   }
   const data = await pinataFetch<{ templates: PinataTemplate[] }>(
     "/v0/public-templates",
   );
-  templateCache = { value: data.templates ?? [], expiresAt: now + TEMPLATE_TTL_MS };
-  return templateCache.value;
+  publicTemplateCache = {
+    value: data.templates ?? [],
+    expiresAt: now + TEMPLATE_TTL_MS,
+  };
+  return publicTemplateCache.value;
 }
 
+/**
+ * Fetch an org template by ID. Requires PINATA_JWT — these are not in the
+ * public marketplace until published.
+ */
+export async function getTemplateById(
+  templateId: string,
+  jwt?: string,
+): Promise<PinataTemplate | null> {
+  if (!templateId) return null;
+  const token = jwt?.trim() || process.env.PINATA_JWT?.trim();
+  if (!token) return null;
+  try {
+    const data = await pinataFetch<unknown>(
+      `/v0/templates/id/${encodeURIComponent(templateId)}`,
+      { jwt: token, method: "GET" },
+    );
+    return normalizeTemplate(data);
+  } catch (err) {
+    if (
+      err instanceof PinataApiError &&
+      (err.status === 404 ||
+        err.status === 401 ||
+        err.status === 403 ||
+        err.status === 503)
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Resolve the Creative Twin *template* (not a deployed agent). Prefers the
+ * org template ID via PINATA_JWT, then public marketplace slug, then a
+ * static fallback so the deploy CTA still points at tmernpdi.
+ */
 export async function findCreativeTwinTemplate(): Promise<PinataTemplate | null> {
-  const all = await listPublicTemplates();
-  return all.find((t) => t.slug === CREATIVE_TWIN_TEMPLATE_SLUG) ?? null;
+  const now = Date.now();
+  if (twinTemplateCache && twinTemplateCache.expiresAt > now) {
+    return twinTemplateCache.value;
+  }
+
+  let template =
+    (await getTemplateById(CREATIVE_TWIN_TEMPLATE_ID).catch(() => null)) ?? null;
+
+  if (!template) {
+    const all = await listPublicTemplates().catch(() => [] as PinataTemplate[]);
+    template =
+      all.find((t) => t.templateId === CREATIVE_TWIN_TEMPLATE_ID) ??
+      all.find((t) => t.slug === CREATIVE_TWIN_TEMPLATE_SLUG) ??
+      null;
+  }
+
+  if (!template) {
+    template = creativeTwinTemplateFallback();
+  }
+
+  twinTemplateCache = { value: template, expiresAt: now + TEMPLATE_TTL_MS };
+  return template;
 }
 
 export async function getAgentDetailsResponse(


### PR DESCRIPTION
Look up tmernpdi via authenticated template API (with marketplace/fallback), and point the deploy CTA at the org template page instead of the public catalog.