### PR TITLE
disable: remove react joyride tour completely

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { headers } from "next/headers";
 import "./globals.css";
 import { Providers } from "./providers";
 import Navbar from "@/components/Navbar";
-import { Tour } from '@/components/Tour/Tour';
 import { cn } from "@/lib/utils/utils";
 import { Toaster } from "@/components/ui/toaster";
 import Footer from "@/components/Footer";
@@ -79,7 +78,6 @@ export default async function RootLayout({
         <LayoutClientChunks />
         <Providers>
           <ErrorBoundary>
-            {!isEmbedRoute ? <Tour /> : null}
             {!isEmbedRoute ? <Navbar /> : null}
             <div className="min-h-screen flex flex-col">
               <main className="flex-1">{children}</main>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -16,7 +16,6 @@ import { PropsWithChildren, Suspense, useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import { VideoProvider } from "../context/VideoContext";
-import { TourProvider } from "../context/TourContext";
 import { HeliaProvider } from "../context/HeliaContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ApolloNextAppProvider } from "@apollo/client-integration-nextjs";
@@ -95,21 +94,19 @@ export const Providers = (props: PropsWithChildren) => {
                         <NoSSR>
                           <RadixProvider>
                             <HeliaProvider>
-                              <TourProvider>
-                                <VideoProvider>
-                                  <MembershipProvider>
-                                    <WalletReadyGuard>
-                                      <AuthErrorMonitor />
-                                      <OrbSessionProvider>
-                                        {props.children}
-                                        <OrbLoginModal />
-                                        <OrbLinkingOverlay />
-                                        <Toaster position="top-right" richColors />
-                                      </OrbSessionProvider>
-                                    </WalletReadyGuard>
-                                  </MembershipProvider>
-                                </VideoProvider>
-                              </TourProvider>
+                              <VideoProvider>
+                                <MembershipProvider>
+                                  <WalletReadyGuard>
+                                    <AuthErrorMonitor />
+                                    <OrbSessionProvider>
+                                      {props.children}
+                                      <OrbLoginModal />
+                                      <OrbLinkingOverlay />
+                                      <Toaster position="top-right" richColors />
+                                    </OrbSessionProvider>
+                                  </WalletReadyGuard>
+                                </MembershipProvider>
+                              </VideoProvider>
                             </HeliaProvider>
                           </RadixProvider>
                         </NoSSR>

--- a/components/home-page/HeroSection.tsx
+++ b/components/home-page/HeroSection.tsx
@@ -11,7 +11,6 @@ import { Src } from "@livepeer/react";
 import { HeroPlayer } from "../Player/HeroPlayer";
 import { PlayerLoading } from "../Player/Player";
 import { getHeroPlaybackSource } from "../../lib/hooks/livepeer/useHeroPlaybackSource";
-import { useTour } from "@/context/TourContext";
 import { logger } from '@/lib/utils/logger';
 
 
@@ -40,10 +39,9 @@ const HeroSection: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { startTour } = useTour();
-
   const handleWatchDemo = () => {
-    startTour();
+    // Tour has been disabled
+    logger.debug("Tour is disabled - watch demo button clicked");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

This PR completely removes the react joyride tour implementation as requested since it was causing a worse user experience than intended.

### What was removed:
- Tour component from app/layout.tsx
- TourProvider from app/providers.tsx
- useTour hook from components/home-page/HeroSection.tsx
- Tour-related button functionality from HeroSection (\"Watch Demo\" button now just logs a debug message)
- Deleted unused Tour and TourContext files

### Why:
The tour was causing a worse user experience than intended, so we are removing it completely to avoid any negative impact on users.

The \"Watch Demo\" button on the homepage will no longer trigger the tour but will instead log a debug message that the tour is disabled.