### PR TITLE
Fix price-history TypeScript build by selecting hub_id.

### DIFF
--- a/app/api/market/tokens/[address]/price-history/route.ts
+++ b/app/api/market/tokens/[address]/price-history/route.ts
@@ -40,7 +40,7 @@ export async function GET(
     // Get MeToken info
     const { data: meToken, error: meTokenError } = await supabase
       .from('metokens')
-      .select('id, address, total_supply, tvl')
+      .select('id, address, total_supply, tvl, hub_id')
       .eq('address', address.toLowerCase())
       .single();
 


### PR DESCRIPTION
The route falls back to meToken.hub_id for vault TVL decimals, but the query omitted that column so production typecheck failed.