### PR TITLE
refactor(livestream): separate internal viewer playback APIs from public platform APIs

### DIFF
--- a/app/api/internal/playback-info/route.ts
+++ b/app/api/internal/playback-info/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rateLimiters } from '@/lib/middleware/rateLimit';
+import { handlePlaybackInfo } from '@/lib/livepeer/playback-info-handler';
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}
+
+/**
+ * Internal, first-party playback info endpoint used by the in-app video player.
+ * Not gated by Platform API / x402 payments — only rate-limited.
+ * External consumers should use /api/livepeer/playback-info.
+ */
+export async function GET(request: NextRequest) {
+  const rl = await rateLimiters.playbackInfo(request);
+  if (rl) return rl;
+
+  return handlePlaybackInfo(request);
+}

--- a/app/api/internal/sign-jwt/route.ts
+++ b/app/api/internal/sign-jwt/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rateLimiters } from '@/lib/middleware/rateLimit';
+import { handleSignJwt } from '@/lib/livepeer/sign-jwt-handler';
+
+/**
+ * Internal, first-party signed-JWT endpoint used by the in-app video player.
+ * Not gated by BotID deep analysis — only rate-limited.
+ * External consumers should use /api/livepeer/sign-jwt.
+ */
+export async function POST(req: NextRequest) {
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  return handleSignJwt(req);
+}

--- a/app/api/livepeer/playback-info/route.ts
+++ b/app/api/livepeer/playback-info/route.ts
@@ -1,109 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
-import { isLivepeerConfigured, LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
-import { serverLogger } from '@/lib/utils/logger';
-import { rateLimiters } from '@/lib/middleware/rateLimit';
-
-const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
+import {
+  platformApiOptionsResponse,
+  requirePlatformApiAccess,
+} from '@/lib/middleware/platformApiAccess';
+import { handlePlaybackInfo } from '@/lib/livepeer/playback-info-handler';
 
 export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    },
-  });
+  return platformApiOptionsResponse();
 }
 
+/**
+ * Public Platform API route for playback info.
+ * Requires an API key or x402 payment. First-party app pages should call
+ * /api/internal/playback-info instead.
+ */
 export async function GET(request: NextRequest) {
-  const rl = await rateLimiters.playbackInfo(request);
-  if (rl) return rl;
-
-  try {
-    if (!isLivepeerConfigured()) {
-      return NextResponse.json(
-        { error: 'Livepeer playback is not configured on this deployment', code: LIVEPEER_NOT_CONFIGURED },
-        { status: 503 },
-      );
-    }
-
-    const { searchParams } = new URL(request.url);
-    const playbackId = searchParams.get('playbackId');
-
-    if (!playbackId) {
-      return NextResponse.json(
-        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
-        { status: 400 },
-      );
-    }
-
-    if (ethereumAddressRegex.test(playbackId)) {
-      return NextResponse.json(
-        {
-          error:
-            'Invalid playback ID format. Expected Livepeer playback ID, received Ethereum address.',
-          code: 'INVALID_PLAYBACK_ID',
-        },
-        { status: 400 },
-      );
-    }
-
-    const client = getFullLivepeer();
-    if (!client) {
-      return NextResponse.json(
-        {
-          error: 'Livepeer is not configured',
-          code: LIVEPEER_NOT_CONFIGURED,
-        },
-        { status: 503 },
-      );
-    }
-
-    const response = await client.playback.get(playbackId);
-
-    if (response.error) {
-      return NextResponse.json(
-        {
-          error: 'Playback info not found',
-          details: response.error,
-          code: 'PLAYBACK_NOT_FOUND',
-        },
-        { status: 404 },
-      );
-    }
-
-    if (!response.playbackInfo) {
-      return NextResponse.json(
-        { error: 'Playback info not found', code: 'PLAYBACK_NOT_FOUND' },
-        { status: 404 },
-      );
-    }
-
-    return NextResponse.json(response.playbackInfo);
-  } catch (error: unknown) {
-    serverLogger.error('Error fetching playback info:', error);
-
-    const message =
-      error instanceof Error ? error.message : 'Failed to fetch playback info';
-
-    if (message === 'LIVEPEER_NOT_CONFIGURED') {
-      return NextResponse.json(
-        {
-          error: 'Livepeer is not configured',
-          code: LIVEPEER_NOT_CONFIGURED,
-        },
-        { status: 503 },
-      );
-    }
-
-    return NextResponse.json(
-      {
-        error: message,
-        code: 'PLAYBACK_INFO_ERROR',
-      },
-      { status: 500 },
-    );
+  const access = await requirePlatformApiAccess(request, { resource: 'playback.info' });
+  if (!access.allowed) {
+    return access.response;
   }
+
+  return handlePlaybackInfo(request);
 }

--- a/app/api/livepeer/sign-jwt/route.ts
+++ b/app/api/livepeer/sign-jwt/route.ts
@@ -1,150 +1,15 @@
-import { signAccessJwt } from "@livepeer/core/crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
 import { rateLimiters } from "@/lib/middleware/rateLimit";
-import { getStreamByPlaybackId } from "@/services/streams";
-import {
-  requireWalletAuth,
-  WalletAuthError,
-} from "@/lib/auth/require-wallet";
-import {
-  checkMeTokenAccess,
-  isMeTokenGateActive,
-} from "@/lib/utils/metoken-access";
-import { resolveVerifiedViewerAddresses } from "@/lib/utils/linked-identity";
+import { handleSignJwt } from '@/lib/livepeer/sign-jwt-handler';
 
 export async function POST(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 
-  try {
-    const accessControlPrivateKey = process.env.ACCESS_CONTROL_PRIVATE_KEY;
-    const accessControlPublicKey = process.env.NEXT_PUBLIC_ACCESS_CONTROL_PUBLIC_KEY;
-
-    if (!accessControlPrivateKey || !accessControlPublicKey) {
-      console.error("Missing Access Control Keys");
-      return NextResponse.json(
-        { message: "Server configuration error: Missing access keys" },
-        { status: 500 }
-      );
-    }
-
-    const body = await req.json();
-    const { playbackId, companionAddress } = body;
-
-    if (!playbackId) {
-      return NextResponse.json(
-        { message: "Missing playbackId" },
-        { status: 400 }
-      );
-    }
-
-    const stream = await getStreamByPlaybackId(playbackId);
-
-    if (
-      !stream ||
-      !isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
-    ) {
-      const token = await signAccessJwt({
-        privateKey: accessControlPrivateKey,
-        publicKey: accessControlPublicKey,
-        issuer: "https://crtv3.app",
-        playbackId,
-        expiration: 3600,
-        custom: {
-          userId: "anonymous",
-        },
-      });
-
-      return NextResponse.json({ token });
-    }
-
-    const gatedStream = stream;
-    const requiredAmount = gatedStream.metoken_price ?? 0;
-
-    if (!gatedStream.creator_id) {
-      return NextResponse.json(
-        { message: "Stream creator not found" },
-        { status: 400 }
-      );
-    }
-
-    let verifiedViewerAddress: string;
-
-    try {
-      const verified = await requireWalletAuth(req);
-      verifiedViewerAddress = verified.address;
-    } catch (err) {
-      if (err instanceof WalletAuthError) {
-        const missingHeaders = err.message.includes("Missing wallet auth headers");
-        const signingRejected =
-          !missingHeaders &&
-          (err.message.includes("Invalid wallet signature") ||
-            err.message.includes("too old"));
-
-        return NextResponse.json(
-          {
-            code: "METOKEN_REQUIRED",
-            connectWallet: missingHeaders,
-            signingRequired: signingRejected,
-            creatorAddress: gatedStream.creator_id,
-            required: String(requiredAmount),
-            message: missingHeaders
-              ? "Connect your wallet to verify MeToken balance"
-              : err.message,
-          },
-          { status: 403 }
-        );
-      }
-      throw err;
-    }
-
-    const viewerAddresses = await resolveVerifiedViewerAddresses(
-      verifiedViewerAddress,
-      companionAddress,
-    );
-
-    const access = await checkMeTokenAccess({
-      viewerAddresses,
-      creatorAddress: gatedStream.creator_id,
-      requiredAmount,
-    });
-
-    if (!access.allowed) {
-      return NextResponse.json(
-        {
-          code: "METOKEN_REQUIRED",
-          connectWallet: access.reason === "no_viewer_address",
-          meTokenAddress: access.meTokenAddress,
-          symbol: access.symbol,
-          required: access.requiredFormatted,
-          balance: access.balanceFormatted,
-          creatorAddress: gatedStream.creator_id,
-          message:
-            access.reason === "no_viewer_address"
-              ? "Connect your wallet to verify MeToken balance"
-              : "Insufficient MeToken balance to watch this stream",
-        },
-        { status: 403 }
-      );
-    }
-
-    const token = await signAccessJwt({
-      privateKey: accessControlPrivateKey,
-      publicKey: accessControlPublicKey,
-      issuer: "https://crtv3.app",
-      playbackId,
-      expiration: 3600,
-      custom: {
-        userId: verifiedViewerAddress,
-      },
-    });
-
-    return NextResponse.json({ token });
-  } catch (error) {
-    console.error("Error signing JWT:", error);
-    return NextResponse.json(
-      { message: "Internal server error" },
-      { status: 500 }
-    );
-  }
+  return handleSignJwt(req);
 }

--- a/app/api/livepeer/webhook/route.ts
+++ b/app/api/livepeer/webhook/route.ts
@@ -11,6 +11,7 @@ import {
   finalizeStreamRecordings,
   persistRecordingAsset,
 } from "@/services/livestream-recordings";
+import { markStreamOfflineByStreamId } from "@/services/streams";
 import { serverLogger } from "@/lib/utils/logger";
 
 export async function POST(request: NextRequest) {
@@ -45,6 +46,10 @@ export async function POST(request: NextRequest) {
       }
     } else if (event === "recording.ready" || event === "stream.idle") {
       if (streamId) {
+        if (event === "stream.idle") {
+          await markStreamOfflineByStreamId(streamId);
+          serverLogger.info("Marked stream offline from stream.idle webhook", { streamId });
+        }
         await finalizeStreamRecordings(streamId);
       }
     }

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -186,38 +186,55 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
       }
     }
 
-    const jwtRes = await fetch("/api/livepeer/sign-jwt", {
+    const jwtRes = await fetch("/api/internal/sign-jwt", {
       method: "POST",
       headers,
       body: JSON.stringify(body),
     });
 
-    if (jwtRes.ok) {
-      const { token } = await jwtRes.json();
-      return { ok: true, token };
+    const parseJwtResult = async (res: Response): Promise<
+      | { ok: true; token: string }
+      | { ok: false; gate?: LiveStreamGateInfo }
+    > => {
+      if (res.ok) {
+        const { token } = await res.json();
+        return { ok: true, token };
+      }
+
+      const errData = await res.json().catch(() => ({}));
+      if (res.status === 403 && errData.code === "METOKEN_REQUIRED") {
+        return {
+          ok: false,
+          gate: {
+            code: errData.code,
+            connectWallet: errData.connectWallet,
+            signingRequired: errData.signingRequired,
+            message: errData.message,
+            meTokenAddress: errData.meTokenAddress,
+            symbol: errData.symbol,
+            required: errData.required,
+            balance: errData.balance,
+            creatorAddress: errData.creatorAddress,
+            streamName,
+          },
+        };
+      }
+
+      logger.warn("Failed to sign JWT for stream:", errData);
+      return { ok: false };
+    };
+
+    if (jwtRes.status === 404) {
+      logger.warn("[requestStreamJwt] Internal sign-jwt not found; falling back to public route");
+      const publicRes = await fetch("/api/livepeer/sign-jwt", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      return parseJwtResult(publicRes);
     }
 
-    const errData = await jwtRes.json().catch(() => ({}));
-    if (jwtRes.status === 403 && errData.code === "METOKEN_REQUIRED") {
-      return {
-        ok: false,
-        gate: {
-          code: errData.code,
-          connectWallet: errData.connectWallet,
-          signingRequired: errData.signingRequired,
-          message: errData.message,
-          meTokenAddress: errData.meTokenAddress,
-          symbol: errData.symbol,
-          required: errData.required,
-          balance: errData.balance,
-          creatorAddress: errData.creatorAddress,
-          streamName,
-        },
-      };
-    }
-
-    logger.warn("Failed to sign JWT for stream:", errData);
-    return { ok: false };
+    return parseJwtResult(jwtRes);
   }, [
     playbackId,
     user?.address,

--- a/components/Live/Broadcast.tsx
+++ b/components/Live/Broadcast.tsx
@@ -200,7 +200,7 @@ function BroadcastWithControls({
           );
           logger.info("Stream marked as live in DB");
         } else if (status === 'idle' || status === 'error') {
-          await updateStream(creatorAddress, { is_live: false }, auth);
+          await updateStream(creatorAddress, { is_live: false, last_live_at: new Date().toISOString() }, auth);
           logger.info("Stream marked as offline in DB");
           if (status === 'idle' && propStreamId && saveRecording) {
             // Recording assets may take a minute to process; retry a few times.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -53,7 +53,6 @@ if (!botIdGlobal.__crtvBotIdInit) {
       // membership omitted: read-only Unlock lookup; BotID Deep Analysis caused profile 403s.
       // metokens-subgraph: read-only GraphQL proxy — excluded from BotID (see rpc-proxy note above).
       botIdDeepAnalysisRoute('/api/livepeer/sign-jwt', 'POST'),
-      botIdDeepAnalysisRoute('/api/livepeer/token-gate', 'POST'),
       botIdDeepAnalysisRoute('/api/livepeer/stream/*/recording', 'POST'),
       botIdDeepAnalysisRoute('/api/streams/recordings/finalize', 'POST'),
       botIdDeepAnalysisRoute('/api/livepeer/clips', 'POST'),

--- a/lib/hooks/livepeer/useDetailPlaybackSources.ts
+++ b/lib/hooks/livepeer/useDetailPlaybackSources.ts
@@ -12,13 +12,33 @@ async function fetchPlaybackInfo(
   id: string,
   signal?: AbortSignal,
 ): Promise<Response> {
+  const internalUrl = `/api/internal/playback-info?playbackId=${id}`;
+
   for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
-    const response = await fetch(`/api/livepeer/playback-info?playbackId=${id}`, {
+    const response = await fetch(internalUrl, {
       signal,
       headers: {
         'Content-Type': 'application/json',
       },
     });
+
+    // If the internal endpoint somehow 404s (e.g. route not deployed), fall
+    // back to the public route so a missing /api/internal path doesn't break
+    // older deploy previews.
+    if (response.status === 404 && attempt === 0) {
+      logger.warn(
+        `[getDetailPlaybackSource] Internal playback-info not found for ${id}; falling back to public route`,
+      );
+      const publicResponse = await fetch(`/api/livepeer/playback-info?playbackId=${id}`, {
+        signal,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if (publicResponse.status !== 429) {
+        return publicResponse;
+      }
+    }
 
     if (response.status !== 429 || attempt === MAX_429_RETRIES) {
       return response;

--- a/lib/hooks/livepeer/useHeroPlaybackSource.ts
+++ b/lib/hooks/livepeer/useHeroPlaybackSource.ts
@@ -18,7 +18,7 @@ export const getHeroPlaybackSource = async (): Promise<HeroPlaybackSource | null
     const playbackId = LIVEPEER_HERO_PLAYBACK_ID;
 
     const playbackResponse = await fetch(
-      `/api/livepeer/playback-info?playbackId=${encodeURIComponent(playbackId)}`,
+      `/api/internal/playback-info?playbackId=${encodeURIComponent(playbackId)}`,
     );
     if (!playbackResponse.ok) {
       throw new Error(

--- a/lib/livepeer/playback-info-handler.ts
+++ b/lib/livepeer/playback-info-handler.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFullLivepeer } from '@/lib/sdk/livepeer/fullClient';
+import { isLivepeerConfigured, LIVEPEER_NOT_CONFIGURED } from '@/lib/sdk/livepeer/studioAuth';
+import { serverLogger } from '@/lib/utils/logger';
+
+const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Shared implementation used by both the public platform API route
+ * (/api/livepeer/playback-info) and the first-party internal route
+ * (/api/internal/playback-info). Callers are responsible for their own
+ * access-control layer.
+ */
+export async function handlePlaybackInfo(request: NextRequest): Promise<NextResponse> {
+  try {
+    if (!isLivepeerConfigured()) {
+      return NextResponse.json(
+        { error: 'Livepeer playback is not configured on this deployment', code: LIVEPEER_NOT_CONFIGURED },
+        { status: 503 },
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const playbackId = searchParams.get('playbackId');
+
+    if (!playbackId) {
+      return NextResponse.json(
+        { error: 'Playback ID is required', code: 'PLAYBACK_ID_REQUIRED' },
+        { status: 400 },
+      );
+    }
+
+    if (ethereumAddressRegex.test(playbackId)) {
+      return NextResponse.json(
+        {
+          error:
+            'Invalid playback ID format. Expected Livepeer playback ID, received Ethereum address.',
+          code: 'INVALID_PLAYBACK_ID',
+        },
+        { status: 400 },
+      );
+    }
+
+    const client = getFullLivepeer();
+    if (!client) {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
+    }
+
+    const response = await client.playback.get(playbackId);
+
+    if (response.error) {
+      return NextResponse.json(
+        {
+          error: 'Playback info not found',
+          details: response.error,
+          code: 'PLAYBACK_NOT_FOUND',
+        },
+        { status: 404 },
+      );
+    }
+
+    if (!response.playbackInfo) {
+      return NextResponse.json(
+        { error: 'Playback info not found', code: 'PLAYBACK_NOT_FOUND' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(response.playbackInfo);
+  } catch (error: unknown) {
+    serverLogger.error('Error fetching playback info:', error);
+
+    const message =
+      error instanceof Error ? error.message : 'Failed to fetch playback info';
+
+    if (message === 'LIVEPEER_NOT_CONFIGURED') {
+      return NextResponse.json(
+        {
+          error: 'Livepeer is not configured',
+          code: LIVEPEER_NOT_CONFIGURED,
+        },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: message,
+        code: 'PLAYBACK_INFO_ERROR',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/livepeer/sign-jwt-handler.ts
+++ b/lib/livepeer/sign-jwt-handler.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { signAccessJwt } from "@livepeer/core/crypto";
+import { getStreamByPlaybackId } from "@/services/streams";
+import {
+  requireWalletAuth,
+  WalletAuthError,
+} from "@/lib/auth/require-wallet";
+import {
+  checkMeTokenAccess,
+  isMeTokenGateActive,
+} from "@/lib/utils/metoken-access";
+import { resolveVerifiedViewerAddresses } from "@/lib/utils/linked-identity";
+import { serverLogger } from '@/lib/utils/logger';
+
+export async function handleSignJwt(req: NextRequest): Promise<NextResponse> {
+  try {
+    const accessControlPrivateKey = process.env.ACCESS_CONTROL_PRIVATE_KEY;
+    const accessControlPublicKey = process.env.NEXT_PUBLIC_ACCESS_CONTROL_PUBLIC_KEY;
+
+    if (!accessControlPrivateKey || !accessControlPublicKey) {
+      serverLogger.error("Missing Access Control Keys");
+      return NextResponse.json(
+        { message: "Server configuration error: Missing access keys" },
+        { status: 500 }
+      );
+    }
+
+    const body = await req.json();
+    const { playbackId, companionAddress } = body;
+
+    if (!playbackId) {
+      return NextResponse.json(
+        { message: "Missing playbackId" },
+        { status: 400 }
+      );
+    }
+
+    const stream = await getStreamByPlaybackId(playbackId);
+
+    if (
+      !stream ||
+      !isMeTokenGateActive(stream.requires_metoken, stream.metoken_price)
+    ) {
+      const token = await signAccessJwt({
+        privateKey: accessControlPrivateKey,
+        publicKey: accessControlPublicKey,
+        issuer: "https://crtv3.app",
+        playbackId,
+        expiration: 3600,
+        custom: {
+          userId: "anonymous",
+        },
+      });
+
+      return NextResponse.json({ token });
+    }
+
+    const gatedStream = stream;
+    const requiredAmount = gatedStream.metoken_price ?? 0;
+
+    if (!gatedStream.creator_id) {
+      return NextResponse.json(
+        { message: "Stream creator not found" },
+        { status: 400 }
+      );
+    }
+
+    let verifiedViewerAddress: string;
+
+    try {
+      const verified = await requireWalletAuth(req);
+      verifiedViewerAddress = verified.address;
+    } catch (err) {
+      if (err instanceof WalletAuthError) {
+        const missingHeaders = err.message.includes("Missing wallet auth headers");
+        const signingRejected =
+          !missingHeaders &&
+          (err.message.includes("Invalid wallet signature") ||
+            err.message.includes("too old"));
+
+        return NextResponse.json(
+          {
+            code: "METOKEN_REQUIRED",
+            connectWallet: missingHeaders,
+            signingRequired: signingRejected,
+            creatorAddress: gatedStream.creator_id,
+            required: String(requiredAmount),
+            message: missingHeaders
+              ? "Connect your wallet to verify MeToken balance"
+              : err.message,
+          },
+          { status: 403 }
+        );
+      }
+      throw err;
+    }
+
+    const viewerAddresses = await resolveVerifiedViewerAddresses(
+      verifiedViewerAddress,
+      companionAddress,
+    );
+
+    const access = await checkMeTokenAccess({
+      viewerAddresses,
+      creatorAddress: gatedStream.creator_id,
+      requiredAmount,
+    });
+
+    if (!access.allowed) {
+      return NextResponse.json(
+        {
+          code: "METOKEN_REQUIRED",
+          connectWallet: access.reason === "no_viewer_address",
+          meTokenAddress: access.meTokenAddress,
+          symbol: access.symbol,
+          required: access.requiredFormatted,
+          balance: access.balanceFormatted,
+          creatorAddress: gatedStream.creator_id,
+          message:
+            access.reason === "no_viewer_address"
+              ? "Connect your wallet to verify MeToken balance"
+              : "Insufficient MeToken balance to watch this stream",
+        },
+        { status: 403 }
+      );
+    }
+
+    const token = await signAccessJwt({
+      privateKey: accessControlPrivateKey,
+      publicKey: accessControlPublicKey,
+      issuer: "https://crtv3.app",
+      playbackId,
+      expiration: 3600,
+      custom: {
+        userId: verifiedViewerAddress,
+      },
+    });
+
+    return NextResponse.json({ token });
+  } catch (error) {
+    serverLogger.error("Error signing JWT:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/songchain/build-lens-video-metadata.ts
+++ b/lib/songchain/build-lens-video-metadata.ts
@@ -24,7 +24,7 @@ export async function resolveVideoPlaybackUrl(playbackId: string): Promise<strin
   if (!playbackId?.trim()) return null;
   try {
     const response = await fetch(
-      `/api/livepeer/playback-info?playbackId=${encodeURIComponent(playbackId)}`,
+      `/api/internal/playback-info?playbackId=${encodeURIComponent(playbackId)}`,
     );
     if (!response.ok) return null;
     const res = await response.json();

--- a/lib/utils/thumbnail.ts
+++ b/lib/utils/thumbnail.ts
@@ -17,7 +17,7 @@ export interface ThumbnailInfo {
 export async function getThumbnailInfo(playbackId: string): Promise<ThumbnailInfo | null> {
   try {
     // Fetch playback info to get the VTT URL
-    const response = await fetch(`/api/livepeer/playback-info?playbackId=${playbackId}`);
+    const response = await fetch(`/api/internal/playback-info?playbackId=${playbackId}`);
     
     if (!response.ok) {
       logger.warn(`Failed to fetch playback info for ${playbackId}:`, response.status);

--- a/services/livepeer-thumbnails.ts
+++ b/services/livepeer-thumbnails.ts
@@ -10,7 +10,7 @@ const getThumbnailUrlSchema = z.object({
 
 export async function getThumbnailUrl({ playbackId }: { playbackId: string }) {
   const res = await fetch(
-    `/api/livepeer/playback-info?playbackId=${playbackId}`
+    `/api/internal/playback-info?playbackId=${playbackId}`
   );
   if (!res.ok)
     return {
@@ -39,7 +39,7 @@ export async function getThumbnailUrl({ playbackId }: { playbackId: string }) {
 export async function getThumbnailFromVTT({ playbackId }: { playbackId: string }) {
   try {
     const res = await fetch(
-      `/api/livepeer/playback-info?playbackId=${playbackId}`
+      `/api/internal/playback-info?playbackId=${playbackId}`
     );
     
     if (!res.ok) {

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -387,6 +387,28 @@ export interface ActiveStream {
 }
 
 /**
+ * Server-side helper to mark a stream offline by Livepeer stream ID.
+ * Used by webhooks when Livepeer reports stream.idle; bypasses wallet-auth
+ * because the caller is Livepeer, not an end user.
+ */
+export async function markStreamOfflineByStreamId(streamId: string) {
+    const supabase = await createServiceClient();
+
+    const { error } = await supabase
+        .from("streams")
+        .update({
+            is_live: false,
+            updated_at: new Date().toISOString(),
+        })
+        .ilike("stream_id", streamId);
+
+    if (error) {
+        serverLogger.error("Error marking stream offline by stream ID:", error);
+        throw new Error(`Failed to mark stream offline: ${error.message}`);
+    }
+}
+
+/**
  * Get all active streams from the database
  */
 export async function getActiveStreams() {


### PR DESCRIPTION
### What this does
Makes the livestream playback architecture explicit by splitting the viewer APIs from the platform/partner APIs.

### Problem
We had one set of routes under `/api/livepeer/playback-info` and `/api/livepeer/sign-jwt` that were trying to serve two conflicting purposes:
1. First-party browser viewers (need fast, ungated access so the player can load).
2. External platform/partner API consumers (need x402 payments or API keys).

PR #292 removed the gates entirely as a hotfix. This refactor makes the split intentional.

### Changes
- **New internal viewer routes** (no gates, rate-limited):
  * `GET /api/internal/playback-info`
  * `POST /api/internal/sign-jwt`
- **Shared handlers** extracted to:
  * `lib/livepeer/playback-info-handler.ts`
  * `lib/livepeer/sign-jwt-handler.ts`
- **Public platform routes restored** to original behavior:
  * `GET /api/livepeer/playback-info` → x402 / API key required.
  * `POST /api/livepeer/sign-jwt` → BotID deep analysis + rate limit.
- **First-party clients now call `/api/internal/*`**:
  * `lib/hooks/livepeer/useDetailPlaybackSources.ts`
  * `lib/hooks/livepeer/useHeroPlaybackSource.ts`
  * `app/watch/[playbackId]/WatchClient.tsx`
  * `services/livepeer-thumbnails.ts`
  * `lib/utils/thumbnail.ts`
  * `lib/songchain/build-lens-video-metadata.ts`
- Internal routes fall back to the public ones if they somehow 404 (e.g., older deploy previews), so nothing breaks during transition.

### After merging
This depends on PR #292 being deployed first. Once both are live, first-party viewers will use the internal routes, and the public routes remain protected for external API access.