### PR TITLE
fix: remove pink background from tip heart button

### DIFF
--- a/components/heartbit/HeartBitTipButton.tsx
+++ b/components/heartbit/HeartBitTipButton.tsx
@@ -547,11 +547,10 @@ export function HeartBitTipButton({
         <Button
           type="button"
           size="icon"
-          variant={holding || myTipTotal != null ? "default" : "secondary"}
+          variant="secondary"
           className={cn(
             "h-10 w-10 rounded-full select-none touch-none",
-            holding && "bg-pink-600 hover:bg-pink-600 scale-110",
-            myTipTotal != null && !holding && "bg-pink-600 hover:bg-pink-600"
+            holding && "scale-110",
           )}
           disabled={isTipping || loadingHistory}
           onPointerDown={(e) => {


### PR DESCRIPTION
Removes the pink circular background behind the heart tip button while keeping the filled heart and tip summary text.

Changes:
- `components/heartbit/HeartBitTipButton.tsx`: the button now always uses `variant="secondary"` and no longer applies `bg-pink-600` when holding or after the user has tipped.
- The heart still fills to 100% after tipping, and the `${amount} · last {seconds}s` text below still appears.

Typecheck passes (only pre-existing test-file errors remain).