### PR TITLE
fix(livestream): remove x402/BotID gates from playback APIs

### DIFF
--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -2,22 +2,24 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
 import { isLivepeerConfigured, LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
 import { serverLogger } from '@/lib/utils/logger';
-import {
-  platformApiOptionsResponse,
-  requirePlatformApiAccess,
-} from '@/lib/middleware/platformApiAccess';
+import { rateLimiters } from '@/lib/middleware/rateLimit';
 
 const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
 
 export async function OPTIONS() {
-  return platformApiOptionsResponse();
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
 }
 
 export async function GET(request: NextRequest) {
-  const access = await requirePlatformApiAccess(request, { resource: 'playback.info' });
-  if (!access.allowed) {
-    return access.response;
-  }
+  const rl = await rateLimiters.playbackInfo(request);
+  if (rl) return rl;
 
   try {
     if (!isLivepeerConfigured()) {

--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -1,6 +1,5 @@
 import { signAccessJwt } from "@livepeer/core/crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
 import { getStreamByPlaybackId } from "@/services/streams";
 import {
@@ -14,10 +13,6 @@ import {
 import { resolveVerifiedViewerAddresses } from "@/lib/utils/linked-identity";
 
 export async function POST(req: NextRequest) {
-  const verification = await checkBotIdDeep();
-  if (verification.isBot) {
-    return NextResponse.json({ error: "Access denied" }, { status: 403 });
-  }
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 


### PR DESCRIPTION
### What this fixes
Livestream playback on `tv.creativeplatform.xyz` was failing because two APIs required by the watch page were gated:

- `/api/livepeer/playback-info` returned **402 Payment Required** from the x402 middleware.
- `/api/livepeer/sign-jwt` returned **403 Access denied** from BotID deep analysis.

Those gates work for external API consumers, but first-party browser viewers need to call these APIs to fetch the HLS source and the signed JWT.

### Changes
- `/api/livepeer/playback-info`:
  * Removed `requirePlatformApiAccess` / x402 gating.
  * Uses the existing `rateLimiters.playbackInfo` (100 req/min).
  * Adds simple CORS headers to `OPTIONS`.
- `/api/livepeer/sign-jwt`:
  * Removed `checkBotIdDeep` bot guard.
  * Keeps the existing `rateLimiters.standard` (10 req/min).
  * MeToken gate logic and wallet-auth flow remain unchanged.

### Security note
Playback is still protected by Livepeer's signed-JWT playback policy. This change just lets first-party viewers *request* the source + token without paying per-request or passing a bot challenge.