### PR TITLE
feat: allow brand memberships to create prediction markets

### DIFF
--- a/components/predictions/CreatePrediction.tsx
+++ b/components/predictions/CreatePrediction.tsx
@@ -547,7 +547,7 @@ function CreatePrediction({
                       <span>Investor membership: unlimited prediction markets. </span>
                     )}
                     {quota.premiumTier === "brand" && (
-                      <span>Brand membership does not include prediction creation. </span>
+                      <span>Brand membership: unlimited prediction markets. </span>
                     )}
                     {!quota.premiumTier && (
                       <span>Unlimited prediction markets for your account. </span>
@@ -564,7 +564,7 @@ function CreatePrediction({
                           href="/"
                           className="underline font-medium text-foreground"
                         >
-                          Upgrade to Investor
+                          Upgrade to Investor or Brand
                         </Link>{" "}
                         for unlimited markets.
                       </span>
@@ -574,7 +574,7 @@ function CreatePrediction({
                           href="/"
                           className="underline font-medium text-foreground"
                         >
-                          Upgrade to Investor
+                          Upgrade to Investor or Brand
                         </Link>{" "}
                         for unlimited markets.
                       </span>

--- a/lib/hooks/predictions/usePredictionAccess.ts
+++ b/lib/hooks/predictions/usePredictionAccess.ts
@@ -10,7 +10,7 @@ import { useMembershipVerification } from "@/lib/hooks/unlock/useMembershipVerif
 import { useWalletStatus } from "@/lib/hooks/accountkit/useWalletStatus";
 
 export const PREDICTION_BLOCK_MESSAGE =
-  "Only non-members and investor members can create or bet on predictions — this keeps markets fair for fans.";
+  "Creator memberships cannot create or bet on predictions — this keeps markets fair for fans.";
 
 export function usePredictionAccess() {
   const { isConnected, walletAddress, smartAccountAddress } = useWalletStatus();
@@ -21,7 +21,8 @@ export function usePredictionAccess() {
   const isAdmin = isPlatformAdmin(address);
   const isCreatorTier = hasValidCreatorPass(membershipDetails);
   const isBrandTier = hasValidBrandPass(membershipDetails);
-  const isBlockedTier = isCreatorTier || isBrandTier;
+  // Only Creator tier is blocked from prediction create/bet.
+  const isBlockedTier = isCreatorTier;
 
   const canCreatePrediction = useMemo(() => {
     if (!isConnected || !address) return false;


### PR DESCRIPTION
Allows brand memberships to create (and bet on) prediction markets alongside investor memberships.

Changes:
- lib/hooks/predictions/usePredictionAccess.ts: only creator tier is blocked from prediction create/bet; brand tier is no longer blocked. Updated block message accordingly.
- components/predictions/CreatePrediction.tsx: brand quota now shows "Brand membership: unlimited prediction markets" and free users are prompted to "Upgrade to Investor or Brand".

Backend (app/api/predictions/quota and app/api/predictions/record) already recognizes brand passes as unlimited and only blocks creator passes, so no API changes were needed.

Prediction API tests pass locally.