### PR TITLE
fix(livestream): detect ended streams, cap HLS timeout, reposition clips

### DIFF
--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -364,6 +364,7 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
 
   // While live (or gated), refresh stream metadata until Lens chat is activated
   // so viewers who joined early pick up lens_live_post_id without a full reload.
+  // Also use this interval to detect when a live stream has gone idle.
   useInterval(
     useCallback(async () => {
       if (!playbackId) return;
@@ -372,14 +373,39 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         if (streamRecord) {
           setStreamData(streamRecord as import("@/services/streams").Stream);
         }
+
+        // If Livepeer no longer reports sources, the stream has ended.
+        if (status.kind === "live" || status.kind === "metoken-gated") {
+          const sources = await getDetailPlaybackSource(playbackId);
+          if (!sources || sources.length === 0) {
+            setStatus({ kind: "offline-temporary", attempts: 0 });
+          }
+        }
       } catch (err) {
         logger.warn("Stream metadata refresh failed:", err);
       }
-    }, [playbackId]),
+    }, [playbackId, status.kind]),
     (status.kind === "live" || status.kind === "metoken-gated") &&
       !streamData?.lens_live_post_id
       ? 15000
       : null
+  );
+
+  // Always poll for live-source health while we think the stream is live,
+  // even after Lens chat is already active.
+  useInterval(
+    useCallback(async () => {
+      if (!playbackId) return;
+      try {
+        const sources = await getDetailPlaybackSource(playbackId);
+        if (!sources || sources.length === 0) {
+          setStatus({ kind: "offline-temporary", attempts: 0 });
+        }
+      } catch (err) {
+        logger.warn("Live source health check failed:", err);
+      }
+    }, [playbackId]),
+    status.kind === "live" || status.kind === "metoken-gated" ? 15000 : null
   );
 
   // Generate a consistent sessionId based on playbackId so viewers share the same chat session.
@@ -483,6 +509,10 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                     title={videoTitle || streamData?.name || "Live Stream"}
                     jwt={jwt}
                     lowLatency={false}
+                    onStalled={() => {
+                      // Stream went idle after we entered live state.
+                      setStatus({ kind: "offline-temporary", attempts: 0 });
+                    }}
                   />
                 </div>
                 {/* Live Stream Viewership Stats */}
@@ -501,6 +531,19 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                     {playbackId && <RealtimeViewsComponent playbackId={playbackId} />}
                   </div>
                 </div>
+
+                {/* Clip Creator - placed directly under the live stats bar */}
+                {playbackId && sessionId && (
+                  <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                    <ClipCreator
+                      playbackId={playbackId}
+                      sessionId={sessionId}
+                      allowClipping={streamData?.allow_clipping ?? true}
+                      parentStoryIpId={streamData?.story_ip_id ?? storyIpId ?? null}
+                      parentCommercialRevShare={streamData?.story_commercial_rev_share ?? null}
+                    />
+                  </div>
+                )}
               </div>
             )}
 
@@ -613,19 +656,6 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
             )}
           </div>
         </div>
-
-        {/* Clip Creator Section - Below video and chat for viewers */}
-        {playbackId && sessionId && (
-          <div className="mt-6">
-            <ClipCreator
-              playbackId={playbackId}
-              sessionId={sessionId}
-              allowClipping={streamData?.allow_clipping ?? true}
-              parentStoryIpId={streamData?.story_ip_id ?? storyIpId ?? null}
-              parentCommercialRevShare={streamData?.story_commercial_rev_share ?? null}
-            />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -32,7 +32,7 @@ export const PlayerLoading: React.FC<{ title: string }> = ({ title }) => {
   );
 };
 
-export function Player(props: {
+interface PlayerProps {
   src: Src[] | null;
   title: string;
   playbackId?: string;
@@ -41,8 +41,12 @@ export function Player(props: {
   onPlay?: () => void;
   autoPlay?: boolean;
   lowLatency?: boolean;
-}) {
-  const { src, title, playbackId, assetId, jwt, onPlay, autoPlay = true, lowLatency = true } = props;
+  /** Called when the player has been trying to load too long or the stream goes offline. */
+  onStalled?: () => void;
+}
+
+export function Player(props: PlayerProps) {
+  const { src, title, playbackId, assetId, jwt, onPlay, onStalled, autoPlay = true, lowLatency = true } = props;
 
   const [controlsVisible, setControlsVisible] = useState(true);
   const fadeTimeoutRef = useRef<NodeJS.Timeout>();
@@ -50,6 +54,23 @@ export function Player(props: {
   const { currentPlayingId, setCurrentPlayingId } = useVideo();
   const playerId = useRef(Math.random().toString(36).substring(7)).current;
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const stalledTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Cap livestream manifest loading at 10s and surface stalls to the parent.
+  useEffect(() => {
+    if (!onStalled) return;
+    const timer = setTimeout(() => {
+      onStalled();
+    }, 10_000);
+    stalledTimerRef.current = timer;
+
+    return () => {
+      if (stalledTimerRef.current) {
+        clearTimeout(stalledTimerRef.current);
+        stalledTimerRef.current = null;
+      }
+    };
+  }, [src, onStalled]);
 
   useEffect(() => {
     const video = containerRef.current?.querySelector("video");
@@ -153,6 +174,13 @@ export function Player(props: {
           className="h-full w-full"
           playsInline
           controls={false}
+          hlsConfig={{
+            manifestLoadingTimeOut: 10_000,
+            manifestLoadingMaxRetry: 2,
+            manifestLoadingRetryDelay: 1_000,
+            levelLoadingTimeOut: 10_000,
+            fragLoadingTimeOut: 10_000,
+          }}
         />
 
         <CreativeBrandOverlay />


### PR DESCRIPTION
### What this fixes
- The HLS manifest request was hanging for ~20s and then being aborted when a live stream had already gone idle.
- The clip creator was sitting at the very bottom of the watch page.

### Changes
- `app/watch/[playbackId]/WatchClient.tsx`:
  * Moved `<ClipCreator>` directly under the broadcast title/views bar.
  * Added a 15s playback-source health check while the viewer is in the `live` or `metoken-gated` state.
  * If Livepeer stops returning sources, the UI now transitions to the offline/ended state instead of spinning forever.
- `components/Player/Player.tsx`:
  * Added `hlsConfig` timeouts (`manifestLoadingTimeOut`, `levelLoadingTimeOut`, `fragLoadingTimeOut` = 10s) to fail fast.
  * Added `onStalled` callback that fires after 10s of no playback, so the parent can switch to offline UI.

### Why PR #289 wasn't enough
Forcing HLS instead of WebRTC was a good safeguard, but the root issue here was that the watch page entered the `live` state and never re-checked whether the stream was still active. When the broadcaster's phone ended the stream, the player kept trying to fetch an idle HLS manifest until the browser aborted it.

### Test notes
- Start a stream, open the watch page on PC, then stop the broadcaster.
- The watch page should switch to "Stream is Offline" within ~15s instead of hanging for 20s+.
- The ClipCreator should render directly under the title/views bar while live.