### PR TITLE
Make louper-cli optional for Vercel installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "@mark3labs/louper-cli": "^0.5.10",
     "@thirdweb-dev/contracts": "^3.15.0",
     "@types/d3": "^7.4.3",
     "@types/node": "^22.15.18",
@@ -184,6 +183,9 @@
     "tsx": "^4.20.5",
     "typescript": "^5.8.3",
     "vitest": "^2.1.0"
+  },
+  "optionalDependencies": {
+    "@mark3labs/louper-cli": "^0.5.10"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
## Summary
- Move `@mark3labs/louper-cli` from `devDependencies` to `optionalDependencies` so Yarn continues when its `go-npm` postinstall fails on Vercel.
- Keeps `--production=false` install command from #257; Louper remains available locally when install succeeds.

## Test plan
- [ ] Confirm Vercel preview/production install no longer exits on `@mark3labs/louper-cli` / `go-npm`
- [ ] Confirm Next.js build proceeds past `yarn install`
- [ ] Optionally verify local `yarn metokens:inspect-diamond` still works when Louper binary installs successfully


Made with [Cursor](https://cursor.com)