### PR TITLE
feat: add Halliday  onramp to LicensePurchaseDialog

### DIFF
--- a/app/api/story/license-terms/route.ts
+++ b/app/api/story/license-terms/route.ts
@@ -100,9 +100,11 @@ export async function GET(request: NextRequest) {
     const client = createStoryClient(account.address, privateKey);
 
     try {
-      const terms = await client.license.getLicenseTerms(
+      const response = await client.license.getLicenseTerms(
         BigInt(resolvedLicenseTermsId)
       );
+
+      const terms = response.terms;
 
       return NextResponse.json({
         ipId: resolvedIpId,
@@ -111,7 +113,7 @@ export async function GET(request: NextRequest) {
           transferable: terms.transferable,
           commercialUse: terms.commercialUse,
           commercialAttribution: terms.commercialAttribution,
-          commercialRevShare: terms.commercialRevShare,
+          commercialRevShare: String(terms.commercialRevShare),
           commercialRevCeiling: terms.commercialRevCeiling?.toString(),
           derivativesAllowed: terms.derivativesAllowed,
           derivativesAttribution: terms.derivativesAttribution,

--- a/app/api/story/mint-license/route.ts
+++ b/app/api/story/mint-license/route.ts
@@ -125,8 +125,8 @@ export async function POST(request: NextRequest) {
     // (funding wallet pays). Free terms keep maxMintingFee at 0.
     let maxMintingFee = 0n;
     try {
-      const terms = await client.license.getLicenseTerms(termsId);
-      const fee = terms.defaultMintingFee;
+      const termsResponse = await client.license.getLicenseTerms(termsId);
+      const fee = termsResponse.terms.defaultMintingFee;
       if (fee !== undefined && fee !== null) {
         maxMintingFee = typeof fee === "bigint" ? fee : BigInt(fee);
       }

--- a/components/Videos/LicensePurchaseDialog.tsx
+++ b/components/Videos/LicensePurchaseDialog.tsx
@@ -19,10 +19,18 @@ import {
   Sparkles,
   Shield,
   ShoppingCart,
+  Wallet,
 } from "lucide-react";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { useAuthModal, useUser } from "@/lib/wallet/react";
+import { useSmartAccountClient } from "@/lib/wallet/react";
 import { logger } from "@/lib/utils/logger";
+import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
+import {
+  buildHallidayInputAssets,
+  buildHallidayStoryOutputAsset,
+  isHallidaySandboxEnabled,
+} from "@/lib/songchain/halliday";
 
 interface LicenseTerms {
   transferable: boolean;
@@ -53,9 +61,16 @@ export function LicensePurchaseDialog({
   open,
   onOpenChange,
 }: LicensePurchaseDialogProps) {
-  const { user } = useUser();
+  const user = useUser();
   const { openAuthModal } = useAuthModal();
   const { getAuthHeaders, address } = useWalletAuth();
+  const { client: smartAccountClient } = useSmartAccountClient({});
+
+  // Halliday onramp config for $DATA/IP purchase
+  const hallidayApiKey = process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() || null;
+  const hallidayOutputAsset = buildHallidayStoryOutputAsset();
+  const hallidayInputAssets = buildHallidayInputAssets();
+  const hallidaySandbox = isHallidaySandboxEnabled();
 
   const [terms, setTerms] = useState<LicenseTerms | null>(null);
   const [loadingTerms, setLoadingTerms] = useState(false);
@@ -308,32 +323,56 @@ export function LicensePurchaseDialog({
 
           {/* Action buttons */}
           {!success && (
-            <div className="flex gap-3">
-              <Button
-                onClick={handleMint}
-                disabled={minting || loadingTerms || !terms}
-                className="flex-1"
-              >
-                {minting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Minting License...
-                  </>
-                ) : (
-                  <>
-                    <ShoppingCart className="mr-2 h-4 w-4" />
-                    Buy License
-                  </>
-                )}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={minting}
-              >
-                Cancel
-              </Button>
-            </div>
+            <>
+              {/* Halliday onramp: show when minting fee > 0 so users can buy $DATA */}
+              {terms && BigInt(terms.defaultMintingFee || "0") > 0n && hallidayApiKey && (
+                <div className="space-y-2 pt-2 border-t">
+                  <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+                    <Wallet className="h-3.5 w-3.5" />
+                    Need $DATA to pay the minting fee? Buy with debit/credit:
+                  </p>
+                  <HallidayOnramp
+                    variant="story"
+                    hallidayApiKey={hallidayApiKey}
+                    hallidayOutputAsset={hallidayOutputAsset}
+                    hallidayInputAssets={hallidayInputAssets}
+                    hallidaySandbox={hallidaySandbox}
+                    destinationAddressOverride={
+                      smartAccountClient?.account?.address ?? address ?? null
+                    }
+                    lazyInit
+                    hideLensBlockedMessage
+                  />
+                </div>
+              )}
+
+              <div className="flex gap-3">
+                <Button
+                  onClick={handleMint}
+                  disabled={minting || loadingTerms || !terms}
+                  className="flex-1"
+                >
+                  {minting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Minting License...
+                    </>
+                  ) : (
+                    <>
+                      <ShoppingCart className="mr-2 h-4 w-4" />
+                      Buy License
+                    </>
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  disabled={minting}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </>
           )}
 
           {/* Success: Creative Pixels CTA */}


### PR DESCRIPTION
## Summary

Adds the Halliday fiat onramp to the LicensePurchaseDialog that was lost during the squash merge of PR #246.

### Changes
- **LicensePurchaseDialog**: Shows Halliday onramp when  so buyers can purchase  with debit/credit to pay the creator's minting fee
- Funds the buyer's smart account directly (not the system gas wallet)
- Also fixes  response type (terms nested under  property) in both  and  routes
- Fixes  destructuring in LicensePurchaseDialog

### Why this was needed
PR #246 had two commits — the squash merge included the first commit (IP license purchase + Creative Pixels + Mixtape) but the second commit (Halliday onramp in LicensePurchaseDialog) was not included. This PR restores that missing piece.

### Verification
- TypeScript: 0 errors
- Tests: 47/47 passed (Story + Songchain)