### PR TITLE
Fix view increments blocked by BotID

### DIFF
--- a/app/api/video-assets/views/increment/[playbackId]/route.ts
+++ b/app/api/video-assets/views/increment/[playbackId]/route.ts
@@ -9,7 +9,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> }
 ) {
-  const rl = await rateLimiters.standard(request);
+  const rl = await rateLimiters.viewIncrement(request);
   if (rl) return rl;
 
   try {

--- a/app/api/video-assets/views/increment/[playbackId]/route.ts
+++ b/app/api/video-assets/views/increment/[playbackId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { createServiceClient } from "@/lib/sdk/supabase/service";
 import { serverLogger } from "@/lib/utils/logger";
 
@@ -9,12 +9,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> }
 ) {
-  const botCheck = await requireHumanOrVerifiedBot(
-    "video-assets.views.increment",
-  );
-  if (!botCheck.allowed) {
-    return botCheck.response;
-  }
+  const rl = await rateLimiters.standard(request);
+  if (rl) return rl;
 
   try {
     const { playbackId } = await params;

--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -155,14 +155,9 @@ export default async function VideoDetailsPage({
               contractAddress={videoAsset?.contract_address ?? null}
               tokenId={videoAsset?.token_id ?? null}
             />
-            {/* Date + views (left) + actions/share (right) */}
+            {/* Views (left) + actions/share (right) */}
             <div className="flex items-center justify-between gap-4 mt-4 flex-wrap">
               <div className="flex items-center gap-3 min-h-4 flex-wrap">
-                {videoAsset?.created_at ? (
-                  <span className="text-sm text-muted-foreground md:text-base">
-                    {new Date(videoAsset.created_at).toLocaleDateString()}
-                  </span>
-                ) : null}
                 {assetData.playbackId && (
                   <VideoViewMetrics
                     playbackId={assetData.playbackId}
@@ -239,6 +234,13 @@ export default async function VideoDetailsPage({
                 </Suspense>
               </div>
             </div>
+            {videoAsset?.created_at ? (
+              <div className="mt-2">
+                <span className="text-sm text-muted-foreground md:text-base">
+                  {new Date(videoAsset.created_at).toLocaleDateString()}
+                </span>
+              </div>
+            ) : null}
             {videoAsset?.description && (
               <div className="mt-4">
                 <div className="prose prose-sm dark:prose-invert max-w-none">

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,20 @@
   }
 }
 
+/*
+ * Phone landscape can exceed Tailwind `md` (768px) width and would switch the
+ * Chones banner to the desktop SVG. Keep the beige mobile layout on coarse-
+ * pointer landscape viewports with a short height (typical phone landscape).
+ */
+@media (orientation: landscape) and (max-height: 600px) and (pointer: coarse) {
+  .chones-banner-mobile {
+    display: block !important;
+  }
+  .chones-banner-desktop {
+    display: none !important;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -241,9 +241,12 @@ export default function VideoDetails({
           `/api/video-assets/views/increment/${encodeURIComponent(asset.playbackId)}`,
           { method: "POST" },
         );
-        let payload: { viewCount?: unknown } | null = null;
+        let payload: { viewCount?: unknown; code?: unknown } | null = null;
         try {
-          payload = (await response.json()) as { viewCount?: unknown };
+          payload = (await response.json()) as {
+            viewCount?: unknown;
+            code?: unknown;
+          };
         } catch {
           payload = null;
         }
@@ -253,6 +256,8 @@ export default function VideoDetails({
           incremented = true;
           const viewCount = Number(payload?.viewCount);
           if (Number.isFinite(viewCount) && viewCount > 0) {
+            // Keep optimistic DB count for this session; do not invalidate Livepeer
+            // metrics (refetch often returns a stale lower total and wipes the bump).
             queryClient.setQueryData<LivepeerViewMetrics>(
               livepeerViewMetricsQueryKey(asset.playbackId),
               (prev) => ({
@@ -264,8 +269,10 @@ export default function VideoDetails({
               }),
             );
           }
-          await queryClient.invalidateQueries({
-            queryKey: livepeerViewMetricsQueryKey(asset.playbackId),
+        } else {
+          console.warn("Failed to increment views:", {
+            status: response.status,
+            code: payload?.code ?? null,
           });
         }
       } catch (err) {

--- a/components/chones/ChonesBanner.tsx
+++ b/components/chones/ChonesBanner.tsx
@@ -23,8 +23,12 @@ export function ChonesBanner({
 }: ChonesBannerProps) {
   return (
     <div className={cn("h-full w-full", className)}>
-      {/* Mobile: original cream logo — scales better on phones */}
-      <div className={channelBannerShell("bg-[#f0e6da] md:hidden")}>
+      {/* Mobile: original cream logo — scales better on phones (incl. landscape) */}
+      <div
+        className={channelBannerShell(
+          "chones-banner-mobile bg-[#f0e6da] md:hidden",
+        )}
+      >
         <div className={channelBannerContentClassName}>
           <div className="relative aspect-[1024/173] w-[min(78vw,720px)] max-w-full">
             <Image
@@ -58,7 +62,7 @@ export function ChonesBanner({
       {/* Tablet/Desktop: full-bleed creative SVG */}
       <div
         className={channelBannerShell(
-          "hidden aspect-[1024/274] bg-[#f0e6da] py-0 md:block",
+          "chones-banner-desktop hidden aspect-[1024/274] bg-[#f0e6da] py-0 md:block",
         )}
       >
         <Image

--- a/components/chones/hack-beta/HackBetaPageClient.tsx
+++ b/components/chones/hack-beta/HackBetaPageClient.tsx
@@ -5,6 +5,7 @@ import { SongchainOrbConnect } from "@/components/songchain/SongchainOrbConnect"
 import { SongCupFeedPanel } from "@/components/songchain/song-cup/SongCupFeedPanel";
 import { ChonesXFollowStrip } from "@/components/chones/ChonesXFollowStrip";
 import { HackBetaHero } from "./HackBetaHero";
+import { HackBetaPlaylistEmbed } from "./HackBetaPlaylistEmbed";
 import { HackBetaSubmitPanel } from "./HackBetaSubmitPanel";
 import { HackBetaGallery } from "./HackBetaGallery";
 import { HackBetaMixtapeSection } from "./HackBetaMixtapeSection";
@@ -45,6 +46,7 @@ export function HackBetaPageClient({ config }: HackBetaPageClientProps) {
       </div>
 
       <div className="mx-auto max-w-7xl space-y-8 px-4 pb-12 sm:px-6">
+        <HackBetaPlaylistEmbed />
         <ChonesXFollowStrip />
         <SongchainOrbConnect />
         <div id="hack-beta-submit" className="scroll-mt-8">

--- a/components/chones/hack-beta/HackBetaPlaylistEmbed.tsx
+++ b/components/chones/hack-beta/HackBetaPlaylistEmbed.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+const CHONES_PLAYLIST_URL = "https://air.creativeplatform.xyz/app/s/chones";
+
+type HackBetaPlaylistEmbedProps = {
+  className?: string;
+};
+
+export function HackBetaPlaylistEmbed({ className }: HackBetaPlaylistEmbedProps) {
+  return (
+    <section
+      aria-labelledby="hack-beta-playlist-heading"
+      className={cn("space-y-3", className)}
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2
+          id="hack-beta-playlist-heading"
+          className="text-lg font-semibold text-foreground"
+        >
+          After Party Playlist
+        </h2>
+        <a
+          href={CHONES_PLAYLIST_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Open playlist
+        </a>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-border bg-background">
+        <iframe
+          title="Chones After Party Playlist"
+          src={CHONES_PLAYLIST_URL}
+          className="min-h-[480px] w-full"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/home-page/HeroSection.tsx
+++ b/components/home-page/HeroSection.tsx
@@ -32,6 +32,8 @@ const PlayIcon = (props: React.SVGProps<SVGSVGElement>) => {
 
 const HeroSection: React.FC = () => {
   const router = useRouter();
+  /** Set to true to restore the homepage Watch Demo CTA. */
+  const SHOW_WATCH_DEMO = false;
   const [src, setSrc] = useState<Src[] | null>(null);
   const [heroPlaybackId, setHeroPlaybackId] = useState<string | undefined>(
     undefined,
@@ -117,18 +119,20 @@ const HeroSection: React.FC = () => {
             <span className="text-orange-600">{HERO_NAME.bottom}</span>
           </h1>
           <p className="text-gray-500">{HERO_DESCRIPTION}</p>
-          <div className="flex flex-col items-center space-y-4 sm:flex-row sm:justify-center sm:space-x-6 sm:space-y-0 md:justify-start">
-            <button
-              className={
-                "flex items-center space-x-2 rounded-full bg-pink-600 px-6 py-2 text-lg font-normal text-white " +
-                "transition duration-200 hover:bg-pink-700 lg:py-3"
-              }
-              onClick={handleWatchDemo}
-            >
-              <PlayIcon className="h-5 w-5" />
-              <span>{HERO_BUTTONS.secondary.text}</span>
-            </button>
-          </div>
+          {SHOW_WATCH_DEMO ? (
+            <div className="flex flex-col items-center space-y-4 sm:flex-row sm:justify-center sm:space-x-6 sm:space-y-0 md:justify-start">
+              <button
+                className={
+                  "flex items-center space-x-2 rounded-full bg-pink-600 px-6 py-2 text-lg font-normal text-white " +
+                  "transition duration-200 hover:bg-pink-700 lg:py-3"
+                }
+                onClick={handleWatchDemo}
+              >
+                <PlayIcon className="h-5 w-5" />
+                <span>{HERO_BUTTONS.secondary.text}</span>
+              </button>
+            </div>
+          ) : null}
         </div>
         <div className="w-full md:ml-8 md:flex-1">
           <div className="relative w-full overflow-hidden rounded-2xl bg-black shadow-2xl">

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -64,7 +64,7 @@ if (!botIdGlobal.__crtvBotIdInit) {
       botIdDeepAnalysisRoute('/api/unlock-nft', 'POST'),
       botIdDeepAnalysisRoute('/api/video-assets/sync-views/*', 'POST'),
       // views/increment omitted: Deep Analysis false-positives blocked legitimate play views;
-      // route uses rateLimiters.standard instead.
+      // route uses rateLimiters.viewIncrement instead.
       botIdDeepAnalysisRoute('/api/video-assets/*/regenerate-thumbnail', 'POST'),
       botIdDeepAnalysisRoute('/api/coinbase/session-token', 'POST'),
       botIdDeepAnalysisRoute('/api/metokens/*/transactions', 'POST'),

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -63,7 +63,8 @@ if (!botIdGlobal.__crtvBotIdInit) {
       botIdDeepAnalysisRoute('/api/ai/generate-thumbnail', 'POST'),
       botIdDeepAnalysisRoute('/api/unlock-nft', 'POST'),
       botIdDeepAnalysisRoute('/api/video-assets/sync-views/*', 'POST'),
-      botIdDeepAnalysisRoute('/api/video-assets/views/increment/*', 'POST'),
+      // views/increment omitted: Deep Analysis false-positives blocked legitimate play views;
+      // route uses rateLimiters.standard instead.
       botIdDeepAnalysisRoute('/api/video-assets/*/regenerate-thumbnail', 'POST'),
       botIdDeepAnalysisRoute('/api/coinbase/session-token', 'POST'),
       botIdDeepAnalysisRoute('/api/metokens/*/transactions', 'POST'),

--- a/lib/middleware/rateLimit.ts
+++ b/lib/middleware/rateLimit.ts
@@ -205,6 +205,18 @@ export const rateLimiters = {
       errorMessage: 'Too many playback info requests. Please try again shortly.',
     }),
 
+  /**
+   * View increments: namespaced by route so shared `standard` traffic cannot
+   * exhaust this bucket (false 429s on legitimate plays).
+   */
+  viewIncrement: (request: NextRequest) =>
+    rateLimit(request, {
+      maxRequests: 30,
+      windowMs: 60 * 1000,
+      keyGenerator: (req) => `view-increment:${getClientIp(req)}`,
+      errorMessage: 'Too many view increments. Please try again shortly.',
+    }),
+
   /** API key-based rate limiter: 100 requests per minute */
   apiKey: (request: NextRequest, apiKey: string) =>
     rateLimit(request, {


### PR DESCRIPTION
## Summary
- Exempt `/api/video-assets/views/increment/*` from BotID Deep Analysis and use rate limiting instead, so legitimate plays can update `views_count`
- Keep optimistic view counts after a successful increment (stop Livepeer refetch from wiping the bump) and log non-OK increment responses
- Video details layout: views + actions → date → description; keep beige Chones mobile banner in phone landscape; hide homepage Watch Demo behind a flag; embed After Party Playlist on Hack Beta

## Test plan
- [ ] Connected wallet → open a video detail page → play → Network tab shows `POST .../views/increment/...` **200** (not 403)
- [ ] View count bumps once per session play and stays bumped
- [ ] Video details shows views/actions on first row, date alone below, description under that
- [ ] Phone portrait + landscape: Chones banner stays beige mobile layout
- [ ] Homepage hero no longer shows Watch Demo
- [ ] `/chones/hack-beta` shows embedded After Party Playlist under the hero and play works (or fallback “Open playlist” link)


Made with [Cursor](https://cursor.com)