### PR TITLE
Add Grove image attachments to Song Cup feed

### DIFF
--- a/components/songchain/song-cup/SongCupFeedCompose.tsx
+++ b/components/songchain/song-cup/SongCupFeedCompose.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import { useState } from "react";
-import { Loader2, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { ImageIcon, Loader2, Plus, X } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useSongchainPost } from "@/hooks/useSongchainPost";
 import type { SongchainCreatedPost } from "@/lib/songchain/feed-types";
+import { resolveMediaImageMimeType } from "@/lib/songchain/build-lens-image-metadata";
+import { uploadToGrove } from "@/lib/songchain/song-cup/upload-to-grove";
 import { cn } from "@/lib/utils/utils";
 import {
   songCupBorderAccent,
   songCupMuted,
   songCupPanelInset,
 } from "@/lib/songchain/song-cup/panel-styles";
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ACCEPTED_IMAGE_TYPES = "image/jpeg,image/png,image/gif,image/webp";
 
 type SongCupFeedComposeProps = {
   feedId: string | null;
@@ -26,31 +32,101 @@ export function SongCupFeedCompose({
 }: SongCupFeedComposeProps) {
   const [content, setContent] = useState("");
   const [focused, setFocused] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { createPost, isPosting, canWrite, needsOrbReauth, promptWriteAccess } =
     useSongchainPost();
 
+  useEffect(() => {
+    if (!imageFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(imageFile);
+    setPreviewUrl(objectUrl);
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [imageFile]);
+
   if (!feedId) return null;
 
   const hasContent = content.trim().length > 0;
-  const canSubmit = hasContent;
+  const hasImage = !!imageFile;
+  const canSubmit = hasContent || hasImage;
+  const busy = isPosting || isUploadingImage;
+  const showExpanded = focused || hasContent || hasImage;
+
+  const clearImage = () => {
+    setImageFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleImagePick = (file: File | undefined) => {
+    if (!file) return;
+    if (!resolveMediaImageMimeType(file.type)) {
+      toast.error("Use JPEG, PNG, GIF, or WebP images.");
+      return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      toast.error("Image must be under 10 MB.");
+      return;
+    }
+    setImageFile(file);
+    setFocused(true);
+  };
 
   const handleSubmit = async () => {
+    let attachedImage: { url: string; mimeType: string } | null = null;
+
+    if (imageFile) {
+      setIsUploadingImage(true);
+      try {
+        const grove = await uploadToGrove(imageFile);
+        attachedImage = {
+          url: grove.url,
+          mimeType: imageFile.type,
+        };
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to upload image to Grove.",
+        );
+        return;
+      } finally {
+        setIsUploadingImage(false);
+      }
+    }
+
     const created = await createPost({
       content,
       feedId,
+      attachedImage,
     });
     if (created) {
       setContent("");
+      clearImage();
       setFocused(false);
       onPosted?.(created);
     }
   };
 
-  const showExpanded = focused || hasContent;
-
   return (
     <div className={cn("relative min-h-[117px] p-4", songCupPanelInset, songCupBorderAccent, "border")}>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_IMAGE_TYPES}
+        className="hidden"
+        disabled={busy}
+        onChange={(e) => {
+          handleImagePick(e.target.files?.[0]);
+          e.target.value = "";
+        }}
+      />
+
       {!showExpanded ? (
         <button
           type="button"
@@ -81,30 +157,65 @@ export function SongCupFeedCompose({
             onChange={(e) => setContent(e.target.value)}
             placeholder={placeholder}
             rows={3}
-            disabled={isPosting}
+            disabled={busy}
             maxLength={5000}
             autoFocus={focused}
             onBlur={() => {
-              if (!hasContent) setFocused(false);
+              if (!hasContent && !hasImage) setFocused(false);
             }}
             className="border-0 bg-transparent p-0 text-sm text-foreground placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-white dark:placeholder:text-white/40"
           />
+
+          {previewUrl && (
+            <div className="relative w-full max-w-xs overflow-hidden rounded-md border border-border/50">
+              {/* Local object URL preview only — Grove URL is used on post */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="Attachment preview"
+                className="max-h-48 w-full object-cover"
+              />
+              <button
+                type="button"
+                onClick={clearImage}
+                disabled={busy}
+                className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/70 text-white hover:bg-black/90 disabled:opacity-50"
+                aria-label="Remove image"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
 
           {!canWrite ? (
             <Button type="button" variant="outline" size="sm" onClick={promptWriteAccess} className="w-fit">
               {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
             </Button>
           ) : (
-            <Button
-              type="button"
-              size="sm"
-              disabled={isPosting || !canSubmit}
-              onClick={() => void handleSubmit()}
-              className="ml-auto rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
-            >
-              {isPosting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              POST
-            </Button>
+            <div className="flex items-center justify-between gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={busy}
+                onClick={() => fileInputRef.current?.click()}
+                className={cn("gap-1.5 px-2", songCupMuted)}
+                aria-label="Attach image"
+              >
+                <ImageIcon className="h-4 w-4" />
+                <span className="text-xs">Image</span>
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={busy || !canSubmit}
+                onClick={() => void handleSubmit()}
+                className="rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
+              >
+                {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {isUploadingImage ? "Uploading…" : "POST"}
+              </Button>
+            </div>
           )}
         </div>
       )}

--- a/hooks/useSongchainPost.ts
+++ b/hooks/useSongchainPost.ts
@@ -20,6 +20,10 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { extractCreatedPostId } from "@/lib/songchain/post-utils";
 import { buildLensVideoMetadataFromAsset } from "@/lib/songchain/build-lens-video-metadata";
 import {
+  buildLensImageMetadata,
+  type SongchainAttachedImage,
+} from "@/lib/songchain/build-lens-image-metadata";
+import {
   buildLensLiveStreamMetadata,
   type StreamSummary,
 } from "@/lib/songchain/build-lens-livestream-metadata";
@@ -33,6 +37,8 @@ export type CreateSongchainPostParams = {
   title?: string;
   attachedVideo?: VideoAsset | null;
   attachedLiveStream?: StreamSummary | null;
+  /** Grove gateway URL + mime type from uploadToGrove */
+  attachedImage?: SongchainAttachedImage | null;
 };
 
 function thumbnailFromAsset(asset: VideoAsset): string | undefined {
@@ -60,13 +66,15 @@ export function useSongchainPost() {
       title = "Songchain post",
       attachedVideo,
       attachedLiveStream,
+      attachedImage,
     }: CreateSongchainPostParams): Promise<SongchainCreatedPost | null> => {
       const trimmed = content.trim();
       const hasLive =
         !!attachedLiveStream?.is_live && !!attachedLiveStream.playback_id;
       const hasVideo = !!attachedVideo?.playback_id;
+      const hasImage = !!attachedImage?.url?.trim();
 
-      if (!trimmed && !hasVideo && !hasLive) {
+      if (!trimmed && !hasVideo && !hasLive && !hasImage) {
         toast.error("Write something or attach media before posting.");
         return null;
       }
@@ -117,6 +125,10 @@ export function useSongchainPost() {
           metadata = await buildLensVideoMetadataFromAsset(attachedVideo, trimmed);
           displayTitle = attachedVideo.title;
           thumbnailUrl = thumbnailFromAsset(attachedVideo);
+        } else if (hasImage && attachedImage) {
+          metadata = buildLensImageMetadata(attachedImage, trimmed);
+          displayTitle = trimmed || "Image post";
+          thumbnailUrl = attachedImage.url.trim();
         } else {
           metadata = textOnly({
             content: trimmed,

--- a/lib/songchain/build-lens-image-metadata.ts
+++ b/lib/songchain/build-lens-image-metadata.ts
@@ -1,0 +1,55 @@
+import {
+  image,
+  MediaImageMimeType,
+  MetadataLicenseType,
+} from "@lens-protocol/metadata";
+
+export type SongchainAttachedImage = {
+  /** Grove gateway URL from uploadToGrove / groveService.uploadFile */
+  url: string;
+  mimeType: string;
+};
+
+const MIME_TO_LENS: Record<string, MediaImageMimeType> = {
+  "image/jpeg": MediaImageMimeType.JPEG,
+  "image/jpg": MediaImageMimeType.JPEG,
+  "image/png": MediaImageMimeType.PNG,
+  "image/gif": MediaImageMimeType.GIF,
+  "image/webp": MediaImageMimeType.WEBP,
+};
+
+export function resolveMediaImageMimeType(
+  mimeType: string,
+): MediaImageMimeType | null {
+  const normalized = mimeType.trim().toLowerCase();
+  return MIME_TO_LENS[normalized] ?? null;
+}
+
+export function buildLensImageMetadata(
+  attached: SongchainAttachedImage,
+  caption: string,
+) {
+  const type = resolveMediaImageMimeType(attached.mimeType);
+  if (!type) {
+    throw new Error(
+      `Unsupported image type: ${attached.mimeType}. Use JPEG, PNG, GIF, or WebP.`,
+    );
+  }
+
+  const groveUrl = attached.url.trim();
+  if (!groveUrl) {
+    throw new Error("Image Grove URL is missing.");
+  }
+
+  const trimmedCaption = caption.trim();
+
+  return image({
+    ...(trimmedCaption ? { content: trimmedCaption } : {}),
+    image: {
+      item: groveUrl,
+      type,
+      license: MetadataLicenseType.CCO,
+    },
+    locale: "en",
+  });
+}


### PR DESCRIPTION
## Summary
- Let Song Cup feed members attach a single JPEG/PNG/GIF/WebP image when composing a post
- Upload image bytes through Grove (`uploadToGrove` / Lens Storage) and post Lens `image()` metadata with the Grove gateway URL
- Extend `useSongchainPost` so image-only posts are supported alongside text

## Test plan
- [ ] Open `/songchain/song-cup`, join the club if needed, open the feed panel
- [ ] Attach an image, confirm local preview and remove control work
- [ ] Reject unsupported types / files over 10MB with a toast
- [ ] Post with image + caption and confirm the image appears in the feed
- [ ] Post image-only and confirm it succeeds
- [ ] Confirm Network/Grove upload uses Grove gateway URLs (not blob/data URLs)


Made with [Cursor](https://cursor.com)