### PR TITLE
Fix Vercel build missing @types/d3

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@supabase/supabase-js": "^2.57.4",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.50.1",
-    "@types/d3": "^7.4.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@unlock-protocol/contracts": "^0.0.35",
     "@unlock-protocol/paywall": "^0.8.1",
@@ -170,6 +169,7 @@
   "devDependencies": {
     "@mark3labs/louper-cli": "^0.5.10",
     "@thirdweb-dev/contracts": "^3.15.0",
+    "@types/d3": "^7.4.3",
     "@types/node": "^22.15.18",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@supabase/supabase-js": "^2.57.4",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.50.1",
+    "@types/d3": "^7.4.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@unlock-protocol/contracts": "^0.0.35",
     "@unlock-protocol/paywall": "^0.8.1",
@@ -169,7 +170,6 @@
   "devDependencies": {
     "@mark3labs/louper-cli": "^0.5.10",
     "@thirdweb-dev/contracts": "^3.15.0",
-    "@types/d3": "^7.4.3",
     "@types/node": "^22.15.18",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "NODE_OPTIONS": "--max-old-space-size=6144 --no-deprecation"
     }
   },
-  "installCommand": "yarn install --network-timeout 600000",
+  "installCommand": "yarn install --production=false --network-timeout 600000",
   "crons": [
     {
       "path": "/api/video-assets/sync-views/cron",


### PR DESCRIPTION
## Summary
- Force Vercel install with `--production=false` so Yarn still installs build-time packages like `@types/d3` and `typescript` when `NODE_ENV=production`.
- Keep `@types/d3` in `devDependencies` (review feedback: moving it to `dependencies` is redundant once install is fixed).

## Test plan
- [ ] Confirm Vercel preview/production build gets past TypeScript for `ClubAffinityCircleGraph.tsx`
- [ ] Confirm `yarn install` still resolves `@types/d3` locally
- [ ] Spot-check club affinity circle still renders