### PR TITLE
Fix Chones mobile banner, feed image picker, and upload Pixels icon

### DIFF
--- a/app/api/video-assets/views/increment/[playbackId]/route.ts
+++ b/app/api/video-assets/views/increment/[playbackId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
 import { createServiceClient } from "@/lib/sdk/supabase/service";
 import { serverLogger } from "@/lib/utils/logger";
 
@@ -8,6 +9,13 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> }
 ) {
+  const botCheck = await requireHumanOrVerifiedBot(
+    "video-assets.views.increment",
+  );
+  if (!botCheck.allowed) {
+    return botCheck.response;
+  }
+
   try {
     const { playbackId } = await params;
 
@@ -19,7 +27,7 @@ export async function POST(
     }
 
     const supabase = createServiceClient();
-    
+
     // Atomically increment view count in database via RPC to prevent race conditions
     const { data: newViews, error } = await supabase.rpc("increment_video_views", {
       p_playback_id: playbackId,
@@ -29,10 +37,21 @@ export async function POST(
       throw error;
     }
 
+    // RPC returns NULL when no video_assets row matches playback_id
+    if (newViews == null) {
+      return NextResponse.json(
+        {
+          error: "Video not found for playback ID",
+          code: "VIDEO_NOT_FOUND",
+        },
+        { status: 404 }
+      );
+    }
+
     return NextResponse.json({
       success: true,
       playbackId,
-      viewCount: newViews,
+      viewCount: Number(newViews),
     });
   } catch (error) {
     serverLogger.error("Error incrementing view count:", error);

--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -155,9 +155,14 @@ export default async function VideoDetailsPage({
               contractAddress={videoAsset?.contract_address ?? null}
               tokenId={videoAsset?.token_id ?? null}
             />
-            {/* Views (left) + actions/share (right) */}
+            {/* Date + views (left) + actions/share (right) */}
             <div className="flex items-center justify-between gap-4 mt-4 flex-wrap">
-              <div className="flex items-center min-h-4">
+              <div className="flex items-center gap-3 min-h-4 flex-wrap">
+                {videoAsset?.created_at ? (
+                  <span className="text-sm text-muted-foreground md:text-base">
+                    {new Date(videoAsset.created_at).toLocaleDateString()}
+                  </span>
+                ) : null}
                 {assetData.playbackId && (
                   <VideoViewMetrics
                     playbackId={assetData.playbackId}

--- a/components/Videos/Upload/FileUpload.tsx
+++ b/components/Videos/Upload/FileUpload.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState, useRef, useEffect } from "react";
 import { toast } from "sonner";
-import { CopyIcon, ExternalLink } from "lucide-react";
+import { Clapperboard, CopyIcon, ExternalLink } from "lucide-react";
 import {
   getLivepeerUploadUrl,
   getLivepeerAsset,
@@ -38,12 +38,7 @@ function EditInPixelsCta() {
           aria-label="Edit video in Creative Pixels"
           data-testid="edit-in-pixels-button"
         >
-          <img
-            src="/songchain/button-icons/Pixels-icon.svg"
-            alt=""
-            aria-hidden
-            className="h-4 w-4"
-          />
+          <Clapperboard className="h-4 w-4" aria-hidden />
           Edit in Pixels
           <ExternalLink className="h-3.5 w-3.5 opacity-70" />
         </a>

--- a/components/Videos/VideoCard.tsx
+++ b/components/Videos/VideoCard.tsx
@@ -4,7 +4,6 @@ import { convertFailingGateway } from "@/lib/utils/image-gateway";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -346,13 +345,6 @@ const VideoCard: React.FC<VideoCardProps> = ({
           </div>
           {videoAssetId && <div className="my-2" />}
           <div className="mt-6 grid grid-flow-row auto-rows-max space-y-3 overflow-hidden">
-            <CardDescription className="text-xl" color={"brand.300"}>
-              <span className="text-xs">
-                {asset?.createdAt
-                  ? new Date(asset.createdAt).toLocaleDateString()
-                  : ""}
-              </span>
-            </CardDescription>
             <CardTitle>
               <Link href={`/discover/${asset.id}`}>
                 <h1

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -37,6 +37,10 @@ import {
   useSubtitles,
 } from "@/components/Player/Subtitles";
 import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
+import {
+  livepeerViewMetricsQueryKey,
+  type LivepeerViewMetrics,
+} from "@/lib/hooks/livepeer/useLivepeerViewMetrics";
 import { generateAccessKey, WebhookContext } from "@/lib/access-key";
 import { Skeleton } from "../ui/skeleton";
 import { Badge } from "../ui/badge";
@@ -217,26 +221,44 @@ export default function VideoDetails({
   useEffect(() => {
     if (!asset?.playbackId || !playbackSources?.length) return;
 
-    const container = containerRef.current;
-    if (!container) return;
-
+    let cancelled = false;
     let incrementing = false;
     let incremented = false;
     let attachedVideo: HTMLVideoElement | null = null;
+    let observer: MutationObserver | null = null;
+    let rafId = 0;
 
     const handlePlay = async () => {
-      if (incremented || incrementing) return;
+      if (incremented || incrementing || !asset.playbackId) return;
       incrementing = true;
 
       try {
         const response = await fetch(
-          `/api/video-assets/views/increment/${encodeURIComponent(asset.playbackId!)}`,
+          `/api/video-assets/views/increment/${encodeURIComponent(asset.playbackId)}`,
           { method: "POST" },
         );
-        if (response.ok) {
+        let payload: { viewCount?: unknown } | null = null;
+        try {
+          payload = (await response.json()) as { viewCount?: unknown };
+        } catch {
+          payload = null;
+        }
+
+        const viewCount = Number(payload?.viewCount);
+        if (response.ok && Number.isFinite(viewCount) && viewCount > 0) {
           incremented = true;
+          queryClient.setQueryData<LivepeerViewMetrics>(
+            livepeerViewMetricsQueryKey(asset.playbackId),
+            (prev) => ({
+              playbackId: asset.playbackId!,
+              viewCount,
+              playtimeMins: prev?.playtimeMins ?? 0,
+              legacyViewCount: prev?.legacyViewCount ?? 0,
+              totalViews: Math.max(viewCount, prev?.totalViews ?? 0),
+            }),
+          );
           await queryClient.invalidateQueries({
-            queryKey: ["livepeer-view-metrics", asset.playbackId],
+            queryKey: livepeerViewMetricsQueryKey(asset.playbackId),
           });
         }
       } catch (err) {
@@ -255,18 +277,31 @@ export default function VideoDetails({
       video.addEventListener("play", handlePlay);
     };
 
-    // Player may mount after this effect — observe until <video> exists
-    const existing = container.querySelector("video");
-    if (existing) attach(existing);
+    const setup = () => {
+      if (cancelled) return;
+      const container = containerRef.current;
+      if (!container) {
+        rafId = requestAnimationFrame(setup);
+        return;
+      }
 
-    const observer = new MutationObserver(() => {
-      const video = container.querySelector("video");
-      if (video) attach(video);
-    });
-    observer.observe(container, { childList: true, subtree: true });
+      // Player may mount after this effect — observe until <video> exists
+      const existing = container.querySelector("video");
+      if (existing) attach(existing);
+
+      observer = new MutationObserver(() => {
+        const video = container.querySelector("video");
+        if (video) attach(video);
+      });
+      observer.observe(container, { childList: true, subtree: true });
+    };
+
+    setup();
 
     return () => {
-      observer.disconnect();
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      observer?.disconnect();
       if (attachedVideo) {
         attachedVideo.removeEventListener("play", handlePlay);
       }

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -219,7 +219,8 @@ export default function VideoDetails({
   const isConnected = !!user;
 
   useEffect(() => {
-    if (!asset?.playbackId || !playbackSources?.length) return;
+    // Player (and containerRef) only mount when wallet is connected
+    if (!isConnected || !asset?.playbackId || !playbackSources?.length) return;
 
     let cancelled = false;
     let incrementing = false;
@@ -227,6 +228,8 @@ export default function VideoDetails({
     let attachedVideo: HTMLVideoElement | null = null;
     let observer: MutationObserver | null = null;
     let rafId = 0;
+    let rafAttempts = 0;
+    const MAX_RAF_ATTEMPTS = 120; // ~2s at 60fps, then stop
 
     const handlePlay = async () => {
       if (incremented || incrementing || !asset.playbackId) return;
@@ -244,19 +247,22 @@ export default function VideoDetails({
           payload = null;
         }
 
-        const viewCount = Number(payload?.viewCount);
-        if (response.ok && Number.isFinite(viewCount) && viewCount > 0) {
+        // DB mutates before the response — treat any 2xx as consumed so we don't double-count
+        if (response.ok) {
           incremented = true;
-          queryClient.setQueryData<LivepeerViewMetrics>(
-            livepeerViewMetricsQueryKey(asset.playbackId),
-            (prev) => ({
-              playbackId: asset.playbackId!,
-              viewCount,
-              playtimeMins: prev?.playtimeMins ?? 0,
-              legacyViewCount: prev?.legacyViewCount ?? 0,
-              totalViews: Math.max(viewCount, prev?.totalViews ?? 0),
-            }),
-          );
+          const viewCount = Number(payload?.viewCount);
+          if (Number.isFinite(viewCount) && viewCount > 0) {
+            queryClient.setQueryData<LivepeerViewMetrics>(
+              livepeerViewMetricsQueryKey(asset.playbackId),
+              (prev) => ({
+                playbackId: asset.playbackId!,
+                viewCount,
+                playtimeMins: prev?.playtimeMins ?? 0,
+                legacyViewCount: prev?.legacyViewCount ?? 0,
+                totalViews: Math.max(viewCount, prev?.totalViews ?? 0),
+              }),
+            );
+          }
           await queryClient.invalidateQueries({
             queryKey: livepeerViewMetricsQueryKey(asset.playbackId),
           });
@@ -281,7 +287,10 @@ export default function VideoDetails({
       if (cancelled) return;
       const container = containerRef.current;
       if (!container) {
-        rafId = requestAnimationFrame(setup);
+        rafAttempts += 1;
+        if (rafAttempts < MAX_RAF_ATTEMPTS) {
+          rafId = requestAnimationFrame(setup);
+        }
         return;
       }
 
@@ -306,7 +315,7 @@ export default function VideoDetails({
         attachedVideo.removeEventListener("play", handlePlay);
       }
     };
-  }, [asset?.playbackId, playbackSources, queryClient]);
+  }, [isConnected, asset?.playbackId, playbackSources, queryClient]);
 
   const loadPlaybackSources = useCallback(async () => {
     if (!asset?.playbackId) {

--- a/components/chones/ChonesBanner.tsx
+++ b/components/chones/ChonesBanner.tsx
@@ -22,36 +22,70 @@ export function ChonesBanner({
   className,
 }: ChonesBannerProps) {
   return (
-    <div
-      className={cn(
-        channelBannerShell("aspect-[1024/274] bg-[#f0e6da] py-0"),
-        className,
-      )}
-    >
-      <Image
-        src="/chones/chonescreativechannelbanner.svg"
-        alt="Chones"
-        fill
-        className="object-cover object-center"
-        priority
-        unoptimized
-        sizes="(max-width: 1280px) 100vw, 1280px"
-      />
+    <div className={cn("h-full w-full", className)}>
+      {/* Mobile: original cream logo — scales better on phones */}
+      <div className={channelBannerShell("bg-[#f0e6da] md:hidden")}>
+        <div className={channelBannerContentClassName}>
+          <div className="relative aspect-[1024/173] w-[min(78vw,720px)] max-w-full">
+            <Image
+              src="/chones/chones-banner.png"
+              alt="Chones"
+              fill
+              className="object-contain object-center"
+              priority
+              sizes="78vw"
+            />
+          </div>
 
-      {showButton ? (
-        <div
-          className={cn(
-            channelBannerContentClassName,
-            "justify-end pb-4 lg:pb-6",
+          {showButton ? (
+            <SongCupGoalButton
+              href={href}
+              label={buttonLabel}
+              className="animate-songcup-pulse hover:animate-none"
+            />
+          ) : (
+            /* Keep vertical rhythm when ENTER is hidden (e.g. /chones page) */
+            <span
+              className="invisible inline-flex w-[clamp(120px,38vw,330px)]"
+              aria-hidden
+            >
+              <span className="aspect-[296/129] w-full" />
+            </span>
           )}
-        >
-          <SongCupGoalButton
-            href={href}
-            label={buttonLabel}
-            className="animate-songcup-pulse hover:animate-none"
-          />
         </div>
-      ) : null}
+      </div>
+
+      {/* Tablet/Desktop: full-bleed creative SVG */}
+      <div
+        className={channelBannerShell(
+          "hidden aspect-[1024/274] bg-[#f0e6da] py-0 md:block",
+        )}
+      >
+        <Image
+          src="/chones/chonescreativechannelbanner.svg"
+          alt="Chones"
+          fill
+          className="object-cover object-center"
+          priority
+          unoptimized
+          sizes="(max-width: 1280px) 100vw, 1280px"
+        />
+
+        {showButton ? (
+          <div
+            className={cn(
+              channelBannerContentClassName,
+              "justify-end pb-4 lg:pb-6",
+            )}
+          >
+            <SongCupGoalButton
+              href={href}
+              label={buttonLabel}
+              className="animate-songcup-pulse hover:animate-none"
+            />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/components/songchain/song-cup/SongCupFeedCompose.tsx
+++ b/components/songchain/song-cup/SongCupFeedCompose.tsx
@@ -35,7 +35,9 @@ export function SongCupFeedCompose({
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [isPickingFile, setIsPickingFile] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
   const { createPost, isPosting, canWrite, needsOrbReauth, promptWriteAccess } =
     useSongchainPost();
@@ -52,13 +54,23 @@ export function SongCupFeedCompose({
     };
   }, [imageFile]);
 
+  // Native file dialog steals focus; keep compose open until dialog closes.
+  useEffect(() => {
+    if (!isPickingFile) return;
+    const onWindowFocus = () => {
+      window.setTimeout(() => setIsPickingFile(false), 300);
+    };
+    window.addEventListener("focus", onWindowFocus);
+    return () => window.removeEventListener("focus", onWindowFocus);
+  }, [isPickingFile]);
+
   if (!feedId) return null;
 
   const hasContent = content.trim().length > 0;
   const hasImage = !!imageFile;
   const canSubmit = hasContent || hasImage;
   const busy = isPosting || isUploadingImage;
-  const showExpanded = focused || hasContent || hasImage;
+  const showExpanded = focused || hasContent || hasImage || isPickingFile;
 
   const clearImage = () => {
     setImageFile(null);
@@ -113,8 +125,17 @@ export function SongCupFeedCompose({
     }
   };
 
+  const openImagePicker = () => {
+    setFocused(true);
+    setIsPickingFile(true);
+    fileInputRef.current?.click();
+  };
+
   return (
-    <div className={cn("relative min-h-[117px] p-4", songCupPanelInset, songCupBorderAccent, "border")}>
+    <div
+      ref={rootRef}
+      className={cn("relative min-h-[117px] p-4", songCupPanelInset, songCupBorderAccent, "border")}
+    >
       <input
         ref={fileInputRef}
         type="file"
@@ -124,6 +145,7 @@ export function SongCupFeedCompose({
         onChange={(e) => {
           handleImagePick(e.target.files?.[0]);
           e.target.value = "";
+          setIsPickingFile(false);
         }}
       />
 
@@ -160,7 +182,10 @@ export function SongCupFeedCompose({
             disabled={busy}
             maxLength={5000}
             autoFocus={focused}
-            onBlur={() => {
+            onBlur={(e) => {
+              if (isPickingFile) return;
+              const next = e.relatedTarget as Node | null;
+              if (rootRef.current?.contains(next)) return;
               if (!hasContent && !hasImage) setFocused(false);
             }}
             className="border-0 bg-transparent p-0 text-sm text-foreground placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-white dark:placeholder:text-white/40"
@@ -188,7 +213,14 @@ export function SongCupFeedCompose({
           )}
 
           {!canWrite ? (
-            <Button type="button" variant="outline" size="sm" onClick={promptWriteAccess} className="w-fit">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={promptWriteAccess}
+              className="w-fit"
+            >
               {needsOrbReauth ? "Sign in again" : "Link Orb to post"}
             </Button>
           ) : (
@@ -198,7 +230,8 @@ export function SongCupFeedCompose({
                 variant="ghost"
                 size="sm"
                 disabled={busy}
-                onClick={() => fileInputRef.current?.click()}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={openImagePicker}
                 className={cn("gap-1.5 px-2", songCupMuted)}
                 aria-label="Attach image"
               >
@@ -209,6 +242,7 @@ export function SongCupFeedCompose({
                 type="button"
                 size="sm"
                 disabled={busy || !canSubmit}
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={() => void handleSubmit()}
                 className="rounded-full bg-gradient-to-br from-[#DC2BB3] to-[#FDBE01] px-5 font-semibold text-black hover:opacity-90 disabled:opacity-50"
               >


### PR DESCRIPTION
## Summary
- Restore the original cream Chones banner on phones only; keep the creative SVG for tablet/desktop
- Keep Song Cup feed compose open when clicking Image so the file picker can open (blur race fix)
- Replace the Edit in Pixels pixel-art icon with Lucide `Clapperboard` on the upload page

## Test plan
- [ ] On `/` and `/discover` at phone width: Chones carousel slide shows cream `chones-banner.png` + cream `#f0e6da` background
- [ ] At tablet/desktop width: Chones slide still shows the creative SVG banner
- [ ] Song Cup feed: open compose via plus → click Image → file picker opens and form stays expanded
- [ ] Cancel file picker: compose stays usable; selecting an image shows preview
- [ ] Upload page: Edit in Pixels button shows Clapperboard icon and still links to Creative Pixels


Made with [Cursor](https://cursor.com)