### PR TITLE
Wire Song Cup / Hack Beta feed auto-refresh after post

### DIFF
--- a/components/songchain/song-cup/SongCupFeedPanel.tsx
+++ b/components/songchain/song-cup/SongCupFeedPanel.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useRef } from "react";
 import { useSongchainGroupMembership } from "@/hooks/useSongchainGroupMembership";
-import { SongchainFeedSection } from "@/components/songchain/SongchainFeedSection";
+import {
+  SongchainFeedSection,
+  type SongchainFeedHandle,
+} from "@/components/songchain/SongchainFeedSection";
 import { SongCupFeedCompose } from "./SongCupFeedCompose";
 import { SongCupFeedMembersRow } from "./SongCupFeedMembersRow";
 import { Loader2 } from "lucide-react";
@@ -38,6 +42,7 @@ export function SongCupFeedPanel({
   clubLogoUrl,
   clubLabel,
 }: SongCupFeedPanelProps) {
+  const feedRef = useRef<SongchainFeedHandle>(null);
   const membership = useSongchainGroupMembership({ groupId });
 
   const joinHref = orbClubUrl ?? SONG_CUP_PLAY_LINKS.club;
@@ -117,7 +122,13 @@ export function SongCupFeedPanel({
 
           {!membership.loading && (
             <>
-              {membership.isMember && <SongCupFeedCompose feedId={feedId} placeholder={placeholder} />}
+              {membership.isMember && (
+                <SongCupFeedCompose
+                  feedId={feedId}
+                  placeholder={placeholder}
+                  onPosted={(created) => feedRef.current?.registerNewPost(created)}
+                />
+              )}
 
               <SongCupFeedMembersRow
                 groupId={groupId}
@@ -127,10 +138,12 @@ export function SongCupFeedPanel({
               />
 
               <SongchainFeedSection
+                ref={feedRef}
                 title={feedTitle}
                 description={feedDescription}
                 feedId={feedId}
                 graphId={graphId}
+                onPostUpdated={() => feedRef.current?.reload()}
                 emptyDescription="Lens custom feeds only show posts published to that feed contract. Existing Orb profile or global posts are not backfilled."
                 layout="grid"
                 hideHeader


### PR DESCRIPTION
## Summary
- Connect `SongCupFeedCompose` `onPosted` to `SongchainFeedSection.registerNewPost` in `SongCupFeedPanel` so new posts appear without a full page refresh
- Wire `onPostUpdated` to reload so reactions/edits stay in sync (same pattern as `SongchainFeedExperience`)
- Fixes Hack Beta and Song Cup together via the shared panel

## Test plan
- [ ] As a club member on `/chones/hack-beta`, submit a text post and confirm a pending card appears, then the indexed post replaces it without refreshing
- [ ] Submit a post with an image attachment and confirm the same auto-refresh behavior
- [ ] Confirm `/songchain/song-cup` feed behaves the same (shared `SongCupFeedPanel`)
- [ ] Confirm reactions still refresh the feed list after update


Made with [Cursor](https://cursor.com)