### PR TITLE
fix(livestream): force HLS playback on watch page and make stats bar responsive

### DIFF
--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -482,20 +482,21 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                     playbackId={playbackId}
                     title={videoTitle || streamData?.name || "Live Stream"}
                     jwt={jwt}
+                    lowLatency={false}
                   />
                 </div>
                 {/* Live Stream Viewership Stats */}
-                <div className="flex items-center justify-between p-4 rounded-xl bg-slate-900/60 backdrop-blur border border-slate-800">
-                  <div className="flex flex-col">
-                    <h1 className="text-xl font-bold text-white truncate max-w-lg">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 rounded-xl bg-slate-900/60 backdrop-blur border border-slate-800">
+                  <div className="min-w-0 flex-1">
+                    <h1 className="text-lg sm:text-xl font-bold text-white truncate">
                       {videoTitle || streamData?.name || "Live Stream"}
                     </h1>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <p className="text-sm text-gray-400 mt-0.5">
                       Broadcasting Live
                     </p>
                   </div>
                   {/* Total + realtime concurrent viewers */}
-                  <div className="flex items-center gap-4">
+                  <div className="flex flex-wrap items-center gap-3 shrink-0">
                     {playbackId && <ViewsComponent playbackId={playbackId} />}
                     {playbackId && <RealtimeViewsComponent playbackId={playbackId} />}
                   </div>

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -40,8 +40,9 @@ export function Player(props: {
   jwt?: string;
   onPlay?: () => void;
   autoPlay?: boolean;
+  lowLatency?: boolean;
 }) {
-  const { src, title, playbackId, assetId, jwt, onPlay, autoPlay = true } = props;
+  const { src, title, playbackId, assetId, jwt, onPlay, autoPlay = true, lowLatency = true } = props;
 
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
@@ -138,7 +139,7 @@ export function Player(props: {
       autoPlay={autoPlay}
       volume={0}
       aspectRatio={16 / 9}
-      lowLatency={true} // Force low latency for livestream
+      lowLatency={lowLatency} // default low latency for livestream; allow override
     >
       <LivepeerPlayer.Container
         ref={containerRef}


### PR DESCRIPTION
### Fixes
- Mobile viewers on the live stream watch page were stuck on the player loading spinner because the player defaulted to low-latency WebRTC, which frequently fails on mobile Safari/iOS.
- The live stats bar pushed the view counter off-screen when the stream title was long.

### Changes
- : add optional  prop (defaults to ).
- : pass  on the viewer page to use HLS and improve mobile playback reliability.
- Make the live stats bar responsive: long titles truncate and the view counter stays visible by stacking vertically on mobile.