### PR TITLE
fix: tour beacons/overlay/repeating + OG image proxy with IPFS fallback

### DIFF
--- a/app/api/og/video/route.ts
+++ b/app/api/og/video/route.ts
@@ -216,16 +216,39 @@ export async function GET(request: NextRequest) {
 
     const thumbnailUrl = await resolveThumbnailUrl(id, playbackId);
 
-    if (thumbnailUrl && (await isSafeRemoteThumbnailUrl(thumbnailUrl))) {
-      const remote = await fetchRemoteImage(thumbnailUrl);
-      if (remote) {
-        return new NextResponse(remote.body, {
-          status: 200,
-          headers: {
-            "Content-Type": remote.contentType,
-            "Cache-Control": CACHE_HEADER,
-          },
-        });
+    if (thumbnailUrl) {
+      // Try the primary URL first
+      if (await isSafeRemoteThumbnailUrl(thumbnailUrl)) {
+        const remote = await fetchRemoteImage(thumbnailUrl);
+        if (remote) {
+          return new NextResponse(remote.body, {
+            status: 200,
+            headers: {
+              "Content-Type": remote.contentType,
+              "Cache-Control": CACHE_HEADER,
+            },
+          });
+        }
+      }
+
+      // If primary URL failed and it's an IPFS URL, try fallback gateways
+      const { getAllIpfsGateways } = await import("@/lib/utils/image-gateway");
+      const gatewayUrls = getAllIpfsGateways(thumbnailUrl);
+      for (const gatewayUrl of gatewayUrls) {
+        if (gatewayUrl === thumbnailUrl) continue; // Already tried
+        if (await isSafeRemoteThumbnailUrl(gatewayUrl)) {
+          const remote = await fetchRemoteImage(gatewayUrl);
+          if (remote) {
+            serverLogger.debug("OG video: fetched via fallback gateway", { gatewayUrl });
+            return new NextResponse(remote.body, {
+              status: 200,
+              headers: {
+                "Content-Type": remote.contentType,
+                "Cache-Control": CACHE_HEADER,
+              },
+            });
+          }
+        }
       }
     }
 

--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -279,11 +279,10 @@ export async function generateMetadata({
     const baseUrl = getSiteOrigin();
     const absoluteUrl = `${baseUrl}/discover/${id}`;
 
-    // Use the direct thumbnail URL when available (works for SMS, Twitter, etc).
-    // Fall back to the same-origin proxy for crawlers that need same-origin images.
-    const directThumb = (videoAsset as any)?.thumbnail_url;
-    const proxyUrl = getVideoOgImageUrl({ id });
-    const ogImageUrl = directThumb || proxyUrl;
+    // Use the same-origin proxy for OG images — Telegram/SMS crawlers can't
+    // fetch IPFS gateway URLs (grove.storage, ipfs.io, etc). The proxy fetches
+    // the image server-side and serves it from our domain.
+    const ogImageUrl = getVideoOgImageUrl({ id });
 
     let videoTitle = (videoAsset as any)?.title || assetData.name || "Watch Video";
     if (videoTitle.endsWith('.mp4')) {

--- a/app/watch/[playbackId]/page.tsx
+++ b/app/watch/[playbackId]/page.tsx
@@ -34,11 +34,10 @@ export async function generateMetadata(
         const title = videoAsset?.title || "Live Stream";
         const desc = "Watch on Creative TV";
 
-        // Use the direct thumbnail URL when available (works for SMS, Twitter, etc).
-        // Fall back to the same-origin proxy for crawlers that need same-origin images.
-        const directThumb = videoAsset?.thumbnail_url;
-        const proxyUrl = getVideoOgImageUrl({ playbackId });
-        const ogImageUrl = directThumb || proxyUrl;
+        // Use the same-origin proxy for OG images — Telegram/SMS crawlers can't
+        // fetch IPFS gateway URLs (grove.storage, ipfs.io, etc). The proxy fetches
+        // the image server-side and serves it from our domain.
+        const ogImageUrl = getVideoOgImageUrl({ playbackId });
         const ogImage = {
             url: ogImageUrl,
             width: VIDEO_OG_IMAGE.width,

--- a/components/Tour/Tour.tsx
+++ b/components/Tour/Tour.tsx
@@ -30,6 +30,7 @@ const DESKTOP_STEPS: TourStep[] = [
     {
         target: '#nav-user-menu',
         content: 'Click your profile to open the menu, then select "Upload" to start adding content.',
+        skipBeacon: true,
         blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'user-menu' },
@@ -37,24 +38,28 @@ const DESKTOP_STEPS: TourStep[] = [
     {
         target: '#upload-video-form',
         content: 'Upload your video file here. You can drag and drop or select a file.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'upload-form' },
     },
     {
         target: '#publish-video-btn',
         content: 'Once uploaded, click Publish to share it with the world!',
+        skipBeacon: true,
         placement: 'top',
         data: { id: 'publish-btn' },
     },
     {
         target: '#nav-discover-link',
         content: 'Check out what others are creating on the Discover page.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'discover' },
     },
     {
         target: '#nav-trade-link',
         content: 'Buy or sell Creative Coins by creators on the platform in the Trading Market.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'trade' },
     },
@@ -72,6 +77,7 @@ const MOBILE_STEPS: TourStep[] = [
     {
         target: '#connect-wallet-btn-mobile',
         content: 'Tap "Get Started" to create your account with just your email.',
+        skipBeacon: true,
         blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'connect-wallet', openMobileMenu: true },
@@ -79,6 +85,7 @@ const MOBILE_STEPS: TourStep[] = [
     {
         target: '#nav-user-menu',
         content: 'After signing in, tap your profile avatar to open account options.',
+        skipBeacon: true,
         blockTargetInteraction: false,
         placement: 'bottom',
         data: { id: 'user-menu' },
@@ -86,24 +93,28 @@ const MOBILE_STEPS: TourStep[] = [
     {
         target: '#nav-upload-link',
         content: 'Open the menu and choose Upload to add your video.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'upload-form', openMobileMenu: true },
     },
     {
         target: '#publish-video-btn',
         content: 'After selecting a file, tap Publish to share your video.',
+        skipBeacon: true,
         placement: 'top',
         data: { id: 'publish-btn' },
     },
     {
         target: '#mobile-nav-discover-link',
         content: 'Use Discover in the menu to see what others are creating.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'discover', openMobileMenu: true },
     },
     {
         target: '#mobile-nav-trade-link',
         content: 'Open Trade in the menu to buy or sell Creative Coins.',
+        skipBeacon: true,
         placement: 'bottom',
         data: { id: 'trade', openMobileMenu: true },
     },
@@ -156,6 +167,7 @@ export const Tour = () => {
     const isConnected = !!user;
 
     const [isMobile, setIsMobile] = useState(false);
+    const [tourKey, setTourKey] = useState(0); // Force re-mount to clear overlay
 
     useEffect(() => {
         const checkMobile = () => {
@@ -212,6 +224,8 @@ export const Tour = () => {
 
         if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status as typeof STATUS.FINISHED)) {
             setRun(false);
+            setStepIndex(0);
+            setTourKey(k => k + 1); // Force Joyride to unmount/remount — clears overlay + beacons
             localStorage.setItem('crtv3_tour_completed', 'true');
             localStorage.removeItem('crtv3_tour_running');
             return;
@@ -226,15 +240,17 @@ export const Tour = () => {
             // If the target is on a different page, navigate there instead of skipping
             if (requiredPage && !currentPath.startsWith(requiredPage)) {
                 logger.debug('Tour: navigating to required page', { requiredPage, stepId });
+                // Save the current step so it resumes on the new page
+                localStorage.setItem('crtv3_tour_step', index.toString());
                 window.location.href = requiredPage;
                 return;
             }
 
-            // Same page but element not found — skip to next step
+            // Same page but element not found — wait longer then skip
             if (index < steps.length - 1) {
                 window.setTimeout(() => {
                     void advanceToStep(index + 1);
-                }, 400);
+                }, 1000);
             }
             return;
         }
@@ -381,6 +397,7 @@ export const Tour = () => {
 
     return (
         <Joyride
+            key={tourKey}
             steps={steps}
             run={run}
             stepIndex={stepIndex}


### PR DESCRIPTION
## Tour fixes
1. **Beacon circles** — Added `skipBeacon: true` to ALL steps. Previously only the first step had it, causing pulsing beacon circles on elements that weren't active tour targets.
2. **Black overlay stays after Finish** — Force Joyride to unmount/remount via `key={tourKey}` when tour finishes/skips. This fully clears the overlay instead of leaving it stuck.
3. **Repeating steps** — When navigating to a new page for a step, save the step index to localStorage so it resumes correctly instead of repeating the same tooltip.
4. **Longer skip timeout** — Increased from 400ms to 1s when target not found on the same page, giving dynamic content more time to load.

## OG image fixes
1. **Revert to same-origin proxy** — Telegram/SMS crawlers cannot fetch IPFS gateway URLs (grove.storage, ipfs.io, etc). The `/api/og/video` proxy fetches the image server-side and serves it from our domain.
2. **IPFS gateway fallback** — If the primary thumbnail URL fails, the proxy now tries all known IPFS gateways (ipfs.io, dweb.link, w3s.link, grove.storage, pinata, etc.) until one works.

## Files changed
- `components/Tour/Tour.tsx` — skipBeacon on all steps, tourKey for overlay clear, step index save on navigation
- `app/discover/[id]/page.tsx` — use proxy for OG image
- `app/watch/[playbackId]/page.tsx` — use proxy for OG image
- `app/api/og/video/route.ts` — IPFS gateway fallback loop