### PR TITLE
Add Songchain Season 2 Unlock NFT (Lens / 10 GHO)

### DIFF
--- a/components/songchain/SongchainFeedExperience.tsx
+++ b/components/songchain/SongchainFeedExperience.tsx
@@ -10,6 +10,7 @@ import { SongchainComposePost } from "@/components/songchain/SongchainComposePos
 import { SongchainBookmarksSection } from "@/components/songchain/SongchainBookmarksSection";
 import { HallidayOnramp } from "@/components/songchain/HallidayOnramp";
 import { SongchainGatedFeedTab } from "@/components/songchain/SongchainGatedFeedTab";
+import { Season2ExclusiveGatedTab } from "@/components/songchain/season-2/Season2ExclusiveGatedTab";
 import type { SongchainConfig } from "@/lib/songchain/config";
 import type { SongchainFeedHandle } from "@/components/songchain/SongchainFeedSection";
 
@@ -36,6 +37,11 @@ type SongchainFeedExperienceProps = {
   clubGateTitle?: string;
   clubGateDescription?: string;
   orbClubUrl?: string;
+  /**
+   * When set, gate the Exclusive tab behind a valid Unlock key on this lock
+   * (Season 2 only — 10 GHO on Lens mainnet).
+   */
+  exclusiveUnlockLockAddress?: string | null;
 };
 
 export function SongchainFeedExperience({
@@ -53,6 +59,7 @@ export function SongchainFeedExperience({
   clubGateTitle,
   clubGateDescription,
   orbClubUrl,
+  exclusiveUnlockLockAddress,
 }: SongchainFeedExperienceProps) {
   const publicFeedRef = useRef<SongchainFeedHandle>(null);
   const exclusiveFeedRef = useRef<SongchainFeedHandle>(null);
@@ -147,19 +154,29 @@ export function SongchainFeedExperience({
 
         {!hidden.has("exclusive") && (
           <TabsContent value="exclusive" className="space-y-6">
-            <SongchainComposePost
-              feedId={resolvedExclusiveFeedId}
-              onPosted={(created) => exclusiveFeedRef.current?.registerNewPost(created)}
-            />
-            <SongchainFeedSection
-              ref={exclusiveFeedRef}
-              title="Exclusive feed"
-              description="Members-only drops and announcements on Lens."
-              feedId={resolvedExclusiveFeedId}
-              graphId={config.graphId}
-              onPostUpdated={() => exclusiveFeedRef.current?.reload()}
-              emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
-            />
+            {exclusiveUnlockLockAddress ? (
+              <Season2ExclusiveGatedTab
+                lockAddress={exclusiveUnlockLockAddress}
+                feedId={resolvedExclusiveFeedId}
+                graphId={config.graphId}
+              />
+            ) : (
+              <>
+                <SongchainComposePost
+                  feedId={resolvedExclusiveFeedId}
+                  onPosted={(created) => exclusiveFeedRef.current?.registerNewPost(created)}
+                />
+                <SongchainFeedSection
+                  ref={exclusiveFeedRef}
+                  title="Exclusive feed"
+                  description="Members-only drops and announcements on Lens."
+                  feedId={resolvedExclusiveFeedId}
+                  graphId={config.graphId}
+                  onPostUpdated={() => exclusiveFeedRef.current?.reload()}
+                  emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
+                />
+              </>
+            )}
           </TabsContent>
         )}
 

--- a/components/songchain/season-2/Season2ExclusiveGatedTab.tsx
+++ b/components/songchain/season-2/Season2ExclusiveGatedTab.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRef } from "react";
+import { Loader2 } from "lucide-react";
+import { SongchainComposePost } from "@/components/songchain/SongchainComposePost";
+import {
+  SongchainFeedSection,
+  type SongchainFeedHandle,
+} from "@/components/songchain/SongchainFeedSection";
+import { Season2UnlockPurchase } from "@/components/songchain/season-2/Season2UnlockPurchase";
+import { useSeason2UnlockKey } from "@/hooks/useSeason2UnlockKey";
+
+type Season2ExclusiveGatedTabProps = {
+  lockAddress: string;
+  feedId: string | null;
+  graphId: string | null;
+};
+
+export function Season2ExclusiveGatedTab({
+  lockAddress,
+  feedId,
+  graphId,
+}: Season2ExclusiveGatedTabProps) {
+  const exclusiveFeedRef = useRef<SongchainFeedHandle>(null);
+  const { hasValidKey, isLoading, refetch } = useSeason2UnlockKey({
+    lockAddress,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center rounded-lg border border-border/60 bg-card py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!hasValidKey) {
+    return (
+      <Season2UnlockPurchase
+        lockAddress={lockAddress}
+        onPurchaseSuccess={() => void refetch()}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SongchainComposePost
+        feedId={feedId}
+        onPosted={(created) => exclusiveFeedRef.current?.registerNewPost(created)}
+      />
+      <SongchainFeedSection
+        ref={exclusiveFeedRef}
+        title="Exclusive feed"
+        description="Season 2 members-only drops and announcements on Lens."
+        feedId={feedId}
+        graphId={graphId}
+        onPostUpdated={() => exclusiveFeedRef.current?.reload()}
+        emptyDescription="Exclusive feeds can require an Orb-linked Lens session, and posts still need to be published directly to the exclusive feed contract before they appear here."
+      />
+    </div>
+  );
+}

--- a/components/songchain/season-2/Season2UnlockPurchase.tsx
+++ b/components/songchain/season-2/Season2UnlockPurchase.tsx
@@ -37,13 +37,10 @@ type Season2UnlockPurchaseProps = {
   onPurchaseSuccess?: () => void | Promise<void>;
 };
 
-function createLensMainnetPublicClient() {
-  const chain = getLensChain("mainnet");
-  return createPublicClient({
-    chain,
-    transport: http(resolveLensRpcUrl("mainnet")),
-  });
-}
+const lensMainnetPublicClient = createPublicClient({
+  chain: getLensChain("mainnet"),
+  transport: http(resolveLensRpcUrl("mainnet")),
+});
 
 export function Season2UnlockPurchase({
   lockAddress,
@@ -74,34 +71,48 @@ export function Season2UnlockPurchase({
   });
 
   useEffect(() => {
+    let active = true;
+
     async function fetchBalance() {
       if (!address || !isAddress(address)) {
-        setGhoBalance("0");
-        setIsBalanceLoading(false);
+        if (active) {
+          setGhoBalance("0");
+          setIsBalanceLoading(false);
+        }
         return;
       }
 
-      setIsBalanceLoading(true);
+      if (active) {
+        setIsBalanceLoading(true);
+      }
       try {
-        const publicClient = createLensMainnetPublicClient();
-        const balance = await publicClient.readContract({
+        const balance = await lensMainnetPublicClient.readContract({
           address: SEASON_2_UNLOCK_CURRENCY,
           abi: erc20Abi,
           functionName: "balanceOf",
           args: [address],
         });
-        setGhoBalance(formatUnits(balance, SEASON_2_UNLOCK_GHO_DECIMALS));
+        if (active) {
+          setGhoBalance(formatUnits(balance, SEASON_2_UNLOCK_GHO_DECIMALS));
+        }
       } catch (error) {
         console.error("[Season2UnlockPurchase] balance", error);
-        setGhoBalance("0");
+        if (active) {
+          setGhoBalance("0");
+        }
       } finally {
-        setIsBalanceLoading(false);
+        if (active) {
+          setIsBalanceLoading(false);
+        }
       }
     }
 
     void fetchBalance();
     const interval = setInterval(() => void fetchBalance(), 10_000);
-    return () => clearInterval(interval);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
   }, [address]);
 
   const handleSwitchToLens = () => {
@@ -140,6 +151,7 @@ export function Season2UnlockPurchase({
     }
 
     const lock = getAddress(lockAddress);
+    const userAddress = getAddress(address);
     const zeroAddress =
       "0x0000000000000000000000000000000000000000" as const;
 
@@ -154,9 +166,9 @@ export function Season2UnlockPurchase({
       functionName: "purchase",
       args: [
         [SEASON_2_UNLOCK_KEY_PRICE],
-        [address],
+        [userAddress],
         [zeroAddress],
-        [address],
+        [userAddress],
         ["0x"],
       ],
     });

--- a/components/songchain/season-2/Season2UnlockPurchase.tsx
+++ b/components/songchain/season-2/Season2UnlockPurchase.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  type Abi,
+  createPublicClient,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  http,
+  isAddress,
+} from "viem";
+import PublicLockV14Json from "@unlock-protocol/contracts/dist/abis/PublicLock/PublicLockV14.json";
+import { Loader2, Lock } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  useAuthModal,
+  useChain,
+  useSendUserOperation,
+  useSmartAccountClient,
+  useUser,
+} from "@/lib/wallet/react";
+import { getLensChain, resolveLensRpcUrl } from "@/lib/sdk/lens/chains";
+import { appendBuilderCode } from "@/lib/utils/builder-code";
+import {
+  SEASON_2_UNLOCK_CHAIN_ID,
+  SEASON_2_UNLOCK_CURRENCY,
+  SEASON_2_UNLOCK_GHO_DECIMALS,
+  SEASON_2_UNLOCK_KEY_PRICE,
+  SEASON_2_UNLOCK_PRICE_GHO,
+} from "@/lib/songchain/season-2-unlock";
+
+type Season2UnlockPurchaseProps = {
+  lockAddress: string;
+  onPurchaseSuccess?: () => void | Promise<void>;
+};
+
+function createLensMainnetPublicClient() {
+  const chain = getLensChain("mainnet");
+  return createPublicClient({
+    chain,
+    transport: http(resolveLensRpcUrl("mainnet")),
+  });
+}
+
+export function Season2UnlockPurchase({
+  lockAddress,
+  onPurchaseSuccess,
+}: Season2UnlockPurchaseProps) {
+  const user = useUser();
+  const { openAuthModal } = useAuthModal();
+  const { chain, setChain } = useChain();
+  const { client, address: clientAddress } = useSmartAccountClient({});
+  const address = client?.account?.address ?? clientAddress ?? user?.address;
+  const lensMainnet = getLensChain("mainnet");
+  const onLensMainnet = chain?.id === SEASON_2_UNLOCK_CHAIN_ID;
+
+  const [ghoBalance, setGhoBalance] = useState("0");
+  const [isBalanceLoading, setIsBalanceLoading] = useState(true);
+
+  const { sendUserOperation, isSendingUserOperation } = useSendUserOperation({
+    client,
+    waitForTxn: true,
+    onSuccess: async () => {
+      toast.success("Season 2 pass purchased!");
+      await onPurchaseSuccess?.();
+    },
+    onError: (error) => {
+      console.error("[Season2UnlockPurchase]", error);
+      toast.error("Failed to purchase Season 2 pass. Please try again.");
+    },
+  });
+
+  useEffect(() => {
+    async function fetchBalance() {
+      if (!address || !isAddress(address)) {
+        setGhoBalance("0");
+        setIsBalanceLoading(false);
+        return;
+      }
+
+      setIsBalanceLoading(true);
+      try {
+        const publicClient = createLensMainnetPublicClient();
+        const balance = await publicClient.readContract({
+          address: SEASON_2_UNLOCK_CURRENCY,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [address],
+        });
+        setGhoBalance(formatUnits(balance, SEASON_2_UNLOCK_GHO_DECIMALS));
+      } catch (error) {
+        console.error("[Season2UnlockPurchase] balance", error);
+        setGhoBalance("0");
+      } finally {
+        setIsBalanceLoading(false);
+      }
+    }
+
+    void fetchBalance();
+    const interval = setInterval(() => void fetchBalance(), 10_000);
+    return () => clearInterval(interval);
+  }, [address]);
+
+  const handleSwitchToLens = () => {
+    setChain({ chain: lensMainnet });
+  };
+
+  const handlePurchase = () => {
+    if (!address) {
+      openAuthModal();
+      return;
+    }
+
+    if (!client) {
+      toast.error("Wallet is still connecting. Try again in a moment.");
+      return;
+    }
+
+    if (!onLensMainnet) {
+      toast.error("Switch to Lens mainnet to purchase the Season 2 pass.");
+      handleSwitchToLens();
+      return;
+    }
+
+    if (!isAddress(lockAddress)) {
+      toast.error("Season 2 Unlock lock is not configured.");
+      return;
+    }
+
+    const balance = Number.parseFloat(ghoBalance);
+    const price = Number.parseFloat(SEASON_2_UNLOCK_PRICE_GHO);
+    if (!Number.isFinite(balance) || balance < price) {
+      toast.error(
+        `Insufficient GHO. You need ${SEASON_2_UNLOCK_PRICE_GHO} GHO on Lens to purchase.`,
+      );
+      return;
+    }
+
+    const lock = getAddress(lockAddress);
+    const zeroAddress =
+      "0x0000000000000000000000000000000000000000" as const;
+
+    const approvalData = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [lock, SEASON_2_UNLOCK_KEY_PRICE],
+    });
+
+    const purchaseData = encodeFunctionData({
+      abi: PublicLockV14Json.abi as Abi,
+      functionName: "purchase",
+      args: [
+        [SEASON_2_UNLOCK_KEY_PRICE],
+        [address],
+        [zeroAddress],
+        [address],
+        ["0x"],
+      ],
+    });
+
+    sendUserOperation({
+      uo: [
+        {
+          target: SEASON_2_UNLOCK_CURRENCY,
+          data: appendBuilderCode(approvalData),
+          value: 0n,
+        },
+        {
+          target: lock,
+          data: appendBuilderCode(purchaseData),
+          value: 0n,
+        },
+      ],
+    });
+  };
+
+  const canPurchase = Boolean(address && client && onLensMainnet);
+
+  return (
+    <section
+      className="rounded-lg border border-violet-500/30 bg-gradient-to-b from-violet-500/10 to-card p-6 sm:p-8"
+      aria-labelledby="season-2-unlock-title"
+    >
+      <div className="mx-auto flex max-w-lg flex-col items-center text-center">
+        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-violet-500/15">
+          <Lock className="h-7 w-7 text-violet-300" aria-hidden />
+        </div>
+        <h2
+          id="season-2-unlock-title"
+          className="text-xl font-bold tracking-tight sm:text-2xl"
+        >
+          Season 2 Exclusive Pass
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground sm:text-base">
+          Unlock the Season 2 exclusive feed with a unique NFT on Lens mainnet
+          for {SEASON_2_UNLOCK_PRICE_GHO} GHO.
+        </p>
+
+        <p className="mt-4 text-sm text-muted-foreground">
+          Your GHO balance:{" "}
+          <span className="font-medium text-foreground">
+            {isBalanceLoading
+              ? "—"
+              : `${Number.isFinite(Number.parseFloat(ghoBalance)) ? Number.parseFloat(ghoBalance).toFixed(2) : "0.00"} GHO`}
+          </span>
+        </p>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+          {!address ? (
+            <Button size="lg" onClick={() => openAuthModal()} className="min-w-[10rem]">
+              Connect wallet
+            </Button>
+          ) : !onLensMainnet ? (
+            <Button size="lg" onClick={handleSwitchToLens} className="min-w-[10rem]">
+              Switch to Lens
+            </Button>
+          ) : (
+            <Button
+              size="lg"
+              disabled={!canPurchase || isSendingUserOperation}
+              onClick={handlePurchase}
+              className="min-w-[10rem]"
+            >
+              {isSendingUserOperation ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Buy for {SEASON_2_UNLOCK_PRICE_GHO} GHO
+            </Button>
+          )}
+        </div>
+
+        <p className="mt-4 text-[10px] text-muted-foreground">
+          Lock{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
+            {lockAddress.slice(0, 10)}…{lockAddress.slice(-6)}
+          </code>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/components/songchain/season-2/SongchainSeason2PageClient.tsx
+++ b/components/songchain/season-2/SongchainSeason2PageClient.tsx
@@ -52,6 +52,7 @@ export function SongchainSeason2PageClient({
           id="songchain-season-2-feeds"
           publicFeedId={publicFeedId}
           exclusiveFeedId={exclusiveFeedId}
+          exclusiveUnlockLockAddress={config.season2LockAddress}
         />
       </div>
     </div>

--- a/env.example
+++ b/env.example
@@ -46,6 +46,9 @@ NEXT_PUBLIC_SONGCHAIN_SEASON_2_ENABLED=false
 # Optional dedicated feeds; fall back to main Songchain feeds when unset.
 NEXT_PUBLIC_SONGCHAIN_SEASON_2_FEED_ID=
 NEXT_PUBLIC_SONGCHAIN_SEASON_2_EXCLUSIVE_FEED_ID=
+# Unlock PublicLock on Lens mainnet (10 GHO). Deploy separately via Unlock factory
+# 0xbD32e0ea3b3a5b038E942A15De61508b4A61Bd23 (chain 232, startBlock 6079300).
+NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS=
 
 # Optional server-only fallbacks (no NEXT_PUBLIC_ prefix)
 # SONGCHAIN_APP_ID=

--- a/hooks/useSeason2UnlockKey.ts
+++ b/hooks/useSeason2UnlockKey.ts
@@ -1,10 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import PublicLockV14Json from "@unlock-protocol/contracts/dist/abis/PublicLock/PublicLockV14.json";
-import { type Address, type Abi, getAddress, isAddress } from "viem";
+import {
+  type Address,
+  type Abi,
+  createPublicClient,
+  getAddress,
+  http,
+  isAddress,
+} from "viem";
 import { useSmartAccountClient, useUser } from "@/lib/wallet/react";
-import { createPublicClient, http } from "viem";
 import { getLensChain, resolveLensRpcUrl } from "@/lib/sdk/lens/chains";
 
 type UseSeason2UnlockKeyArgs = {
@@ -19,14 +25,10 @@ export type Season2UnlockKeyState = {
   refetch: () => Promise<void>;
 };
 
-function createSeason2UnlockPublicClient() {
-  const chain = getLensChain("mainnet");
-  const rpcUrl = resolveLensRpcUrl("mainnet");
-  return createPublicClient({
-    chain,
-    transport: http(rpcUrl),
-  });
-}
+const season2UnlockPublicClient = createPublicClient({
+  chain: getLensChain("mainnet"),
+  transport: http(resolveLensRpcUrl("mainnet")),
+});
 
 export function useSeason2UnlockKey({
   lockAddress,
@@ -40,8 +42,11 @@ export function useSeason2UnlockKey({
     null;
 
   const [hasValidKey, setHasValidKey] = useState(false);
-  const [isLoading, setIsLoading] = useState(Boolean(lockAddress));
+  const [isLoading, setIsLoading] = useState(
+    Boolean(lockAddress && isAddress(lockAddress)),
+  );
   const [error, setError] = useState<string | null>(null);
+  const activeRequestRef = useRef(0);
 
   const refetch = useCallback(async () => {
     if (!lockAddress || !isAddress(lockAddress)) {
@@ -58,27 +63,35 @@ export function useSeason2UnlockKey({
       return;
     }
 
+    const requestId = ++activeRequestRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
-      const publicClient = createSeason2UnlockPublicClient();
       const lock = getAddress(lockAddress);
-      const result = await publicClient.readContract({
+      const result = await season2UnlockPublicClient.readContract({
         address: lock,
         abi: PublicLockV14Json.abi as Abi,
         functionName: "getHasValidKey",
         args: [ownerAddress],
       });
-      setHasValidKey(Boolean(result));
+      if (requestId === activeRequestRef.current) {
+        setHasValidKey(Boolean(result));
+      }
     } catch (err) {
       console.error("[useSeason2UnlockKey]", err);
-      setHasValidKey(false);
-      setError(
-        err instanceof Error ? err.message : "Failed to check Season 2 Unlock key",
-      );
+      if (requestId === activeRequestRef.current) {
+        setHasValidKey(false);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to check Season 2 Unlock key",
+        );
+      }
     } finally {
-      setIsLoading(false);
+      if (requestId === activeRequestRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [lockAddress, ownerAddress]);
 

--- a/hooks/useSeason2UnlockKey.ts
+++ b/hooks/useSeason2UnlockKey.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import PublicLockV14Json from "@unlock-protocol/contracts/dist/abis/PublicLock/PublicLockV14.json";
+import { type Address, type Abi, getAddress, isAddress } from "viem";
+import { useSmartAccountClient, useUser } from "@/lib/wallet/react";
+import { createPublicClient, http } from "viem";
+import { getLensChain, resolveLensRpcUrl } from "@/lib/sdk/lens/chains";
+
+type UseSeason2UnlockKeyArgs = {
+  lockAddress: string | null | undefined;
+};
+
+export type Season2UnlockKeyState = {
+  hasValidKey: boolean;
+  isLoading: boolean;
+  error: string | null;
+  ownerAddress: Address | null;
+  refetch: () => Promise<void>;
+};
+
+function createSeason2UnlockPublicClient() {
+  const chain = getLensChain("mainnet");
+  const rpcUrl = resolveLensRpcUrl("mainnet");
+  return createPublicClient({
+    chain,
+    transport: http(rpcUrl),
+  });
+}
+
+export function useSeason2UnlockKey({
+  lockAddress,
+}: UseSeason2UnlockKeyArgs): Season2UnlockKeyState {
+  const user = useUser();
+  const { client, address: clientAddress } = useSmartAccountClient({});
+  const ownerAddress =
+    (client?.account?.address as Address | undefined) ??
+    (clientAddress as Address | undefined) ??
+    (user?.address as Address | undefined) ??
+    null;
+
+  const [hasValidKey, setHasValidKey] = useState(false);
+  const [isLoading, setIsLoading] = useState(Boolean(lockAddress));
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!lockAddress || !isAddress(lockAddress)) {
+      setHasValidKey(false);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (!ownerAddress) {
+      setHasValidKey(false);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const publicClient = createSeason2UnlockPublicClient();
+      const lock = getAddress(lockAddress);
+      const result = await publicClient.readContract({
+        address: lock,
+        abi: PublicLockV14Json.abi as Abi,
+        functionName: "getHasValidKey",
+        args: [ownerAddress],
+      });
+      setHasValidKey(Boolean(result));
+    } catch (err) {
+      console.error("[useSeason2UnlockKey]", err);
+      setHasValidKey(false);
+      setError(
+        err instanceof Error ? err.message : "Failed to check Season 2 Unlock key",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [lockAddress, ownerAddress]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return {
+    hasValidKey,
+    isLoading,
+    error,
+    ownerAddress,
+    refetch,
+  };
+}

--- a/lib/chones/config.ts
+++ b/lib/chones/config.ts
@@ -77,6 +77,7 @@ export function getChonesConfig(): ChonesConfig {
     season2Enabled: false,
     season2PublicFeedId: null,
     season2ExclusiveFeedId: null,
+    season2LockAddress: null,
   };
 }
 
@@ -121,5 +122,6 @@ export function getHackBetaConfig(): ChonesConfig {
     season2Enabled: false,
     season2PublicFeedId: null,
     season2ExclusiveFeedId: null,
+    season2LockAddress: null,
   };
 }

--- a/lib/songchain/config.test.ts
+++ b/lib/songchain/config.test.ts
@@ -65,6 +65,22 @@ describe('getSongchainConfig', () => {
     );
     expect(config.enabled).toBe(true);
   });
+
+  it('reads Season 2 Unlock lock address from env', () => {
+    process.env.NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS =
+      '0xAbC0000000000000000000000000000000000099';
+    const config = getSongchainConfig();
+    expect(config.season2LockAddress).toBe(
+      '0xabc0000000000000000000000000000000000099',
+    );
+  });
+
+  it('defaults Season 2 lock address to null when unset', () => {
+    delete process.env.NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS;
+    delete process.env.SONGCHAIN_SEASON_2_LOCK_ADDRESS;
+    const config = getSongchainConfig();
+    expect(config.season2LockAddress).toBeNull();
+  });
 });
 
 describe('getSongCupConfig', () => {
@@ -100,6 +116,7 @@ describe('getSongCupConfig', () => {
     expect(config.season2Enabled).toBe(false);
     expect(config.season2PublicFeedId).toBeNull();
     expect(config.season2ExclusiveFeedId).toBeNull();
+    expect(config.season2LockAddress).toBeNull();
   });
 
   it('uses built-in Song Cup club defaults when Song Cup feed/group vars are unset', () => {

--- a/lib/songchain/config.ts
+++ b/lib/songchain/config.ts
@@ -27,6 +27,8 @@ export type SongchainConfig = {
   season2Enabled: boolean;
   season2PublicFeedId: string | null;
   season2ExclusiveFeedId: string | null;
+  /** Unlock PublicLock on Lens mainnet for Season 2 exclusive access (10 GHO). */
+  season2LockAddress: string | null;
 };
 
 function readEnv(...keys: string[]): string | null {
@@ -93,6 +95,10 @@ export function getSongchainConfig(): SongchainConfig {
     'NEXT_PUBLIC_SONGCHAIN_SEASON_2_EXCLUSIVE_FEED_ID',
     'SONGCHAIN_SEASON_2_EXCLUSIVE_FEED_ID',
   );
+  const season2LockAddress = readLensPrimitiveEnv(
+    'NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS',
+    'SONGCHAIN_SEASON_2_LOCK_ADDRESS',
+  );
 
   const network = getLensNetwork();
 
@@ -113,6 +119,7 @@ export function getSongchainConfig(): SongchainConfig {
     season2Enabled,
     season2PublicFeedId,
     season2ExclusiveFeedId,
+    season2LockAddress,
   };
 }
 
@@ -160,5 +167,6 @@ export function getSongCupConfig(): SongchainConfig {
     season2Enabled: false,
     season2PublicFeedId: null,
     season2ExclusiveFeedId: null,
+    season2LockAddress: null,
   };
 }

--- a/lib/songchain/resolve-lens-app.test.ts
+++ b/lib/songchain/resolve-lens-app.test.ts
@@ -31,6 +31,7 @@ const baseConfig: SongchainConfig = {
   season2Enabled: false,
   season2PublicFeedId: null,
   season2ExclusiveFeedId: null,
+  season2LockAddress: null,
 };
 
 describe('resolveSongchainConfig', () => {

--- a/lib/songchain/season-2-unlock.ts
+++ b/lib/songchain/season-2-unlock.ts
@@ -1,0 +1,36 @@
+import { parseUnits } from "viem";
+import { LENS_GHO_TOKEN_ADDRESS } from "@/lib/songchain/halliday";
+import { LENS_MAINNET_CHAIN_ID } from "@/lib/sdk/lens/chains";
+
+/**
+ * Songchain Season 2 Unlock (Lens mainnet) — deploy PublicLock offline, then set
+ * NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS.
+ *
+ * Deploy checklist (not called from the app):
+ * 1. createLock on SEASON_2_UNLOCK_FACTORY (chain 232)
+ *    - keyPrice = SEASON_2_UNLOCK_KEY_PRICE (10 GHO)
+ *    - tokenAddress = SEASON_2_UNLOCK_CURRENCY (Lens WGHO 0x…800a)
+ *    - name/symbol for Season 2; set expirationDuration / maxNumberOfKeys as needed
+ * 2. Set NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS to the deployed lock
+ * 3. Enable Season 2 with NEXT_PUBLIC_SONGCHAIN_SEASON_2_ENABLED=true
+ *
+ * Factory startBlock (for future subgraph indexing): 6079300
+ */
+export const SEASON_2_UNLOCK_FACTORY =
+  "0xbD32e0ea3b3a5b038E942A15De61508b4A61Bd23" as const;
+
+export const SEASON_2_UNLOCK_START_BLOCK = 6079300;
+
+export const SEASON_2_UNLOCK_CHAIN_ID = LENS_MAINNET_CHAIN_ID;
+
+export const SEASON_2_UNLOCK_CURRENCY = LENS_GHO_TOKEN_ADDRESS;
+
+/** GHO / WGHO on Lens uses 18 decimals. */
+export const SEASON_2_UNLOCK_GHO_DECIMALS = 18;
+
+export const SEASON_2_UNLOCK_PRICE_GHO = "10";
+
+export const SEASON_2_UNLOCK_KEY_PRICE = parseUnits(
+  SEASON_2_UNLOCK_PRICE_GHO,
+  SEASON_2_UNLOCK_GHO_DECIMALS,
+);


### PR DESCRIPTION
## Summary
- Adds Season 2–only Unlock lock config (`NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS`) on Lens mainnet with 10 GHO pricing constants and factory metadata.
- Gates `/songchain/season-2` Exclusive feed behind a valid key, with approve + purchase user-op CTA when missing.
- Leaves Base Creative Passes and main Songchain / Song Cup gating unchanged.

## Test plan
- [ ] Set `NEXT_PUBLIC_SONGCHAIN_SEASON_2_LOCK_ADDRESS=0x6a7ffbcd5fcbb7256aa9935390a4bb1db1eae707` and `NEXT_PUBLIC_SONGCHAIN_SEASON_2_ENABLED=true`
- [ ] Open `/songchain/season-2` Exclusive tab without a key → see 10 GHO purchase CTA
- [ ] Switch to Lens, approve GHO, purchase → Exclusive feed unlocks
- [ ] Confirm main `/songchain` and Song Cup exclusive tabs are ungated
- [ ] `npx vitest run lib/songchain/config.test.ts`


Made with [Cursor](https://cursor.com)