### PR TITLE
fix: OG cards for /discover/[id] + react-joyride tour improvements

### DIFF
--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -278,7 +278,12 @@ export async function generateMetadata({
 
     const baseUrl = getSiteOrigin();
     const absoluteUrl = `${baseUrl}/discover/${id}`;
-    const ogImageUrl = getVideoOgImageUrl({ id });
+
+    // Use the direct thumbnail URL when available (works for SMS, Twitter, etc).
+    // Fall back to the same-origin proxy for crawlers that need same-origin images.
+    const directThumb = (videoAsset as any)?.thumbnail_url;
+    const proxyUrl = getVideoOgImageUrl({ id });
+    const ogImageUrl = directThumb || proxyUrl;
 
     let videoTitle = (videoAsset as any)?.title || assetData.name || "Watch Video";
     if (videoTitle.endsWith('.mp4')) {

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -109,13 +109,25 @@ const MOBILE_STEPS: TourStep[] = [
     },
 ];
 
+// Map step IDs to the page they require (if not on home)
+const STEP_PAGE_MAP: Record<string, string> = {
+    'upload-form': '/upload',
+    'publish-btn': '/upload',
+    'discover': '/discover',
+    'trade': '/market',
+};
+
+function getStepPage(stepId: string): string | null {
+    return STEP_PAGE_MAP[stepId] ?? null;
+}
+
 function openMobileMenuForTour() {
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new Event('crtv:open-mobile-menu'));
     }
 }
 
-function waitForElement(selector: string, timeoutMs = 2500): Promise<boolean> {
+function waitForElement(selector: string, timeoutMs = 5000): Promise<boolean> {
     return new Promise((resolve) => {
         if (document.querySelector(selector)) {
             resolve(true);
@@ -201,11 +213,24 @@ export const Tour = () => {
         if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status as typeof STATUS.FINISHED)) {
             setRun(false);
             localStorage.setItem('crtv3_tour_completed', 'true');
+            localStorage.removeItem('crtv3_tour_running');
             return;
         }
 
         if (type === EVENTS.TARGET_NOT_FOUND) {
             logger.warn('Tour: target not found', { target: currentStep?.target, index });
+            const stepId = currentStep?.data?.id;
+            const requiredPage = stepId ? getStepPage(stepId) : null;
+            const currentPath = window.location.pathname;
+
+            // If the target is on a different page, navigate there instead of skipping
+            if (requiredPage && !currentPath.startsWith(requiredPage)) {
+                logger.debug('Tour: navigating to required page', { requiredPage, stepId });
+                window.location.href = requiredPage;
+                return;
+            }
+
+            // Same page but element not found — skip to next step
             if (index < steps.length - 1) {
                 window.setTimeout(() => {
                     void advanceToStep(index + 1);

--- a/context/TourContext.tsx
+++ b/context/TourContext.tsx
@@ -22,14 +22,20 @@ export const TourProvider = ({ children }: { children: ReactNode }) => {
     useEffect(() => {
         const tourCompleted = localStorage.getItem("crtv3_tour_completed");
         const storedStep = localStorage.getItem("crtv3_tour_step");
+        const tourRunning = localStorage.getItem("crtv3_tour_running");
 
-        logger.debug("TourContext: Checking localStorage:", { tourCompleted, storedStep });
+        logger.debug("TourContext: Checking localStorage:", { tourCompleted, storedStep, tourRunning });
 
         if (storedStep) {
             setStepIndex(parseInt(storedStep, 10));
         }
 
-        if (!tourCompleted) {
+        // Resume tour if it was running (e.g. after page navigation)
+        // Or start fresh if never completed
+        if (tourRunning === "true") {
+            logger.debug("TourContext: Resuming tour");
+            setRun(true);
+        } else if (!tourCompleted) {
             logger.debug("TourContext: No completion found, setting run=true");
             setRun(true);
         } else {
@@ -51,12 +57,14 @@ export const TourProvider = ({ children }: { children: ReactNode }) => {
         // Clear completion and saved step
         localStorage.removeItem("crtv3_tour_completed");
         localStorage.setItem("crtv3_tour_step", "0");
+        localStorage.setItem("crtv3_tour_running", "true");
     };
 
     const resetTour = () => {
         logger.debug("TourContext: resetTour called");
         setRun(false);
         setStepIndex(0);
+        localStorage.removeItem("crtv3_tour_running");
     };
 
     return (


### PR DESCRIPTION
## Changes

### 1. Dynamic OG/Twitter cards for /discover/[id] 
The discover page already had `generateMetadata` but always used the `/api/og/video` proxy for the OG image. Now uses the direct `thumbnail_url` from the database when available (same fix as `/watch/[playbackId]`).

### 2. React-joyride tour — smarter TARGET_NOT_FOUND handling
When a tour step targets an element that isn't on the current page (e.g. `#upload-video-form` on `/upload`), the tour now **navigates to the required page** instead of blindly skipping the step. Uses a `STEP_PAGE_MAP` to know which page each step needs.

### 3. Tour resume across page navigation
Added `crtv3_tour_running` localStorage flag so the tour auto-resumes after navigating to a new page. Previously the tour would stop when the page changed.

### 4. Longer element wait timeout
`waitForElement` timeout increased from 2.5s → 5s to give dynamic content more time to load.

## Files changed
- `app/discover/[id]/page.tsx` — direct thumbnail_url for OG image
- `components/Tour/Tour.tsx` — page-aware TARGET_NOT_FOUND, running flag cleanup, longer timeout
- `context/TourContext.tsx` — persist/resume running state across page loads