### PR TITLE
Fix view accrual and video detail layout UX

### DIFF
--- a/app/api/video-assets/views/increment/[playbackId]/route.ts
+++ b/app/api/video-assets/views/increment/[playbackId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireHumanOrVerifiedBot } from "@/lib/middleware/botIdGuard";
 import { createServiceClient } from "@/lib/sdk/supabase/service";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { serverLogger } from "@/lib/utils/logger";
 
 export const dynamic = "force-dynamic";
@@ -9,12 +9,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ playbackId: string }> }
 ) {
-  const botCheck = await requireHumanOrVerifiedBot(
-    "video-assets.views.increment",
-  );
-  if (!botCheck.allowed) {
-    return botCheck.response;
-  }
+  // BotID removed: Deep Analysis false-positives blocked legitimate play increments.
+  const rl = await rateLimiters.generous(request);
+  if (rl) return rl;
 
   try {
     const { playbackId } = await params;

--- a/app/discover/[id]/page.tsx
+++ b/app/discover/[id]/page.tsx
@@ -155,21 +155,8 @@ export default async function VideoDetailsPage({
               contractAddress={videoAsset?.contract_address ?? null}
               tokenId={videoAsset?.token_id ?? null}
             />
-            {/* Date + views (left) + actions/share (right) */}
-            <div className="flex items-center justify-between gap-4 mt-4 flex-wrap">
-              <div className="flex items-center gap-3 min-h-4 flex-wrap">
-                {videoAsset?.created_at ? (
-                  <span className="text-sm text-muted-foreground md:text-base">
-                    {new Date(videoAsset.created_at).toLocaleDateString()}
-                  </span>
-                ) : null}
-                {assetData.playbackId && (
-                  <VideoViewMetrics
-                    playbackId={assetData.playbackId}
-                    fallbackViews={videoAsset?.views_count ?? 0}
-                  />
-                )}
-              </div>
+            {/* Actions (right-aligned) → views → date, each on its own row */}
+            <div className="mt-4 space-y-2">
               <div className="flex items-center gap-2 flex-wrap justify-end ml-auto">
                 {creatorAddress && (
                   <>
@@ -238,6 +225,21 @@ export default async function VideoDetailsPage({
                   />
                 </Suspense>
               </div>
+              {assetData.playbackId && (
+                <div className="min-h-4">
+                  <VideoViewMetrics
+                    playbackId={assetData.playbackId}
+                    fallbackViews={videoAsset?.views_count ?? 0}
+                  />
+                </div>
+              )}
+              {videoAsset?.created_at ? (
+                <div>
+                  <span className="text-sm text-muted-foreground md:text-base">
+                    {new Date(videoAsset.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              ) : null}
             </div>
             {videoAsset?.description && (
               <div className="mt-4">

--- a/components/Player/ViewsComponent.tsx
+++ b/components/Player/ViewsComponent.tsx
@@ -15,8 +15,7 @@ export const ViewsComponent: React.FC<ViewsComponentProps> = ({
   playbackId,
   fallbackViews = 0,
 }) => {
-  const { totalViews, viewMetrics, loading, error } =
-    useLivepeerViewMetrics(playbackId);
+  const { totalViews, loading } = useLivepeerViewMetrics(playbackId);
 
   if (loading) {
     return (
@@ -31,12 +30,8 @@ export const ViewsComponent: React.FC<ViewsComponentProps> = ({
   const livepeer = Math.max(0, Number(totalViews) || 0);
   const displayViews = Math.max(livepeer, fallback);
 
-  // Prefer Livepeer metrics or a DB fallback — never blank when we have a number.
-  if (error && !viewMetrics && displayViews <= 0) {
-    return null;
-  }
-
-  if (!viewMetrics && displayViews <= 0) {
+  // Never show "0 views", even when Livepeer returns a zeroed metrics object.
+  if (displayViews <= 0) {
     return null;
   }
 

--- a/components/Player/view-metrics-ui.test.tsx
+++ b/components/Player/view-metrics-ui.test.tsx
@@ -141,7 +141,7 @@ describe("restored view count UI", () => {
     expect(html.toLowerCase()).toContain("views");
   });
 
-  it("VideoViewMetrics shows 0 views when both Livepeer and fallback are 0", () => {
+  it("VideoViewMetrics hides when both Livepeer and fallback are 0", () => {
     vi.mocked(useLivepeerViewMetrics).mockReturnValue({
       viewMetrics: {
         playbackId: "p2",
@@ -158,8 +158,27 @@ describe("restored view count UI", () => {
     const html = renderToStaticMarkup(
       React.createElement(VideoViewMetrics, { playbackId: "p2" }),
     );
-    expect(html).toContain("0");
-    expect(html.toLowerCase()).toContain("views");
+    expect(html).toBe("");
+  });
+
+  it("ViewsComponent hides when Livepeer metrics exist but total is 0", () => {
+    vi.mocked(useLivepeerViewMetrics).mockReturnValue({
+      viewMetrics: {
+        playbackId: "p1",
+        viewCount: 0,
+        playtimeMins: 3,
+        legacyViewCount: 0,
+        totalViews: 0,
+      },
+      totalViews: 0,
+      loading: false,
+      error: null,
+    });
+
+    const html = renderToStaticMarkup(
+      React.createElement(ViewsComponent, { playbackId: "p1" }),
+    );
+    expect(html).toBe("");
   });
 
   it("RealtimeViewsComponent renders concurrent watching count", () => {

--- a/components/Videos/VideoViewMetrics.tsx
+++ b/components/Videos/VideoViewMetrics.tsx
@@ -14,7 +14,7 @@ const VideoViewMetrics: React.FC<VideoViewMetricsProps> = ({
   playbackId,
   fallbackViews = 0,
 }) => {
-  const { totalViews, loading, error } = useLivepeerViewMetrics(playbackId);
+  const { totalViews, loading } = useLivepeerViewMetrics(playbackId);
 
   if (loading) return <Skeleton className="h-4 w-16" />;
 
@@ -22,8 +22,8 @@ const VideoViewMetrics: React.FC<VideoViewMetricsProps> = ({
   const livepeer = Math.max(0, Number(totalViews) || 0);
   const displayViews = Math.max(livepeer, fallback);
 
-  // Hard failure with nothing to show — stay blank rather than flash "0 views"
-  if (error && displayViews <= 0) return null;
+  // Never show "0 views" — blank until we have a real count.
+  if (displayViews <= 0) return null;
 
   return (
     <h3 className="text-sm font-medium text-muted-foreground md:text-base">

--- a/components/chones/hack-beta/HackBetaPageClient.tsx
+++ b/components/chones/hack-beta/HackBetaPageClient.tsx
@@ -50,8 +50,8 @@ export function HackBetaPageClient({ config }: HackBetaPageClientProps) {
         <div id="hack-beta-submit" className="scroll-mt-8">
           <HackBetaSubmitPanel />
         </div>
-        <HackBetaMixtapeSection />
         <HackBetaGallery />
+        <HackBetaMixtapeSection />
 
         <div id="hack-beta-feed" className="scroll-mt-8">
           {config.enabled ? (

--- a/context/context.ts
+++ b/context/context.ts
@@ -35,7 +35,7 @@ export const HERO_NAME = {
  */
 export const HERO_DESCRIPTION =
   `${SITE_NAME} is a decentralized live-streaming platform that puts you in control of your content and earnings. ` +
-  `Get paid 100% of streaming revenue, have access to your own token, and monetize your content into NFTs.`;
+  `Get paid 100% of streaming revenue, have access to your own token, and monetize your content.`;
 
 /**
  * Primary call to action buttons on the hero section

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -63,7 +63,7 @@ if (!botIdGlobal.__crtvBotIdInit) {
       botIdDeepAnalysisRoute('/api/ai/generate-thumbnail', 'POST'),
       botIdDeepAnalysisRoute('/api/unlock-nft', 'POST'),
       botIdDeepAnalysisRoute('/api/video-assets/sync-views/*', 'POST'),
-      botIdDeepAnalysisRoute('/api/video-assets/views/increment/*', 'POST'),
+      // views/increment omitted: BotID Deep Analysis false-positives block legitimate play increments.
       botIdDeepAnalysisRoute('/api/video-assets/*/regenerate-thumbnail', 'POST'),
       botIdDeepAnalysisRoute('/api/coinbase/session-token', 'POST'),
       botIdDeepAnalysisRoute('/api/metokens/*/transactions', 'POST'),


### PR DESCRIPTION
## Summary
- Unblock play-triggered view increments by removing BotID Deep Analysis (false positives were blocking accrual) and using generous rate limiting instead
- Hide view-count UI when the displayed count is zero to avoid a bad empty-state UX
- Stack discover video detail metadata as actions → views → date on separate rows, and move the Hack Beta mixtape section below the demo gallery

## Test plan
- [ ] Play a video while connected; Network shows `POST /api/video-assets/views/increment/...` → `200` with rising `viewCount`
- [ ] Refresh the video detail page and confirm views appear only when count > 0 (zero stays hidden)
- [ ] Confirm detail page order under the player: action buttons (right-aligned), then views, then date
- [ ] On `/chones/hack-beta`, confirm Featured mixtape sits below the Demo gallery
- [ ] Run `pnpm exec vitest run components/Player/view-metrics-ui.test.tsx`


Made with [Cursor](https://cursor.com)