### PR TITLE
Improve video sharing, live Lens chat, and IP licensing

### DIFF
--- a/app/api/og/video/route.ts
+++ b/app/api/og/video/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  getVideoAssetByAssetId,
+  getVideoAssetByPlaybackId,
+} from "@/services/video-assets";
+import { convertFailingGateway } from "@/lib/utils/image-gateway";
+import { serverLogger } from "@/lib/utils/logger";
+
+export const runtime = "nodejs";
+
+const FETCH_TIMEOUT_MS = 8_000;
+const CACHE_HEADER =
+  "public, s-maxage=86400, stale-while-revalidate=604800";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function fallbackImage(): Promise<NextResponse> {
+  const filePath = path.join(process.cwd(), "public", "Creative_TV.png");
+  const buffer = await readFile(filePath);
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": CACHE_HEADER,
+    },
+  });
+}
+
+function isUsableRemoteUrl(url: string): boolean {
+  if (!url) return false;
+  if (url.includes("storage.googleapis.com/lp-ai-generate-com")) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function fetchRemoteImage(
+  url: string
+): Promise<{ body: ArrayBuffer; contentType: string } | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "image/*,*/*" },
+      redirect: "follow",
+    });
+    if (!res.ok) return null;
+    const contentType = res.headers.get("content-type") || "";
+    if (contentType && !contentType.startsWith("image/")) return null;
+    const body = await res.arrayBuffer();
+    if (!body.byteLength) return null;
+    return {
+      body,
+      contentType: contentType.startsWith("image/")
+        ? contentType
+        : "image/jpeg",
+    };
+  } catch (err) {
+    serverLogger.warn("OG video image fetch failed:", { url, err });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolveThumbnailUrl(
+  id: string | null,
+  playbackId: string | null
+): Promise<string | null> {
+  if (id) {
+    if (!UUID_REGEX.test(id)) return null;
+    const asset = await getVideoAssetByAssetId(id).catch((err) => {
+      serverLogger.warn("OG video: getVideoAssetByAssetId failed", err);
+      return null;
+    });
+    const raw = (asset as { thumbnail_url?: string | null } | null)
+      ?.thumbnail_url;
+    if (raw?.trim()) return convertFailingGateway(raw.trim());
+  }
+
+  if (playbackId) {
+    const asset = await getVideoAssetByPlaybackId(playbackId).catch((err) => {
+      serverLogger.warn("OG video: getVideoAssetByPlaybackId failed", err);
+      return null;
+    });
+    const raw = asset?.thumbnail_url;
+    if (raw?.trim()) return convertFailingGateway(raw.trim());
+  }
+
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl;
+    const id = searchParams.get("id");
+    const playbackId = searchParams.get("playbackId");
+
+    if (!id && !playbackId) {
+      return fallbackImage();
+    }
+
+    const thumbnailUrl = await resolveThumbnailUrl(id, playbackId);
+
+    if (thumbnailUrl && isUsableRemoteUrl(thumbnailUrl)) {
+      const remote = await fetchRemoteImage(thumbnailUrl);
+      if (remote) {
+        return new NextResponse(remote.body, {
+          status: 200,
+          headers: {
+            "Content-Type": remote.contentType,
+            "Cache-Control": CACHE_HEADER,
+          },
+        });
+      }
+    }
+
+    return fallbackImage();
+  } catch (error) {
+    serverLogger.error("OG video route error:", error);
+    try {
+      return await fallbackImage();
+    } catch {
+      return new NextResponse("OG image unavailable", { status: 500 });
+    }
+  }
+}

--- a/app/api/og/video/route.ts
+++ b/app/api/og/video/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
+import dns from "node:dns";
 import path from "node:path";
 import {
   getVideoAssetByAssetId,
@@ -17,6 +18,33 @@ const CACHE_HEADER =
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+/** Host suffixes permitted for remote OG thumbnail fetches (SSRF mitigation). */
+const ALLOWED_HOST_SUFFIXES = [
+  "creativeplatform.xyz",
+  "ipfs.io",
+  "dweb.link",
+  "w3s.link",
+  "cf-ipfs.com",
+  "gateway.ipfscdn.io",
+  "4everland.io",
+  "pinata.cloud",
+  "gateway.pinata.cloud",
+  "grove.storage",
+  "api.grove.storage",
+  "lighthouse.storage",
+  "gateway.lighthouse.storage",
+  "livepeer.studio",
+  "livepeercdn.com",
+  "livepeercdn.studio",
+  "lp-playback.studio",
+  "vod-cdn.lp-playback.studio",
+  "storage.googleapis.com",
+  "cloudflare-ipfs.com",
+  "orb.club",
+  "vercel-storage.com",
+  "public.blob.vercel-storage.com",
+] as const;
+
 async function fallbackImage(): Promise<NextResponse> {
   const filePath = path.join(process.cwd(), "public", "Creative_TV.png");
   const buffer = await readFile(filePath);
@@ -29,15 +57,69 @@ async function fallbackImage(): Promise<NextResponse> {
   });
 }
 
-function isUsableRemoteUrl(url: string): boolean {
+function isPrivateIp(ip: string): boolean {
+  if (
+    ip.startsWith("127.") ||
+    ip.startsWith("10.") ||
+    ip.startsWith("192.168.") ||
+    ip.startsWith("169.254.") ||
+    ip.startsWith("0.")
+  ) {
+    return true;
+  }
+  if (ip.startsWith("172.")) {
+    const second = parseInt(ip.split(".")[1] ?? "", 10);
+    if (second >= 16 && second <= 31) return true;
+  }
+  if (
+    ip === "::1" ||
+    ip.startsWith("fe80:") ||
+    ip.startsWith("fc00:") ||
+    ip.startsWith("fd00:")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isAllowedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host === "0.0.0.0" ||
+    host === "[::1]"
+  ) {
+    return false;
+  }
+  return ALLOWED_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`)
+  );
+}
+
+async function isSafeRemoteThumbnailUrl(url: string): Promise<boolean> {
   if (!url) return false;
   if (url.includes("storage.googleapis.com/lp-ai-generate-com")) return false;
+
+  let parsed: URL;
   try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    parsed = new URL(url);
   } catch {
     return false;
   }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  if (!isAllowedHostname(parsed.hostname)) return false;
+
+  try {
+    const addresses = await dns.promises.lookup(parsed.hostname, { all: true });
+    if (addresses.length === 0) return false;
+    if (addresses.some(({ address }) => isPrivateIp(address))) return false;
+  } catch {
+    return false;
+  }
+
+  return true;
 }
 
 async function fetchRemoteImage(
@@ -46,22 +128,36 @@ async function fetchRemoteImage(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: { Accept: "image/*,*/*" },
-      redirect: "follow",
-    });
-    if (!res.ok) return null;
-    const contentType = res.headers.get("content-type") || "";
-    if (contentType && !contentType.startsWith("image/")) return null;
-    const body = await res.arrayBuffer();
-    if (!body.byteLength) return null;
-    return {
-      body,
-      contentType: contentType.startsWith("image/")
-        ? contentType
-        : "image/jpeg",
-    };
+    // Manual redirects so each hop is re-checked against the allowlist.
+    let current = url;
+    for (let hop = 0; hop < 3; hop++) {
+      if (!(await isSafeRemoteThumbnailUrl(current))) return null;
+      const res = await fetch(current, {
+        signal: controller.signal,
+        headers: { Accept: "image/*,*/*" },
+        redirect: "manual",
+      });
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get("location");
+        if (!location) return null;
+        current = new URL(location, current).toString();
+        continue;
+      }
+
+      if (!res.ok) return null;
+      const contentType = res.headers.get("content-type") || "";
+      if (contentType && !contentType.startsWith("image/")) return null;
+      const body = await res.arrayBuffer();
+      if (!body.byteLength) return null;
+      return {
+        body,
+        contentType: contentType.startsWith("image/")
+          ? contentType
+          : "image/jpeg",
+      };
+    }
+    return null;
   } catch (err) {
     serverLogger.warn("OG video image fetch failed:", { url, err });
     return null;
@@ -109,7 +205,7 @@ export async function GET(request: NextRequest) {
 
     const thumbnailUrl = await resolveThumbnailUrl(id, playbackId);
 
-    if (thumbnailUrl && isUsableRemoteUrl(thumbnailUrl)) {
+    if (thumbnailUrl && (await isSafeRemoteThumbnailUrl(thumbnailUrl))) {
       const remote = await fetchRemoteImage(thumbnailUrl);
       if (remote) {
         return new NextResponse(remote.body, {

--- a/app/api/streams/creator/[address]/route.ts
+++ b/app/api/streams/creator/[address]/route.ts
@@ -31,6 +31,7 @@ export async function GET(
         story_ip_id: null,
         story_license_terms_id: null,
         story_commercial_rev_share: null,
+        lens_live_post_id: null,
       });
     }
 
@@ -47,6 +48,7 @@ export async function GET(
       story_ip_id: stream.story_ip_id ?? null,
       story_license_terms_id: stream.story_license_terms_id ?? null,
       story_commercial_rev_share: stream.story_commercial_rev_share ?? null,
+      lens_live_post_id: stream.lens_live_post_id ?? null,
     });
   } catch (error) {
     return NextResponse.json(

--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -20,12 +20,18 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { VideoShareButton } from "@/components/Videos/VideoShareButton";
 import { VideoBuyButton } from "@/components/Videos/VideoBuyButton";
+import { BuyIPButton } from "@/components/Videos/BuyIPButton";
+import { CreatorMessageButton } from "@/components/Videos/CreatorMessageButton";
 import { VideoEditButton } from "@/components/Videos/VideoEditButton";
 import { VideoSplitDistributeButton } from "@/components/Videos/VideoSplitDistributeButton";
 import { RemixInPixelsButton } from "@/components/Videos/RemixInPixelsButton";
 import { AddToMixtapeButton } from "@/components/Videos/AddToMixtapeButton";
 import { logger } from '@/lib/utils/logger';
-import { convertFailingGateway } from "@/lib/utils/image-gateway";
+import {
+  getSiteOrigin,
+  getVideoOgImageUrl,
+  VIDEO_OG_IMAGE,
+} from "@/lib/utils/og-image";
 
 type VideoDetailsPageProps = {
   params: Promise<{
@@ -182,6 +188,28 @@ export default async function VideoDetailsPage({
                     />
                   )}
                 </Suspense>
+                {creatorAddress &&
+                  videoAsset?.attributes?.content_coin_id && (
+                    <Suspense fallback={<div className="h-9 w-9" />}>
+                      <CreatorMessageButton
+                        creatorAddress={creatorAddress}
+                        meTokenAddress={
+                          videoAsset.attributes.content_coin_id as string
+                        }
+                      />
+                    </Suspense>
+                  )}
+                {videoAsset?.story_ip_registered &&
+                  videoAsset?.story_ip_id &&
+                  videoAsset?.story_license_terms_id && (
+                    <Suspense fallback={<div className="h-9 w-9" />}>
+                      <BuyIPButton
+                        ipId={videoAsset.story_ip_id}
+                        licenseTermsId={String(videoAsset.story_license_terms_id)}
+                        videoTitle={videoAsset?.title || assetData?.name || "Video"}
+                      />
+                    </Suspense>
+                  )}
                 <Suspense fallback={<div className="h-9 w-9" />}>
                   <AddToMixtapeButton
                     assetId={id}
@@ -248,31 +276,9 @@ export async function generateMetadata({
       return { title: "Video Not Found" };
     }
 
-    let thumbnailUrl =
-      (videoAsset as any)?.thumbnail_url?.trim() ||
-      (assetData as any)?.thumbnailUri?.trim() ||
-      null;
-
-    if (!thumbnailUrl || thumbnailUrl === "") {
-      thumbnailUrl = "/Creative_TV.png";
-    } else {
-      thumbnailUrl = convertFailingGateway(thumbnailUrl);
-    }
-
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ||
-      (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` :
-        "https://tv.creativeplatform.xyz");
+    const baseUrl = getSiteOrigin();
     const absoluteUrl = `${baseUrl}/discover/${id}`;
-
-    let absoluteThumbnailUrl: string;
-    if (thumbnailUrl.startsWith("http://") || thumbnailUrl.startsWith("https://")) {
-      absoluteThumbnailUrl = thumbnailUrl;
-    } else {
-      const normalizedPath = thumbnailUrl.startsWith("/")
-        ? thumbnailUrl
-        : `/${thumbnailUrl}`;
-      absoluteThumbnailUrl = `${baseUrl}${normalizedPath}`;
-    }
+    const ogImageUrl = getVideoOgImageUrl({ id });
 
     let videoTitle = (videoAsset as any)?.title || assetData.name || "Watch Video";
     if (videoTitle.endsWith('.mp4')) {
@@ -281,31 +287,29 @@ export async function generateMetadata({
 
     const videoDescription = (videoAsset as any)?.description ?? `Watch ${videoTitle} on Creative TV`;
 
+    const ogImage = {
+      url: ogImageUrl,
+      width: VIDEO_OG_IMAGE.width,
+      height: VIDEO_OG_IMAGE.height,
+      alt: videoTitle || VIDEO_OG_IMAGE.alt,
+      type: VIDEO_OG_IMAGE.type,
+    };
+
     return {
       title: videoTitle,
       description: videoDescription,
       openGraph: {
         title: videoTitle,
         description: videoDescription,
-        images: [absoluteThumbnailUrl],
+        images: [ogImage],
         url: absoluteUrl,
-        type: "video.other",
-        videos: assetData.playbackUrl
-          ? [
-            {
-              url: assetData.playbackUrl,
-              type: "video/mp4",
-              width: 1280,
-              height: 720,
-            },
-          ]
-          : [],
+        type: "website",
       },
       twitter: {
         card: "summary_large_image",
         title: videoTitle,
         description: videoDescription,
-        images: [absoluteThumbnailUrl],
+        images: [ogImageUrl],
       },
     };
   } catch (error) {

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -557,16 +557,17 @@ export default function LivePage() {
                           playbackId
                             ? buildGoingLivePostContent({
                                 streamName: streamName || "Live stream",
-                                watchUrl: `${typeof window !== "undefined" ? window.location.origin : "https://tv.creativeplatform.xyz"}/watch/${playbackId}`,
+                                watchUrl: `${(process.env.NEXT_PUBLIC_SITE_URL || "https://tv.creativeplatform.xyz").replace(/\/$/, "")}/watch/${playbackId}`,
                               })
                             : null
                         }
                         onEnsurePost={async () => {
                           if (!playbackId || !creatorAddress) return null;
-                          const watchUrl =
-                            typeof window !== "undefined"
-                              ? `${window.location.origin}/watch/${playbackId}`
-                              : undefined;
+                          const siteOrigin = (
+                            process.env.NEXT_PUBLIC_SITE_URL ||
+                            "https://tv.creativeplatform.xyz"
+                          ).replace(/\/$/, "");
+                          const watchUrl = `${siteOrigin}/watch/${playbackId}`;
                           const content = buildGoingLivePostContent({
                             streamName: streamName || "Live stream",
                             watchUrl,

--- a/app/live/[address]/page.tsx
+++ b/app/live/[address]/page.tsx
@@ -45,7 +45,9 @@ import { getThumbnailUrl } from "@/services/livepeer-thumbnails";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { LiveTokenPanel } from "@/components/Live/LiveTokenPanel";
-import { LiveChat } from "@/components/Live/LiveChat";
+import { LensLiveChat } from "@/components/Live/LensLiveChat";
+import { useEnsureLiveLensPost } from "@/hooks/useEnsureLiveLensPost";
+import { buildGoingLivePostContent } from "@/lib/live/lens-live-feed";
 import { ShareDialog } from "@/components/Videos/ShareDialog";
 import { useLivepeerRealtimeMetrics } from "@/lib/hooks/livepeer/useLivepeerRealtimeMetrics";
 import { ModeratorsDialog } from "@/components/Live/ModeratorsDialog";
@@ -115,6 +117,9 @@ export default function LivePage() {
   const [storyIpId, setStoryIpId] = useState<string | null>(null);
   const [storyLicenseTermsId, setStoryLicenseTermsId] = useState<string | null>(null);
   const [storyRevShare, setStoryRevShare] = useState<number | null>(null);
+  const [lensLivePostId, setLensLivePostId] = useState<string | null>(null);
+  const { ensureLivePost, isPosting: isEnsuringLensPost } =
+    useEnsureLiveLensPost();
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [songchainShareOpen, setSongchainShareOpen] = useState(false);
   const [moderatorsDialogOpen, setModeratorsDialogOpen] = useState(false);
@@ -220,6 +225,7 @@ export default function LivePage() {
           setStoryIpId(stream.story_ip_id ?? null);
           setStoryLicenseTermsId(stream.story_license_terms_id ?? null);
           setStoryRevShare(stream.story_commercial_rev_share ?? null);
+          setLensLivePostId(stream.lens_live_post_id ?? null);
         } else {
           logger.error("Error fetching stream metadata:", await res.text());
         }
@@ -541,13 +547,44 @@ export default function LivePage() {
                         streamId={chatStreamId}
                         sessionId={chatSessionId}
                       />
-                      <LiveChat
-                        streamId={chatStreamId}
-                        sessionId={chatSessionId}
-                        creatorAddress={creatorAddress!}
-                        viewerCount={viewerCount}
+                      <LensLiveChat
+                        lensPostId={lensLivePostId}
                         variant="host"
                         className="h-[min(70vh,520px)] mt-4"
+                        ensuringPost={isEnsuringLensPost}
+                        streamName={streamName}
+                        goingLivePreview={
+                          playbackId
+                            ? buildGoingLivePostContent({
+                                streamName: streamName || "Live stream",
+                                watchUrl: `${typeof window !== "undefined" ? window.location.origin : "https://tv.creativeplatform.xyz"}/watch/${playbackId}`,
+                              })
+                            : null
+                        }
+                        onEnsurePost={async () => {
+                          if (!playbackId || !creatorAddress) return null;
+                          const watchUrl =
+                            typeof window !== "undefined"
+                              ? `${window.location.origin}/watch/${playbackId}`
+                              : undefined;
+                          const content = buildGoingLivePostContent({
+                            streamName: streamName || "Live stream",
+                            watchUrl,
+                          });
+                          const postId = await ensureLivePost({
+                            creatorAddress,
+                            existingPostId: lensLivePostId,
+                            stream: {
+                              playback_id: playbackId,
+                              name: streamName,
+                              thumbnail_url: thumbnailUrl,
+                              is_live: true,
+                            },
+                            contentOverride: content,
+                          });
+                          if (postId) setLensLivePostId(postId);
+                          return postId;
+                        }}
                       />
                     </>
                   )}

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -362,6 +362,26 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
     status.kind === "offline-temporary" ? 15000 : null
   );
 
+  // While live (or gated), refresh stream metadata until Lens chat is activated
+  // so viewers who joined early pick up lens_live_post_id without a full reload.
+  useInterval(
+    useCallback(async () => {
+      if (!playbackId) return;
+      try {
+        const streamRecord = await getStreamByPlaybackId(playbackId);
+        if (streamRecord) {
+          setStreamData(streamRecord as import("@/services/streams").Stream);
+        }
+      } catch (err) {
+        logger.warn("Stream metadata refresh failed:", err);
+      }
+    }, [playbackId]),
+    (status.kind === "live" || status.kind === "metoken-gated") &&
+      !streamData?.lens_live_post_id
+      ? 15000
+      : null
+  );
+
   // Generate a consistent sessionId based on playbackId so viewers share the same chat session.
   const sessionId = playbackId ? `session-${playbackId}` : "";
   const streamId = playbackId || "";

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -7,7 +7,7 @@ import { Player } from "@/components/Player/Player";
 import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
 import { getStreamByPlaybackId } from "@/services/streams";
 import { LiveTokenPanel } from "@/components/Live/LiveTokenPanel";
-import { LiveChat } from "@/components/Live/LiveChat";
+import { LensLiveChat } from "@/components/Live/LensLiveChat";
 import { ClipCreator } from "@/components/Live/ClipCreator";
 import { DigitalTwinOverlay } from "@/components/Live/DigitalTwinOverlay";
 import { Src } from "@livepeer/react";
@@ -581,11 +581,8 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
               />
             )}
             {playbackId && sessionId ? (
-              <LiveChat
-                streamId={streamId}
-                sessionId={sessionId}
-                creatorAddress={streamData?.creator_id ?? null}
-                viewerCount={viewerCount}
+              <LensLiveChat
+                lensPostId={streamData?.lens_live_post_id ?? null}
               />
             ) : (
               <div className="border rounded-lg p-4 text-sm text-muted-foreground">

--- a/app/watch/[playbackId]/page.tsx
+++ b/app/watch/[playbackId]/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata, ResolvingMetadata } from "next";
 import { getVideoAssetByPlaybackId } from "@/services/video-assets";
 import { getTokenMarketData } from "@/lib/services/market";
+import {
+  getVideoOgImageUrl,
+  VIDEO_OG_IMAGE,
+} from "@/lib/utils/og-image";
 import WatchClient from "./WatchClient";
 
 interface WatchPageProps {
@@ -29,48 +33,66 @@ export async function generateMetadata(
 
         const title = videoAsset?.title || "Live Stream";
         const desc = "Watch on Creative TV";
+        const ogImageUrl = getVideoOgImageUrl({ playbackId });
+        const ogImage = {
+            url: ogImageUrl,
+            width: VIDEO_OG_IMAGE.width,
+            height: VIDEO_OG_IMAGE.height,
+            alt: title || VIDEO_OG_IMAGE.alt,
+            type: VIDEO_OG_IMAGE.type,
+        };
 
-        if (!tokenAddress) {
-            return {
-                title: videoAsset?.title ? `Watch ${title}` : 'Watch Live',
-                description: desc,
-            };
-        }
+        if (tokenAddress) {
+            const marketData = await getTokenMarketData(tokenAddress).catch((err) => {
+                console.error("Watch page metadata: market data fetch failed", err);
+                return null;
+            });
 
-        const marketData = await getTokenMarketData(tokenAddress).catch((err) => {
-            console.error("Watch page metadata: market data fetch failed", err);
-            return null;
-        });
+            if (marketData) {
+                const price = `$${marketData.price.toFixed(4)}`;
+                const tvl = marketData.tvl >= 1000
+                    ? `$${(marketData.tvl / 1000).toFixed(1)}K`
+                    : `$${marketData.tvl.toFixed(2)}`;
 
-        if (marketData) {
-            const price = `$${marketData.price.toFixed(4)}`;
-            const tvl = marketData.tvl >= 1000
-                ? `$${(marketData.tvl / 1000).toFixed(1)}K`
-                : `$${marketData.tvl.toFixed(2)}`;
+                const metaTitle = `${marketData.symbol} ($${price}) - ${title}`;
+                const metaDesc = `Watch & Trade ${marketData.symbol}. TVL: ${tvl}. ${desc}`;
 
-            const metaTitle = `${marketData.symbol} ($${price}) - ${title}`;
-            const metaDesc = `Watch & Trade ${marketData.symbol}. TVL: ${tvl}. ${desc}`;
-
-            return {
-                title: metaTitle,
-                description: metaDesc,
-                openGraph: {
+                return {
                     title: metaTitle,
                     description: metaDesc,
-                    images: videoAsset?.thumbnail_url ? [videoAsset.thumbnail_url] : [],
-                },
-                twitter: {
-                    card: "summary_large_image",
-                    title: metaTitle,
-                    description: metaDesc,
-                    images: videoAsset?.thumbnail_url ? [videoAsset.thumbnail_url] : [],
-                }
-            };
+                    openGraph: {
+                        title: metaTitle,
+                        description: metaDesc,
+                        type: "website",
+                        images: [ogImage],
+                    },
+                    twitter: {
+                        card: "summary_large_image",
+                        title: metaTitle,
+                        description: metaDesc,
+                        images: [ogImageUrl],
+                    },
+                };
+            }
         }
+
+        const metaTitle = videoAsset?.title ? `Watch ${title}` : "Watch Live";
 
         return {
-            title: `Watch ${title}`,
+            title: metaTitle,
             description: desc,
+            openGraph: {
+                title: metaTitle,
+                description: desc,
+                type: "website",
+                images: [ogImage],
+            },
+            twitter: {
+                card: "summary_large_image",
+                title: metaTitle,
+                description: desc,
+                images: [ogImageUrl],
+            },
         };
     } catch (err) {
         console.error("Watch page generateMetadata failed", err);

--- a/components/Live/LensLiveChat.tsx
+++ b/components/Live/LensLiveChat.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+/**
+ * Live stream chat backed by Lens comments on a going-live root post (option B).
+ * Replaces XMTP session groups for livestream chat.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  fetchPostReferences,
+  post as createLensPost,
+} from "@lens-protocol/client/actions";
+import { PostReferenceType, postId, uri } from "@lens-protocol/client";
+import type { AnyPost } from "@lens-protocol/graphql";
+import { textOnly } from "@lens-protocol/metadata";
+import { publicClient } from "@/lib/sdk/lens/client";
+import { groveService } from "@/lib/sdk/grove/service";
+import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
+import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertCircle,
+  HelpCircle,
+  Loader2,
+  MessageCircle,
+  Radio,
+  Send,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const POLL_MS = 8_000;
+
+interface LensLiveChatProps {
+  lensPostId: string | null | undefined;
+  className?: string;
+  headerActions?: React.ReactNode;
+  variant?: "participant" | "host";
+  /** Called when host should create/ensure the going-live post. */
+  onEnsurePost?: () => Promise<string | null>;
+  ensuringPost?: boolean;
+  /** Preview of the Lens post that will be published when chat is activated. */
+  goingLivePreview?: string | null;
+  /** Stream display name for copy. */
+  streamName?: string | null;
+}
+
+function commentAuthorLabel(item: AnyPost): string {
+  const author = (item as any)?.author;
+  const handle =
+    author?.username?.localName ||
+    author?.username?.value ||
+    author?.username;
+  if (typeof handle === "string" && handle.length > 0) return `@${handle}`;
+  const addr = author?.address as string | undefined;
+  if (addr) return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+  return "anon";
+}
+
+function commentText(item: AnyPost): string {
+  const meta = (item as any)?.metadata;
+  if (meta?.content && typeof meta.content === "string") return meta.content;
+  return "";
+}
+
+export function LensLiveChat({
+  lensPostId,
+  className,
+  headerActions,
+  variant = "participant",
+  onEnsurePost,
+  ensuringPost,
+  goingLivePreview,
+  streamName,
+}: LensLiveChatProps) {
+  const [message, setMessage] = useState("");
+  const [comments, setComments] = useState<AnyPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const isHost = variant === "host";
+
+  const {
+    canWrite,
+    promptWriteAccess,
+    getSessionClient,
+    lensAccount,
+  } = useLensOrbWrite();
+
+  const loadComments = useCallback(async () => {
+    if (!lensPostId) return;
+    try {
+      const result = await fetchPostReferences(publicClient, {
+        referencedPost: postId(lensPostId),
+        referenceTypes: [PostReferenceType.CommentOn],
+      });
+      if (result.isOk()) {
+        setComments([...result.value.items]);
+        setError(null);
+      } else {
+        setError(result.error.message);
+      }
+    } catch (err) {
+      logger.warn("Lens live chat load failed:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to load live chat"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [lensPostId]);
+
+  useEffect(() => {
+    if (!lensPostId) return;
+    setLoading(true);
+    void loadComments();
+    const timer = setInterval(() => void loadComments(), POLL_MS);
+    return () => clearInterval(timer);
+  }, [lensPostId, loadComments]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [comments.length]);
+
+  const handleSend = async () => {
+    const trimmed = message.trim();
+    if (!trimmed || !lensPostId) return;
+
+    if (!canWrite) {
+      promptWriteAccess();
+      toast.info("Link Orb / Lens to chat on this live stream.");
+      return;
+    }
+
+    setSending(true);
+    try {
+      const client = await getSessionClient();
+      const metadata = textOnly({ content: trimmed, locale: "en" });
+      const upload = await groveService.uploadJson(metadata);
+      if (!upload.success || !upload.url) {
+        throw new Error("Failed to upload message metadata");
+      }
+      const result = await createLensPost(client, {
+        contentUri: uri(upload.url),
+        commentOn: { post: postId(lensPostId) },
+      });
+      if (result.isErr()) {
+        throw new Error(result.error.message);
+      }
+      setMessage("");
+      void loadComments();
+    } catch (err) {
+      clearStaleOrbSessionIfNeeded(err);
+      toast.error(err instanceof Error ? err.message : "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!lensPostId) {
+    return (
+      <div
+        className={cn(
+          "border rounded-lg flex flex-col h-[500px] max-h-[70vh]",
+          className
+        )}
+      >
+        <div className="flex items-center justify-between p-3 border-b">
+          <div className="flex items-center gap-2">
+            <MessageCircle className="h-4 w-4 text-red-500" />
+            <span className="text-sm font-medium">Live chat</span>
+            {isHost && (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground"
+                      aria-label="How live chat works"
+                    >
+                      <HelpCircle className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-left">
+                    Activating chat posts a public “going live” announcement on
+                    Lens. Viewer messages become comments on that post — anyone
+                    on Orb/Lens can discover and join the conversation.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+          {headerActions}
+        </div>
+        <div className="flex-1 flex flex-col items-stretch justify-center gap-4 p-5">
+          {isHost ? (
+            <>
+              <div className="space-y-2 text-left">
+                <div className="flex items-center gap-2">
+                  <Radio className="h-4 w-4 text-red-500" />
+                  <p className="text-sm font-medium">Activate public live chat</p>
+                </div>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  Optional. When you activate, we publish a Lens post for{" "}
+                  <span className="font-medium text-foreground">
+                    {streamName?.trim() || "this stream"}
+                  </span>
+                  . Viewers chat by commenting — visible on Creative TV and Orb.
+                  You need Orb linked to your wallet.
+                </p>
+                <ol className="text-xs text-muted-foreground list-decimal list-inside space-y-1">
+                  <li>Review the going-live message below</li>
+                  <li>Click Activate live chat</li>
+                  <li>Viewers can comment once you&apos;re live</li>
+                </ol>
+              </div>
+
+              {goingLivePreview && (
+                <div className="rounded-md border bg-muted/40 p-3 text-left">
+                  <p className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1.5">
+                    Post preview
+                  </p>
+                  <pre className="text-xs whitespace-pre-wrap font-sans text-foreground/90">
+                    {goingLivePreview}
+                  </pre>
+                </div>
+              )}
+
+              {onEnsurePost && (
+                <Button
+                  className="w-full"
+                  onClick={() => void onEnsurePost()}
+                  disabled={ensuringPost}
+                >
+                  {ensuringPost ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Publishing on Lens…
+                    </>
+                  ) : (
+                    "Activate live chat"
+                  )}
+                </Button>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center">
+              The host hasn&apos;t activated public chat for this stream yet.
+            </p>
+          )}
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "border rounded-lg flex flex-col h-[500px] max-h-[70vh]",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between p-3 border-b">
+        <div className="flex items-center gap-2">
+          <MessageCircle className="h-4 w-4 text-red-500" />
+          <span className="text-sm font-medium">Live chat</span>
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Lens
+          </span>
+        </div>
+        {headerActions}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {loading && comments.length === 0 ? (
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-3/4" />
+            <Skeleton className="h-8 w-1/2" />
+            <Skeleton className="h-8 w-2/3" />
+          </div>
+        ) : comments.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No messages yet — be the first.
+          </p>
+        ) : (
+          comments.map((item) => (
+            <div key={item.id} className="text-sm">
+              <span className="font-medium text-muted-foreground mr-2">
+                {commentAuthorLabel(item)}
+              </span>
+              <span className="break-words">{commentText(item)}</span>
+            </div>
+          ))
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {!isHost && (
+        <div className="p-3 border-t flex gap-2">
+          {!canWrite ? (
+            <Button
+              className="w-full"
+              variant="outline"
+              onClick={() => promptWriteAccess()}
+            >
+              Connect Orb to chat
+            </Button>
+          ) : (
+            <>
+              <Input
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder={
+                  lensAccount ? "Say something…" : "Write a message…"
+                }
+                maxLength={500}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    void handleSend();
+                  }
+                }}
+                disabled={sending}
+              />
+              <Button
+                size="icon"
+                onClick={() => void handleSend()}
+                disabled={sending || !message.trim()}
+              >
+                {sending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Live/LensLiveChat.tsx
+++ b/components/Live/LensLiveChat.tsx
@@ -56,13 +56,21 @@ interface LensLiveChatProps {
 }
 
 function commentAuthorLabel(item: AnyPost): string {
-  const author = (item as any)?.author;
+  // Lens canary / Songchain posts use `author` (not V2 `by`).
+  const raw = item as any;
+  const author = raw?.author ?? raw?.by;
   const handle =
     author?.username?.localName ||
     author?.username?.value ||
-    author?.username;
-  if (typeof handle === "string" && handle.length > 0) return `@${handle}`;
-  const addr = author?.address as string | undefined;
+    author?.handle?.localName ||
+    author?.handle?.fullHandle ||
+    (typeof author?.username === "string" ? author.username : null);
+  if (typeof handle === "string" && handle.length > 0) {
+    return handle.startsWith("@") ? handle : `@${handle}`;
+  }
+  const addr =
+    (author?.address as string | undefined) ||
+    (author?.ownedBy?.address as string | undefined);
   if (addr) return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
   return "anon";
 }

--- a/components/Videos/BuyIPButton.tsx
+++ b/components/Videos/BuyIPButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { useState } from "react";
+import { Shield } from "lucide-react";
+import { Button } from "../ui/button";
+import { LicensePurchaseDialog } from "./LicensePurchaseDialog";
+
+interface BuyIPButtonProps {
+  ipId: string;
+  licenseTermsId: string;
+  videoTitle: string;
+  className?: string;
+}
+
+export function BuyIPButton({
+  ipId,
+  licenseTermsId,
+  videoTitle,
+  className = "",
+}: BuyIPButtonProps) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleOpen = () => {
+    buttonRef.current?.blur();
+    setOpen(true);
+  };
+
+  if (!ipId || !licenseTermsId) return null;
+
+  return (
+    <>
+      <Button
+        ref={buttonRef}
+        className={`cursor-pointer hover:scale-105 transition-all text-violet-600 dark:text-violet-400 hover:text-violet-700 dark:hover:text-violet-300 px-3 py-2 h-auto whitespace-nowrap ${className}`}
+        aria-label={`Buy IP license for ${videoTitle}`}
+        variant="ghost"
+        onClick={handleOpen}
+      >
+        <div className="flex items-center gap-1.5">
+          <Shield className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm font-medium">IP</span>
+        </div>
+      </Button>
+
+      <LicensePurchaseDialog
+        ipId={ipId}
+        licenseTermsId={licenseTermsId}
+        videoTitle={videoTitle}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}

--- a/components/Videos/CreatorMessageButton.tsx
+++ b/components/Videos/CreatorMessageButton.tsx
@@ -127,6 +127,8 @@ export function CreatorMessageButton({
         await anyClient.conversations.newDm(creatorAddress);
       } else if (typeof anyClient.conversations?.createDm === "function") {
         await anyClient.conversations.createDm(creatorAddress);
+      } else if (typeof anyClient.conversations?.newConversation === "function") {
+        await anyClient.conversations.newConversation(creatorAddress);
       } else {
         throw new Error("XMTP DM API not available in this SDK build");
       }

--- a/components/Videos/CreatorMessageButton.tsx
+++ b/components/Videos/CreatorMessageButton.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * meToken-gated creator DM entry point (XMTP).
+ * Requires the viewer to hold at least `minBalance` of the creator's meToken.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { MessageCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useAuthModal, useUser } from "@/lib/wallet/react";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { useXmtpClient } from "@/lib/hooks/xmtp/useXmtpClient";
+import { logger } from "@/lib/utils/logger";
+import { toast } from "sonner";
+import Link from "next/link";
+import { formatEther, type Address } from "viem";
+import { publicClient } from "@/lib/viem";
+
+const DEFAULT_MIN_BALANCE = Number(
+  process.env.NEXT_PUBLIC_CREATOR_DM_METOKEN_MIN || "1"
+);
+
+const ERC20_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+interface CreatorMessageButtonProps {
+  creatorAddress: string;
+  meTokenAddress?: string | null;
+  meTokenSymbol?: string | null;
+  minBalance?: number;
+  className?: string;
+}
+
+export function CreatorMessageButton({
+  creatorAddress,
+  meTokenAddress,
+  meTokenSymbol,
+  minBalance = DEFAULT_MIN_BALANCE,
+  className = "",
+}: CreatorMessageButtonProps) {
+  const user = useUser();
+  const { openAuthModal } = useAuthModal();
+  const { address } = useWalletAuth();
+  const { client, isLoading: xmtpLoading, error: xmtpError } = useXmtpClient();
+
+  const [open, setOpen] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [balance, setBalance] = useState<number | null>(null);
+  const [gateError, setGateError] = useState<string | null>(null);
+  const [dmReady, setDmReady] = useState(false);
+
+  const fetchBalance = useCallback(async () => {
+    if (!meTokenAddress || !address) {
+      setBalance(null);
+      return;
+    }
+    setChecking(true);
+    setGateError(null);
+    try {
+      const raw = (await publicClient.readContract({
+        address: meTokenAddress as Address,
+        abi: ERC20_ABI,
+        functionName: "balanceOf",
+        args: [address as Address],
+      })) as bigint;
+      setBalance(Number(formatEther(raw)));
+    } catch (err) {
+      logger.warn("Creator DM balance check failed:", err);
+      setGateError(
+        err instanceof Error ? err.message : "Balance check failed"
+      );
+      setBalance(null);
+    } finally {
+      setChecking(false);
+    }
+  }, [meTokenAddress, address]);
+
+  useEffect(() => {
+    if (open) void fetchBalance();
+  }, [open, fetchBalance]);
+
+  const handleOpen = () => {
+    if (!user || !address) {
+      openAuthModal();
+      return;
+    }
+    if (!meTokenAddress) {
+      toast.error("This creator does not have a meToken yet.");
+      return;
+    }
+    setOpen(true);
+    setDmReady(false);
+  };
+
+  const handleStartDm = async () => {
+    if (balance === null || balance < minBalance) {
+      setGateError(
+        `You need at least ${minBalance} ${meTokenSymbol || "meTokens"} to message this creator.`
+      );
+      return;
+    }
+    if (!client) {
+      setGateError(
+        xmtpError?.message ||
+          "XMTP is still connecting. Try again in a moment."
+      );
+      return;
+    }
+    try {
+      const anyClient = client as any;
+      if (typeof anyClient.conversations?.newDm === "function") {
+        await anyClient.conversations.newDm(creatorAddress);
+      } else if (typeof anyClient.conversations?.createDm === "function") {
+        await anyClient.conversations.createDm(creatorAddress);
+      } else {
+        throw new Error("XMTP DM API not available in this SDK build");
+      }
+      setDmReady(true);
+      toast.success("Direct message ready");
+    } catch (err) {
+      logger.error("Failed to open XMTP DM:", err);
+      setGateError(
+        err instanceof Error ? err.message : "Failed to start direct message"
+      );
+    }
+  };
+
+  const hasAccess = balance !== null && balance >= minBalance;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        className={`cursor-pointer hover:scale-105 transition-all px-3 py-2 h-auto ${className}`}
+        aria-label="Message creator"
+        onClick={handleOpen}
+      >
+        <MessageCircle className="w-5 h-5 mr-1.5" />
+        <span className="text-sm font-medium">Message</span>
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Message creator</DialogTitle>
+            <DialogDescription>
+              Hold at least {minBalance}{" "}
+              {meTokenSymbol || "meTokens"} to start a private XMTP conversation.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 text-sm">
+            {checking || xmtpLoading ? (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Checking access…
+              </div>
+            ) : (
+              <>
+                <p>
+                  Your balance:{" "}
+                  <span className="font-medium">
+                    {balance === null
+                      ? "—"
+                      : `${balance} ${meTokenSymbol || "tokens"}`}
+                  </span>
+                </p>
+                {!hasAccess && meTokenAddress && (
+                  <p className="text-amber-600 dark:text-amber-400">
+                    Not enough tokens yet.{" "}
+                    <Link
+                      href={`/profile/${creatorAddress}`}
+                      className="underline"
+                    >
+                      Buy {meTokenSymbol || "meTokens"}
+                    </Link>{" "}
+                    to unlock messaging.
+                  </p>
+                )}
+                {gateError && (
+                  <p className="text-destructive text-xs">{gateError}</p>
+                )}
+                {dmReady && (
+                  <p className="text-green-600 dark:text-green-400">
+                    DM conversation created. Open your XMTP inbox to continue.
+                  </p>
+                )}
+              </>
+            )}
+
+            <Button
+              className="w-full"
+              disabled={!hasAccess || checking || xmtpLoading || dmReady}
+              onClick={() => void handleStartDm()}
+            >
+              {dmReady ? "DM ready" : "Start direct message"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/Videos/LicensePurchaseDialog.tsx
+++ b/components/Videos/LicensePurchaseDialog.tsx
@@ -31,6 +31,26 @@ import {
   buildHallidayStoryOutputAsset,
   isHallidaySandboxEnabled,
 } from "@/lib/songchain/halliday";
+import { createPublicClient, formatEther, http, type Address } from "viem";
+import { WIP_TOKEN_ADDRESS } from "@/lib/sdk/story/constants";
+
+const ERC20_BALANCE_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+function formatTokenAmount(wei: bigint, digits = 4): string {
+  const n = Number(formatEther(wei));
+  if (!Number.isFinite(n)) return "0";
+  if (n === 0) return "0";
+  if (n < 0.0001) return "<0.0001";
+  return n.toLocaleString(undefined, { maximumFractionDigits: digits });
+}
 
 interface LicenseTerms {
   transferable: boolean;
@@ -66,7 +86,10 @@ export function LicensePurchaseDialog({
   const { getAuthHeaders, address } = useWalletAuth();
   const { client: smartAccountClient } = useSmartAccountClient({});
 
-  // Halliday onramp config for $DATA/IP purchase
+  const walletAddress =
+    (smartAccountClient?.account?.address as string | undefined) ?? address ?? null;
+
+  // Halliday onramp config for $IP / gas funding
   const hallidayApiKey = process.env.NEXT_PUBLIC_HALLIDAY_API_KEY?.trim() || null;
   const hallidayOutputAsset = buildHallidayStoryOutputAsset();
   const hallidayInputAssets = buildHallidayInputAssets();
@@ -80,6 +103,9 @@ export function LicensePurchaseDialog({
     licenseTokenIds: string[];
     txHash: string;
   } | null>(null);
+  const [ipBalance, setIpBalance] = useState<bigint | null>(null);
+  const [wipBalance, setWipBalance] = useState<bigint | null>(null);
+  const [loadingBalances, setLoadingBalances] = useState(false);
 
   const network = process.env.NEXT_PUBLIC_STORY_NETWORK || "testnet";
   const storyScanBaseUrl =
@@ -115,11 +141,58 @@ export function LicensePurchaseDialog({
     }
   }, [ipId, licenseTermsId]);
 
+  const fetchBalances = useCallback(async () => {
+    if (!walletAddress) {
+      setIpBalance(null);
+      setWipBalance(null);
+      return;
+    }
+    setLoadingBalances(true);
+    try {
+      const chainId = network === "mainnet" ? 1514 : 1315;
+      const publicClient = createPublicClient({
+        chain: {
+          id: chainId,
+          name: "Story",
+          nativeCurrency: { name: "IP", symbol: "IP", decimals: 18 },
+          rpcUrls: { default: { http: ["/api/story/rpc-proxy"] } },
+        } as any,
+        transport: http("/api/story/rpc-proxy"),
+      });
+
+      const [native, wip] = await Promise.all([
+        publicClient.getBalance({
+          address: walletAddress as Address,
+        }),
+        publicClient.readContract({
+          address: WIP_TOKEN_ADDRESS,
+          abi: ERC20_BALANCE_ABI,
+          functionName: "balanceOf",
+          args: [walletAddress as Address],
+        }) as Promise<bigint>,
+      ]);
+      setIpBalance(native);
+      setWipBalance(wip);
+    } catch (err) {
+      logger.warn("Failed to fetch Story balances:", err);
+      setIpBalance(null);
+      setWipBalance(null);
+    } finally {
+      setLoadingBalances(false);
+    }
+  }, [walletAddress, network]);
+
   useEffect(() => {
     if (open && !terms && !loadingTerms && !error) {
       void fetchTerms();
     }
   }, [open, terms, loadingTerms, error, fetchTerms]);
+
+  useEffect(() => {
+    if (open) {
+      void fetchBalances();
+    }
+  }, [open, fetchBalances]);
 
   // Reset state when dialog closes
   useEffect(() => {
@@ -184,14 +257,20 @@ export function LicensePurchaseDialog({
     const feeBigInt = BigInt(fee || "0");
     if (feeBigInt === 0n) return "Free";
     const feeNum = Number(feeBigInt) / 1e18;
+    const currencyLower = (currency || "").toLowerCase();
     const tokenSymbol =
+      currencyLower === WIP_TOKEN_ADDRESS.toLowerCase() ||
       currency === "0x1514000000000000000000000000000000000000"
-        ? "$DATA"
+        ? "WIP"
         : currency === "0x0000000000000000000000000000000000000000"
-          ? "Native"
+          ? "IP"
           : "tokens";
     return `${feeNum} ${tokenSymbol}`;
   };
+
+  const feeWei = terms ? BigInt(terms.defaultMintingFee || "0") : 0n;
+  const isPaid = feeWei > 0n;
+  const hasEnoughWip = wipBalance !== null ? wipBalance >= feeWei : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -281,6 +360,46 @@ export function LicensePurchaseDialog({
                   {formatFee(terms.defaultMintingFee, terms.currency)}
                 </span>
               </div>
+
+              {/* Wallet balances */}
+              <div className="rounded-lg border p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium flex items-center gap-1.5">
+                    <Wallet className="h-3.5 w-3.5" />
+                    Your Story balances
+                  </span>
+                  {loadingBalances && (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                  )}
+                </div>
+                {!walletAddress ? (
+                  <p className="text-xs text-muted-foreground">
+                    Connect a wallet to see balances.
+                  </p>
+                ) : (
+                  <div className="grid grid-cols-2 gap-2 text-sm">
+                    <div>
+                      <span className="text-muted-foreground">IP </span>
+                      <span className="font-medium">
+                        {ipBalance === null ? "—" : formatTokenAmount(ipBalance)}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">WIP </span>
+                      <span className="font-medium">
+                        {wipBalance === null
+                          ? "—"
+                          : formatTokenAmount(wipBalance)}
+                      </span>
+                    </div>
+                  </div>
+                )}
+                {isPaid && hasEnoughWip === false && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    You need more WIP to cover this license fee. Top up below.
+                  </p>
+                )}
+              </div>
             </div>
           )}
 
@@ -324,12 +443,12 @@ export function LicensePurchaseDialog({
           {/* Action buttons */}
           {!success && (
             <>
-              {/* Halliday onramp: show when minting fee > 0 so users can buy $DATA */}
-              {terms && BigInt(terms.defaultMintingFee || "0") > 0n && hallidayApiKey && (
+              {/* Halliday: top-up IP/WIP for paid licenses */}
+              {isPaid && hallidayApiKey && (
                 <div className="space-y-2 pt-2 border-t">
                   <p className="text-xs text-muted-foreground flex items-center gap-1.5">
                     <Wallet className="h-3.5 w-3.5" />
-                    Need $DATA to pay the minting fee? Buy with debit/credit:
+                    Need IP or WIP for fees? Top up with debit/credit:
                   </p>
                   <HallidayOnramp
                     variant="story"
@@ -337,9 +456,7 @@ export function LicensePurchaseDialog({
                     hallidayOutputAsset={hallidayOutputAsset}
                     hallidayInputAssets={hallidayInputAssets}
                     hallidaySandbox={hallidaySandbox}
-                    destinationAddressOverride={
-                      smartAccountClient?.account?.address ?? address ?? null
-                    }
+                    destinationAddressOverride={walletAddress}
                     lazyInit
                     hideLensBlockedMessage
                   />
@@ -360,7 +477,12 @@ export function LicensePurchaseDialog({
                   ) : (
                     <>
                       <ShoppingCart className="mr-2 h-4 w-4" />
-                      Buy License
+                      {isPaid && terms
+                        ? `Buy License (${formatFee(
+                            terms.defaultMintingFee,
+                            terms.currency
+                          )})`
+                        : "Get Free License"}
                     </>
                   )}
                 </Button>

--- a/components/Videos/LicensePurchaseDialog.tsx
+++ b/components/Videos/LicensePurchaseDialog.tsx
@@ -160,7 +160,7 @@ export function LicensePurchaseDialog({
         transport: http("/api/story/rpc-proxy"),
       });
 
-      const [native, wip] = await Promise.all([
+      const [nativeResult, wipResult] = await Promise.allSettled([
         publicClient.getBalance({
           address: walletAddress as Address,
         }),
@@ -169,10 +169,14 @@ export function LicensePurchaseDialog({
           abi: ERC20_BALANCE_ABI,
           functionName: "balanceOf",
           args: [walletAddress as Address],
-        }) as Promise<bigint>,
+        }),
       ]);
-      setIpBalance(native);
-      setWipBalance(wip);
+      setIpBalance(
+        nativeResult.status === "fulfilled" ? nativeResult.value : null
+      );
+      setWipBalance(
+        wipResult.status === "fulfilled" ? (wipResult.value as bigint) : null
+      );
     } catch (err) {
       logger.warn("Failed to fetch Story balances:", err);
       setIpBalance(null);

--- a/components/Videos/Upload/CreateDetailsAndUpload.tsx
+++ b/components/Videos/Upload/CreateDetailsAndUpload.tsx
@@ -88,7 +88,7 @@ const CreateDetailsAndUpload = ({ onPressNext }: CreateDetailsAndUploadProps) =>
                                     <FormField
                                         control={form.control}
                                         name="description"
-                                        rules={{ required: true, maxLength: 500 }}
+                                        rules={{ required: true, maxLength: 1000 }}
                                         render={({ field }) => (
                                             <FormItem>
                                                 <Label>Description</Label>
@@ -97,11 +97,11 @@ const CreateDetailsAndUpload = ({ onPressNext }: CreateDetailsAndUploadProps) =>
                                                         <textarea
                                                             className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-y pb-6"
                                                             placeholder="Video Description (Markdown supported)"
-                                                            maxLength={500}
+                                                            maxLength={1000}
                                                             {...field}
                                                         />
                                                         <div className="absolute bottom-2 right-2 text-xs text-muted-foreground">
-                                                            {field.value?.length || 0}/500
+                                                            {field.value?.length || 0}/1000
                                                         </div>
                                                     </div>
                                                 </FormControl>

--- a/components/Videos/Upload/StoryLicenseSelector.tsx
+++ b/components/Videos/Upload/StoryLicenseSelector.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -31,25 +32,42 @@ export function StoryLicenseSelector({
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>(
     selectedLicense?.templateId || ""
   );
+  const [mintingFee, setMintingFee] = useState<string>(
+    selectedLicense?.defaultMintingFee != null
+      ? String(selectedLicense.defaultMintingFee)
+      : "0"
+  );
+
+  const buildTerms = (
+    templateId: string,
+    feeStr: string
+  ): StoryLicenseTerms | null => {
+    const template = PIL_TEMPLATES.find((t) => t.id === templateId);
+    if (!template) return null;
+    const feeNum = Number(feeStr);
+    return {
+      templateId: template.id,
+      commercialUse: template.terms.commercialUse ?? false,
+      derivativesAllowed: template.terms.derivativesAllowed ?? false,
+      derivativesAttribution: template.terms.derivativesAttribution ?? false,
+      derivativesApproval: template.terms.derivativesApproval ?? false,
+      derivativesReciprocal: template.terms.derivativesReciprocal ?? false,
+      distributionMethod: template.terms.distributionMethod,
+      revenueShare: template.terms.revenueShare,
+      defaultMintingFee: Number.isFinite(feeNum) && feeNum > 0 ? feeNum : 0,
+    };
+  };
 
   const handleTemplateChange = (templateId: string) => {
     setSelectedTemplateId(templateId);
-    const template = PIL_TEMPLATES.find((t) => t.id === templateId);
-    
-    if (template) {
-      const licenseTerms: StoryLicenseTerms = {
-        templateId: template.id,
-        commercialUse: template.terms.commercialUse ?? false,
-        derivativesAllowed: template.terms.derivativesAllowed ?? false,
-        derivativesAttribution: template.terms.derivativesAttribution ?? false,
-        derivativesApproval: template.terms.derivativesApproval ?? false,
-        derivativesReciprocal: template.terms.derivativesReciprocal ?? false,
-        distributionMethod: template.terms.distributionMethod,
-        revenueShare: template.terms.revenueShare,
-      };
-      onLicenseChange(licenseTerms);
-    } else {
-      onLicenseChange(null);
+    onLicenseChange(buildTerms(templateId, mintingFee));
+  };
+
+  const handleFeeChange = (value: string) => {
+    if (value !== "" && !/^\d*\.?\d*$/.test(value)) return;
+    setMintingFee(value);
+    if (selectedTemplateId) {
+      onLicenseChange(buildTerms(selectedTemplateId, value));
     }
   };
 
@@ -131,6 +149,24 @@ export function StoryLicenseSelector({
               </div>
             )}
           </div>
+
+          {selectedTemplateId && (
+            <div className="space-y-2">
+              <Label htmlFor="minting-fee">License price (WIP / $DATA)</Label>
+              <Input
+                id="minting-fee"
+                type="text"
+                inputMode="decimal"
+                placeholder="0"
+                value={mintingFee}
+                onChange={(e) => handleFeeChange(e.target.value)}
+                disabled={!enabled}
+              />
+              <p className="text-xs text-muted-foreground">
+                Amount buyers pay in WIP to mint a license token. Use 0 for a free license.
+              </p>
+            </div>
+          )}
         </CardContent>
       )}
     </Card>

--- a/components/Videos/VideoEditDialog.tsx
+++ b/components/Videos/VideoEditDialog.tsx
@@ -88,30 +88,28 @@ export function VideoEditDialog({
 
   const categoryValue = watch("category");
 
-  // Reset form when video asset changes
+  // Reset form when dialog opens or video identity changes (not every object refresh)
   useEffect(() => {
-    if (videoAsset) {
-      reset({
-        title: videoAsset.title || "",
-        description: videoAsset.description || "",
-        category: videoAsset.category || "",
-        location: videoAsset.location || "",
-      });
-      // Reset thumbnail state
-      setThumbnailFile(null);
-      setNewThumbnailUrl(null);
-      setUploadProgress(0);
-      setIsRegenerating(false);
-      setManualThumbnailUrl("");
-      setManualUrlError("");
-      setThumbnailTab("upload");
-      if (blobUrlRef.current) {
-        URL.revokeObjectURL(blobUrlRef.current);
-        blobUrlRef.current = null;
-      }
-      setThumbnailPreview(null);
+    if (!open || !videoAsset) return;
+    reset({
+      title: videoAsset.title || "",
+      description: videoAsset.description || "",
+      category: videoAsset.category || "",
+      location: videoAsset.location || "",
+    });
+    setThumbnailFile(null);
+    setNewThumbnailUrl(null);
+    setUploadProgress(0);
+    setIsRegenerating(false);
+    setManualThumbnailUrl("");
+    setManualUrlError("");
+    setThumbnailTab("upload");
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
     }
-  }, [videoAsset, reset]);
+    setThumbnailPreview(null);
+  }, [open, videoAsset?.id, reset]);
 
   // Cleanup blob URLs on unmount
   useEffect(() => {
@@ -182,17 +180,17 @@ export function VideoEditDialog({
 
         setNewThumbnailUrl(finalUrl);
 
-        // Clear preview and revoke blob URL after successful upload to prevent memory leak
-        // The uploaded IPFS thumbnail will be shown in the current thumbnail preview section
-        setThumbnailPreview(null);
+        // Keep blob preview while uploading finishes; prefer IPFS URL in UI via
+        // pendingPreview. Revoke blob to free memory but leave newThumbnailUrl set.
         if (blobUrlRef.current) {
           URL.revokeObjectURL(blobUrlRef.current);
           blobUrlRef.current = null;
         }
+        setThumbnailPreview(null);
 
         toast({
           title: "Thumbnail Uploaded",
-          description: "Thumbnail has been uploaded successfully.",
+          description: "Thumbnail has been uploaded successfully. Save changes to apply it.",
         });
       } else {
         toast({
@@ -455,20 +453,45 @@ export function VideoEditDialog({
             <div className="grid gap-2">
               <Label htmlFor="thumbnail">Thumbnail</Label>
               <div className="space-y-4">
-                {/* Current Thumbnail Preview */}
-                {(videoAsset as any).thumbnail_url && (
+                {/* Pending / current thumbnail preview */}
+                {(thumbnailPreview || newThumbnailUrl || (videoAsset as any).thumbnail_url) && (
                   <div className="space-y-2">
-                    <Label className="text-sm text-muted-foreground">Current Thumbnail</Label>
+                    <Label className="text-sm text-muted-foreground">
+                      {thumbnailPreview || newThumbnailUrl
+                        ? "New thumbnail (pending save)"
+                        : "Current Thumbnail"}
+                    </Label>
                     <div className="relative aspect-video w-full max-w-md rounded-lg overflow-hidden border">
-                      <GatewayImage
-                        src={(videoAsset as any).thumbnail_url}
-                        alt="Current thumbnail"
-                        fill
-                        className="object-cover"
-                        showSkeleton={true}
-                        fallbackSrc="/Creative_TV.png"
-                      />
+                      {thumbnailPreview?.startsWith("blob:") ? (
+                        <img
+                          src={thumbnailPreview}
+                          alt="Thumbnail preview"
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <GatewayImage
+                          src={
+                            thumbnailPreview ||
+                            newThumbnailUrl ||
+                            (videoAsset as any).thumbnail_url
+                          }
+                          alt={
+                            thumbnailPreview || newThumbnailUrl
+                              ? "New thumbnail pending save"
+                              : "Current thumbnail"
+                          }
+                          fill
+                          className="object-cover"
+                          showSkeleton={true}
+                          fallbackSrc="/Creative_TV.png"
+                        />
+                      )}
                     </div>
+                    {(thumbnailPreview || newThumbnailUrl) && (
+                      <p className="text-xs text-muted-foreground">
+                        Click Save changes to apply this thumbnail.
+                      </p>
+                    )}
                   </div>
                 )}
 
@@ -482,64 +505,49 @@ export function VideoEditDialog({
 
                   {/* Upload Tab */}
                   <TabsContent value="upload" className="space-y-2">
-                    {thumbnailPreview ? (
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                          <Label className="text-sm text-muted-foreground">New Thumbnail</Label>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleThumbnailRemove}
-                            className="h-8 w-8 p-0"
-                          >
-                            <X className="h-4 w-4" />
-                          </Button>
-                        </div>
-                        <div className="relative aspect-video w-full max-w-md rounded-lg overflow-hidden border">
-                          <img
-                            src={thumbnailPreview}
-                            alt="Thumbnail preview"
-                            className="w-full h-full object-cover"
-                          />
-                        </div>
-                        {isUploadingThumbnail && (
-                          <div className="space-y-2">
-                            <Progress value={uploadProgress} className="w-full" />
-                            <p className="text-xs text-muted-foreground">Uploading thumbnail...</p>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <div className="space-y-2">
-                        <Input
-                          id="thumbnail"
-                          type="file"
-                          accept="image/*"
-                          ref={fileInputRef}
-                          onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (file) {
-                              handleThumbnailSelect(file);
-                            }
-                          }}
-                          disabled={isUploadingThumbnail || isRegenerating}
-                          className="cursor-pointer"
-                        />
-                        {isUploadingThumbnail && (
-                          <div className="space-y-2">
-                            <Progress value={uploadProgress} className="w-full" />
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                              <span>Processing thumbnail...</span>
-                            </div>
-                          </div>
-                        )}
-                        <p className="text-xs text-muted-foreground">
-                          Upload a new thumbnail image (JPG, PNG, or WebP). Max 5MB.
-                        </p>
+                    {(thumbnailPreview || newThumbnailUrl) && (
+                      <div className="flex items-center justify-between">
+                        <Label className="text-sm text-muted-foreground">
+                          {isUploadingThumbnail ? "Uploading…" : "Ready to save"}
+                        </Label>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleThumbnailRemove}
+                          className="h-8 w-8 p-0"
+                          disabled={isUploadingThumbnail}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
                       </div>
                     )}
+                    <Input
+                      id="thumbnail"
+                      type="file"
+                      accept="image/*"
+                      ref={fileInputRef}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) {
+                          handleThumbnailSelect(file);
+                        }
+                      }}
+                      disabled={isUploadingThumbnail || isRegenerating}
+                      className="cursor-pointer"
+                    />
+                    {isUploadingThumbnail && (
+                      <div className="space-y-2">
+                        <Progress value={uploadProgress} className="w-full" />
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>Processing thumbnail...</span>
+                        </div>
+                      </div>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Upload a new thumbnail image (JPG, PNG, or WebP). Max 5MB.
+                    </p>
                   </TabsContent>
 
                   {/* Regenerate Tab */}

--- a/env.example
+++ b/env.example
@@ -29,6 +29,11 @@ NEXT_PUBLIC_SONGCHAIN_APP_ID=
 # from feeds linked to the app). Do NOT paste the app address here.
 NEXT_PUBLIC_SONGCHAIN_FEED_ID=
 
+# Creative TV live-stream chat (going-live posts + comment chat). Platform-wide —
+# NOT Songchain / Hack Beta. Create a dedicated Feed in the Lens dashboard and paste
+# its contract address here.
+NEXT_PUBLIC_LIVE_LENS_FEED_ID=
+
 # Group-gated / default app feed for the exclusive tab. Optional when APP_ID is set.
 NEXT_PUBLIC_SONGCHAIN_EXCLUSIVE_FEED_ID=
 NEXT_PUBLIC_SONGCHAIN_GROUP_ID=

--- a/hooks/useEnsureLiveLensPost.ts
+++ b/hooks/useEnsureLiveLensPost.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Ensures a Lens "going live" root post exists for a stream session (option B).
+ * Chat is implemented as comments on that post.
+ *
+ * Uses NEXT_PUBLIC_LIVE_LENS_FEED_ID (platform live feed), not Songchain.
+ */
+
+import { useCallback, useState } from "react";
+import { useSongchainPost } from "@/hooks/useSongchainPost";
+import {
+  buildGoingLivePostContent,
+  getLiveLensFeedConfigError,
+  getLiveLensFeedId,
+} from "@/lib/live/lens-live-feed";
+import { updateStream } from "@/services/streams";
+import { walletAuthHeadersToArgs } from "@/lib/auth/require-wallet";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { logger } from "@/lib/utils/logger";
+import type { StreamSummary } from "@/lib/songchain/build-lens-livestream-metadata";
+
+export function useEnsureLiveLensPost() {
+  const { createPost, isPosting } = useSongchainPost();
+  const { getAuthHeaders } = useWalletAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  const ensureLivePost = useCallback(
+    async (params: {
+      creatorAddress: string;
+      existingPostId?: string | null;
+      stream: StreamSummary;
+      title?: string;
+      /** Optional override of the going-live caption body. */
+      contentOverride?: string;
+    }): Promise<string | null> => {
+      setError(null);
+      if (params.existingPostId) return params.existingPostId;
+
+      const feedId = getLiveLensFeedId();
+      if (!feedId) {
+        const msg = getLiveLensFeedConfigError()!;
+        setError(msg);
+        logger.warn(msg);
+        return null;
+      }
+
+      const watchUrl =
+        typeof window !== "undefined" && params.stream.playback_id
+          ? `${window.location.origin}/watch/${params.stream.playback_id}`
+          : "";
+      const streamName = params.stream.name?.trim() || "Live stream";
+      const content =
+        params.contentOverride?.trim() ||
+        buildGoingLivePostContent({ streamName, watchUrl });
+
+      try {
+        const created = await createPost({
+          content,
+          feedId,
+          title: params.title || streamName,
+          attachedLiveStream: {
+            ...params.stream,
+            is_live: true,
+          },
+        });
+
+        const postId = created?.postId ?? null;
+        if (!postId) {
+          setError("Failed to create Lens live post");
+          return null;
+        }
+
+        const auth = walletAuthHeadersToArgs(await getAuthHeaders());
+        await updateStream(
+          params.creatorAddress,
+          { lens_live_post_id: postId },
+          auth
+        );
+        return postId;
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to create live Lens post";
+        setError(msg);
+        logger.error("ensureLivePost failed:", err);
+        return null;
+      }
+    },
+    [createPost, getAuthHeaders]
+  );
+
+  return { ensureLivePost, isPosting, error };
+}

--- a/lib/constants/video-genres.ts
+++ b/lib/constants/video-genres.ts
@@ -14,6 +14,7 @@ export const VIDEO_GENRES = [
   { value: "Metal", label: "Metal" },
   { value: "Original", label: "Original" },
   { value: "Podcast", label: "Podcast" },
+  { value: "Education", label: "Education" },
   { value: "World", label: "World Music" },
   { value: "Hackathon", label: "Hackathon" },
 ] as const;

--- a/lib/live/lens-live-feed.test.ts
+++ b/lib/live/lens-live-feed.test.ts
@@ -1,0 +1,36 @@
+import {
+  buildGoingLivePostContent,
+  getLiveLensFeedConfigError,
+  getLiveLensFeedId,
+} from "@/lib/live/lens-live-feed";
+
+describe("lens-live-feed", () => {
+  const prev = process.env.NEXT_PUBLIC_LIVE_LENS_FEED_ID;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.NEXT_PUBLIC_LIVE_LENS_FEED_ID;
+    else process.env.NEXT_PUBLIC_LIVE_LENS_FEED_ID = prev;
+    delete process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID;
+  });
+
+  it("builds going-live post content with watch url", () => {
+    const text = buildGoingLivePostContent({
+      streamName: "Jazz Night",
+      watchUrl: "https://tv.example/watch/abc",
+    });
+    expect(text).toContain("🔴 LIVE now: Jazz Night");
+    expect(text).toContain("https://tv.example/watch/abc");
+    expect(text).toContain("Chat in the comments");
+  });
+
+  it("prefers LIVE_LENS_FEED_ID over songchain", () => {
+    process.env.NEXT_PUBLIC_LIVE_LENS_FEED_ID =
+      "0x1111111111111111111111111111111111111111";
+    process.env.NEXT_PUBLIC_SONGCHAIN_FEED_ID =
+      "0x2222222222222222222222222222222222222222";
+    expect(getLiveLensFeedId()).toBe(
+      "0x1111111111111111111111111111111111111111"
+    );
+    expect(getLiveLensFeedConfigError()).toBeNull();
+  });
+});

--- a/lib/live/lens-live-feed.ts
+++ b/lib/live/lens-live-feed.ts
@@ -1,0 +1,62 @@
+/**
+ * Lens feed used for Creative TV live-stream chat ("going live" posts + comments).
+ *
+ * This is platform-wide live streaming — NOT Songchain / Hack Beta / Chones.
+ * Create a dedicated Feed in the Lens dashboard and set:
+ *   NEXT_PUBLIC_LIVE_LENS_FEED_ID=0x…
+ *
+ * Optional fallbacks exist only so existing deployments keep working until
+ * the live-specific feed is configured.
+ */
+
+import { normalizeLensPrimitiveId } from "@/lib/sdk/lens/primitive-id";
+
+function readEnv(...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Feed contract address for live-stream going-live posts.
+ * Prefer NEXT_PUBLIC_LIVE_LENS_FEED_ID.
+ */
+export function getLiveLensFeedId(): string | null {
+  const primary = normalizeLensPrimitiveId(
+    readEnv("NEXT_PUBLIC_LIVE_LENS_FEED_ID", "LIVE_LENS_FEED_ID")
+  );
+  if (primary) return primary;
+
+  // Temporary fallbacks for older env setups (not preferred)
+  return normalizeLensPrimitiveId(
+    readEnv(
+      "NEXT_PUBLIC_CREATIVE_TV_LIVE_FEED_ID",
+      "NEXT_PUBLIC_SONGCHAIN_FEED_ID",
+      "SONGCHAIN_FEED_ID"
+    )
+  );
+}
+
+export function getLiveLensFeedConfigError(): string | null {
+  if (getLiveLensFeedId()) return null;
+  return (
+    "Live Lens feed is not configured. Create a Feed in the Lens dashboard " +
+    "and set NEXT_PUBLIC_LIVE_LENS_FEED_ID to that feed address."
+  );
+}
+
+export function buildGoingLivePostContent(params: {
+  streamName: string;
+  watchUrl?: string | null;
+}): string {
+  const name = params.streamName.trim() || "Live stream";
+  return [
+    `🔴 LIVE now: ${name}`,
+    params.watchUrl ? `Watch: ${params.watchUrl}` : null,
+    "Chat in the comments — this is our live stream conversation.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/lib/sdk/story/ip-registration.ts
+++ b/lib/sdk/story/ip-registration.ts
@@ -11,6 +11,10 @@ import type {
   StoryIPRegistrationResult,
   StoryLicenseTerms,
 } from "@/lib/types/story-protocol";
+import {
+  mintingFeeToWei,
+  STORY_LICENSE_FEE_CURRENCY,
+} from "@/lib/sdk/story/minting-fee";
 
 /**
  * Register an NFT as an IP Asset on Story Protocol
@@ -104,10 +108,10 @@ export async function attachLicenseTerms(
             derivativesAttribution: licenseTerms.derivativesAttribution ?? false,
             derivativesApproval: licenseTerms.derivativesApproval ?? false,
             derivativesReciprocal: licenseTerms.derivativesReciprocal ?? false,
-            currency: "0x0000000000000000000000000000000000000000" as `0x${string}`, // Native token (ETH)
+            currency: STORY_LICENSE_FEE_CURRENCY,
             uri: licenseTerms.licenseTermsUri ?? "", // License terms URI (e.g. app video page) links IP back to source media
             // Required fields with sensible defaults
-            defaultMintingFee: BigInt(0), // Free minting by default (in wei)
+            defaultMintingFee: mintingFeeToWei(licenseTerms.defaultMintingFee),
             expiration: BigInt(0), // No expiration (0 = never expires)
             commercialRevCeiling: BigInt(0), // No ceiling (0 = unlimited)
             derivativeRevCeiling: BigInt(0), // No ceiling (0 = unlimited)

--- a/lib/sdk/story/minting-fee.test.ts
+++ b/lib/sdk/story/minting-fee.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { mintingFeeToWei } from "./minting-fee";
+
+describe("mintingFeeToWei", () => {
+  it("parses normal amounts", () => {
+    expect(mintingFeeToWei(1)).toBe(10n ** 18n);
+    expect(mintingFeeToWei("1.5")).toBe(15n * 10n ** 17n);
+  });
+
+  it("does not collapse tiny fees to free via scientific notation", () => {
+    // Number(0.0000001) stringifies as 1e-7 which parseEther rejects
+    expect(mintingFeeToWei(0.0000001)).toBeGreaterThan(0n);
+  });
+
+  it("treats invalid/zero as free", () => {
+    expect(mintingFeeToWei(0)).toBe(0n);
+    expect(mintingFeeToWei(-1)).toBe(0n);
+    expect(mintingFeeToWei(undefined)).toBe(0n);
+  });
+});

--- a/lib/sdk/story/minting-fee.ts
+++ b/lib/sdk/story/minting-fee.ts
@@ -17,7 +17,9 @@ export function mintingFeeToWei(amount: number | string | undefined | null): big
   const n = typeof amount === "number" ? amount : Number(amount);
   if (!Number.isFinite(n) || n <= 0) return 0n;
   try {
-    return parseEther(String(n));
+    // Avoid scientific notation (e.g. 1e-7) which parseEther rejects.
+    const fixed = n.toFixed(18).replace(/\.?0+$/, "");
+    return parseEther(fixed);
   } catch {
     return 0n;
   }

--- a/lib/sdk/story/minting-fee.ts
+++ b/lib/sdk/story/minting-fee.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers for Story Protocol PIL minting fees (WIP / $DATA, 18 decimals).
+ */
+
+import { parseEther } from "viem";
+import { WIP_TOKEN_ADDRESS } from "@/lib/sdk/story/constants";
+
+/** Story WIP / $DATA payment token for PIL minting fees. */
+export const STORY_LICENSE_FEE_CURRENCY = WIP_TOKEN_ADDRESS;
+
+/**
+ * Convert a human-readable WIP amount (e.g. 1.5) to wei bigint.
+ * Invalid / negative / empty values become 0n (free).
+ */
+export function mintingFeeToWei(amount: number | string | undefined | null): bigint {
+  if (amount === undefined || amount === null || amount === "") return 0n;
+  const n = typeof amount === "number" ? amount : Number(amount);
+  if (!Number.isFinite(n) || n <= 0) return 0n;
+  try {
+    return parseEther(String(n));
+  } catch {
+    return 0n;
+  }
+}

--- a/lib/types/story-protocol.ts
+++ b/lib/types/story-protocol.ts
@@ -29,6 +29,11 @@ export interface StoryLicenseTerms {
   revenueShare?: number; // Revenue share percentage (0-100)
   /** URI for the license terms (e.g. app video page or license doc). Links IP license back to source video. */
   licenseTermsUri?: string;
+  /**
+   * Minting fee in whole WIP/$DATA tokens (human-readable).
+   * Converted to wei (18 decimals) when attaching PIL terms. Default 0 = free.
+   */
+  defaultMintingFee?: number;
 }
 
 /**

--- a/lib/utils/og-image.ts
+++ b/lib/utils/og-image.ts
@@ -1,0 +1,41 @@
+/**
+ * Same-origin OG/Twitter image URLs for video share previews.
+ * Crawlers fetch these; the /api/og/video route proxies (or falls back) the real thumbnail.
+ */
+
+export function getSiteOrigin(): string {
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/$/, "");
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL.replace(/\/$/, "")}`;
+  }
+  return "https://tv.creativeplatform.xyz";
+}
+
+export type VideoOgImageParams = {
+  id?: string | null;
+  playbackId?: string | null;
+};
+
+/**
+ * Absolute URL for the OG image proxy used in generateMetadata.
+ */
+export function getVideoOgImageUrl({
+  id,
+  playbackId,
+}: VideoOgImageParams): string {
+  const origin = getSiteOrigin();
+  const params = new URLSearchParams();
+  if (id) params.set("id", id);
+  else if (playbackId) params.set("playbackId", playbackId);
+  const qs = params.toString();
+  return qs ? `${origin}/api/og/video?${qs}` : `${origin}/Creative_TV.png`;
+}
+
+export const VIDEO_OG_IMAGE = {
+  width: 1200,
+  height: 630,
+  alt: "Creative TV video",
+  type: "image/jpeg",
+} as const;

--- a/services/story-protocol.ts
+++ b/services/story-protocol.ts
@@ -16,6 +16,10 @@ import { getOrCreateCreatorCollection } from "@/lib/sdk/story/collection-service
 import { buildAndUploadIpaMetadata } from "@/lib/sdk/story/ipa-metadata";
 import { updateVideoAssetStoryIPStatus } from "./video-assets";
 import type { VideoAsset } from "@/lib/types/video-asset";
+import {
+  mintingFeeToWei,
+  STORY_LICENSE_FEE_CURRENCY,
+} from "@/lib/sdk/story/minting-fee";
 import type {
   StoryIPRegistrationOptions,
   StoryIPRegistrationResult,
@@ -354,9 +358,9 @@ export async function mintAndRegisterVideoIP(
               derivativesAttribution: licenseTerms.derivativesAttribution ?? false,
               derivativesApproval: licenseTerms.derivativesApproval ?? false,
               derivativesReciprocal: licenseTerms.derivativesReciprocal ?? false,
-              currency: "0x0000000000000000000000000000000000000000" as Address,
+              currency: STORY_LICENSE_FEE_CURRENCY,
               uri: sourceVideoUrl, // License terms URI points back to source video
-              defaultMintingFee: 0, // Required by SDK
+              defaultMintingFee: mintingFeeToWei(licenseTerms.defaultMintingFee),
               expiration: 0, // Required by SDK (0 = never expires)
               commercialRevCeiling: 0, // Required by SDK
               derivativeRevCeiling: 0, // Required by SDK

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -259,7 +259,7 @@ export async function getStreamByPlaybackId(playbackId: string) {
 
     const { data, error } = await supabase
         .from("streams")
-        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, allow_clipping, requires_metoken, metoken_price, story_ip_id, story_license_terms_id, story_commercial_rev_share, story_ip_registered_at")
+        .select("id, creator_id, playback_id, thumbnail_url, name, is_live, last_live_at, allow_clipping, requires_metoken, metoken_price, story_ip_id, story_license_terms_id, story_commercial_rev_share, story_ip_registered_at, lens_live_post_id")
         .eq("playback_id", playbackId)
         .maybeSingle();
 

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -28,6 +28,8 @@ export interface Stream {
     story_commercial_rev_share?: number | null;
     requires_metoken?: boolean;
     metoken_price?: number | null;
+    /** Lens post ID for going-live announcement; chat = comments on this post. */
+    lens_live_post_id?: string | null;
     created_at: string;
     updated_at: string;
 }
@@ -43,6 +45,7 @@ export type UpdateStreamParams = Partial<
     | "allow_clipping"
     | "requires_metoken"
     | "metoken_price"
+    | "lens_live_post_id"
   >
 >;
 
@@ -54,6 +57,7 @@ const CLIENT_MUTABLE_STREAM_FIELDS = new Set<keyof UpdateStreamParams>([
   "allow_clipping",
   "requires_metoken",
   "metoken_price",
+  "lens_live_post_id",
 ]);
 
 async function authorizeStreamOwner(

--- a/supabase/migrations/20260713160000_add_lens_live_post_id_to_streams.sql
+++ b/supabase/migrations/20260713160000_add_lens_live_post_id_to_streams.sql
@@ -1,0 +1,6 @@
+-- Store Lens "going live" root post id for live stream comment-chat (option B).
+ALTER TABLE public.streams
+  ADD COLUMN IF NOT EXISTS lens_live_post_id text;
+
+COMMENT ON COLUMN public.streams.lens_live_post_id IS
+  'Lens post ID for the stream going-live announcement; live chat uses comments on this post.';


### PR DESCRIPTION
## Summary
- Add same-origin OG/Twitter image cards for discover and watch share previews, and keep edit-thumbnail pending until save; raise upload description limit to 1000 and add Education genre.
- Surface Buy IP on discover with creator-set WIP minting fees, Story balance display, and Halliday top-up in the purchase modal.
- Replace live XMTP chat with opt-in Lens “going live” posts + comment chat (`NEXT_PUBLIC_LIVE_LENS_FEED_ID`), and add meToken-gated XMTP creator DMs.

## Test plan
- [ ] Share a discover and watch URL; confirm `og:image` / `twitter:image` hit `/api/og/video` and previews render on Discord/X
- [ ] Edit a video thumbnail: new image stays visible as “pending save” until Save
- [ ] Upload form allows 1000-char description; Education appears in genre list
- [ ] Discover shows IP between Buy and Mixtape when Story IP + terms exist; modal shows balances + Halliday for paid fees
- [ ] Apply migration `20260713160000_add_lens_live_post_id_to_streams.sql`
- [ ] Set `NEXT_PUBLIC_LIVE_LENS_FEED_ID`; host Activate live chat publishes preview post; viewers see Lens comments
- [ ] Message button requires meToken balance ≥ threshold before starting XMTP DM


Made with [Cursor](https://cursor.com)