### PR TITLE
fix: Solana webpack stub + OG video thumbnail sharing

### DIFF
--- a/app/api/market/tokens/[address]/price-history/route.ts
+++ b/app/api/market/tokens/[address]/price-history/route.ts
@@ -40,7 +40,7 @@ export async function GET(
     // Get MeToken info
     const { data: meToken, error: meTokenError } = await supabase
       .from('metokens')
-      .select('id, address, total_supply, tvl')
+      .select('id, address, total_supply, tvl, hub_id')
       .eq('address', address.toLowerCase())
       .single();
 

--- a/app/api/og/video/route.ts
+++ b/app/api/og/video/route.ts
@@ -188,6 +188,17 @@ async function resolveThumbnailUrl(
     });
     const raw = asset?.thumbnail_url;
     if (raw?.trim()) return convertFailingGateway(raw.trim());
+
+    // Fallback: fetch thumbnail directly from Livepeer API
+    if (!raw) {
+      try {
+        const { getClipThumbnailUrl } = await import("@/services/livepeer-clips");
+        const lpThumb = await getClipThumbnailUrl(playbackId);
+        if (lpThumb?.trim()) return convertFailingGateway(lpThumb.trim());
+      } catch (err) {
+        serverLogger.warn("OG video: Livepeer thumbnail fallback failed", err);
+      }
+    }
   }
 
   return null;

--- a/app/watch/[playbackId]/page.tsx
+++ b/app/watch/[playbackId]/page.tsx
@@ -33,7 +33,12 @@ export async function generateMetadata(
 
         const title = videoAsset?.title || "Live Stream";
         const desc = "Watch on Creative TV";
-        const ogImageUrl = getVideoOgImageUrl({ playbackId });
+
+        // Use the direct thumbnail URL when available (works for SMS, Twitter, etc).
+        // Fall back to the same-origin proxy for crawlers that need same-origin images.
+        const directThumb = videoAsset?.thumbnail_url;
+        const proxyUrl = getVideoOgImageUrl({ playbackId });
+        const ogImageUrl = directThumb || proxyUrl;
         const ogImage = {
             url: ogImageUrl,
             width: VIDEO_OG_IMAGE.width,

--- a/lib/webpack/alchemy-solana-actions-stub.mjs
+++ b/lib/webpack/alchemy-solana-actions-stub.mjs
@@ -1,5 +1,12 @@
 // Creative TV only uses the EVM path from @alchemy/wallet-apis.
-// The package imports its Solana decorator unconditionally, which pulls @solana/kit
-// into the Next.js bundle and can fail when other dependencies install a different
-// Solana package major. This stub keeps the EVM client path buildable.
+// The package imports its Solana decorator and helpers unconditionally,
+// which pulls @solana/kit into the Next.js bundle and can fail when other
+// dependencies install a different @solana/errors major.
+// This stub keeps the EVM client path buildable by providing no-op
+// replacements for every Solana-named export.
 export const solanaSmartWalletActions = () => ({});
+export const createSolanaSmartWalletClient = () => ({});
+export const resolveSignerSlot = () => null;
+export const signSignatureRequest = () => ({});
+export const signPreparedCalls = () => ({});
+export default { solanaSmartWalletActions };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -240,14 +240,18 @@ const nextConfig = {
       })
     );
 
+    // Creative TV only uses the EVM path from @alchemy/wallet-apis.
+    // The package imports @solana/kit transitively through multiple Solana
+    // helper files (resolveSignerSlot, signSignatureRequest, signPreparedCalls,
+    // solanaSmartWalletActions, adapters/*, actions/solana/*). Stub ALL of them
+    // so @solana/kit never enters the webpack graph — different nested
+    // @solana/errors majors conflict and break the build.
     const alchemySolanaActionsStub = require.resolve('./lib/webpack/alchemy-solana-actions-stub.mjs');
     config.plugins.push(
       new webpack.NormalModuleReplacementPlugin(
-        /solanaSmartWalletActions\.js$/,
+        /@alchemy[\\/]wallet-apis[\\/]dist[\\/]esm[\\/](?:decorators[\\/]solana.*|actions[\\/]solana[\\/].*|adapters[\\/].*|decorators[\\/]solanaSmartWalletActions)\.js$/,
         (resource) => {
-          if (/@alchemy[\\/]wallet-apis[\\/]dist[\\/]esm[\\/]client\.js$/.test(resource.contextInfo?.issuer || '')) {
-            resource.request = alchemySolanaActionsStub;
-          }
+          resource.request = alchemySolanaActionsStub;
         }
       )
     );


### PR DESCRIPTION
## Fixes

### 1. Vercel build failure — Solana version conflict
`@alchemy/wallet-apis` imports `@solana/kit` transitively through multiple Solana helper files. The old webpack stub only caught `solanaSmartWalletActions.js`, but `resolveSignerSlot.js`, `signSignatureRequest.js`, `signPreparedCalls.js` still pulled `@solana/kit` into the bundle. Different nested `@solana/errors` majors (v2.3.0/v3.0.3 vs v5.5.1) conflict and break the build.

**Fix:** Broadened `NormalModuleReplacementPlugin` regex to stub ALL Solana-named files from `@alchemy/wallet-apis` (`decorators/solana*`, `actions/solana/*`, `adapters/*`).

### 2. Video share preview — no thumbnail image
At commit `ed3b85e7db` (which worked for SMS), the watch page used the **direct thumbnail URL** from the database:
```js
images: videoAsset?.thumbnail_url ? [videoAsset.thumbnail_url] : []
```

The current version routed everything through `/api/og/video?playbackId=xxx` (same-origin proxy). This was added for Orb.club but broke SMS and other platforms that could fetch Livepeer CDN URLs directly.

**Fix:** Use direct `thumbnail_url` when available, fall back to the same-origin proxy when it's not.

### 3. OG image route — Livepeer API fallback
When `thumbnail_url` is null in the database, the proxy route now fetches it directly from Livepeer's playback info API via `getClipThumbnailUrl()`.

## Files changed
- `next.config.mjs` — broadened Solana stub regex
- `lib/webpack/alchemy-solana-actions-stub.mjs` — added more no-op exports
- `app/watch/[playbackId]/page.tsx` — use direct thumbnail URL in OG metadata
- `app/api/og/video/route.ts` — Livepeer API fallback for null thumbnails