### PR TITLE
revert: restore working Solana webpack config (keep OG image fix)

### DIFF
--- a/lib/webpack/alchemy-solana-actions-stub.mjs
+++ b/lib/webpack/alchemy-solana-actions-stub.mjs
@@ -1,12 +1,5 @@
 // Creative TV only uses the EVM path from @alchemy/wallet-apis.
-// The package imports its Solana decorator and helpers unconditionally,
-// which pulls @solana/kit into the Next.js bundle and can fail when other
-// dependencies install a different @solana/errors major.
-// This stub keeps the EVM client path buildable by providing no-op
-// replacements for every Solana-named export.
+// The package imports its Solana decorator unconditionally, which pulls @solana/kit
+// into the Next.js bundle and can fail when other dependencies install a different
+// Solana package major. This stub keeps the EVM client path buildable.
 export const solanaSmartWalletActions = () => ({});
-export const createSolanaSmartWalletClient = () => ({});
-export const resolveSignerSlot = () => null;
-export const signSignatureRequest = () => ({});
-export const signPreparedCalls = () => ({});
-export default { solanaSmartWalletActions };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -240,18 +240,14 @@ const nextConfig = {
       })
     );
 
-    // Creative TV only uses the EVM path from @alchemy/wallet-apis.
-    // The package imports @solana/kit transitively through multiple Solana
-    // helper files (resolveSignerSlot, signSignatureRequest, signPreparedCalls,
-    // solanaSmartWalletActions, adapters/*, actions/solana/*). Stub ALL of them
-    // so @solana/kit never enters the webpack graph — different nested
-    // @solana/errors majors conflict and break the build.
     const alchemySolanaActionsStub = require.resolve('./lib/webpack/alchemy-solana-actions-stub.mjs');
     config.plugins.push(
       new webpack.NormalModuleReplacementPlugin(
-        /@alchemy[\\/]wallet-apis[\\/]dist[\\/]esm[\\/](?:decorators[\\/]solana.*|actions[\\/]solana[\\/].*|adapters[\\/].*|decorators[\\/]solanaSmartWalletActions)\.js$/,
+        /solanaSmartWalletActions\.js$/,
         (resource) => {
-          resource.request = alchemySolanaActionsStub;
+          if (/@alchemy[\\/]wallet-apis[\\/]dist[\\/]esm[\\/]client\.js$/.test(resource.contextInfo?.issuer || '')) {
+            resource.request = alchemySolanaActionsStub;
+          }
         }
       )
     );


### PR DESCRIPTION
PR #265 broadened the Solana `NormalModuleReplacementPlugin` regex which broke the Vercel build. This reverts `next.config.mjs` and `alchemy-solana-actions-stub.mjs` back to the version at `ed3b85e7db` that was building successfully.

The OG image fix from PR #265 is kept:
- Direct `thumbnail_url` in watch page metadata (instead of always using proxy)
- Livepeer API fallback in `/api/og/video` route

Only the webpack config changes are reverted.