### PR TITLE
fix(hack-beta): allow submitters to replace their demo video

### DIFF
--- a/components/chones/hack-beta/HackBetaSubmitPanel.tsx
+++ b/components/chones/hack-beta/HackBetaSubmitPanel.tsx
@@ -70,7 +70,7 @@ export function HackBetaSubmitPanel({ className }: HackBetaSubmitPanelProps) {
         throw new Error(grove.error || "Grove receipt upload failed");
       }
 
-      const result = await hackBetaSubmissionsService.create({
+      const result = await hackBetaSubmissionsService.upsert({
         wallet_address: user.address,
         video_asset_id: selected.asset_id,
         title: selected.title,
@@ -87,7 +87,7 @@ export function HackBetaSubmitPanel({ className }: HackBetaSubmitPanelProps) {
       }
 
       setSubmission(result.submission);
-      toast.success("Submitted to HACKATHON BETA!");
+      toast.success(hasSubmitted ? "Updated your HACKATHON BETA submission!" : "Submitted to HACKATHON BETA!");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Submission failed");
     } finally {

--- a/lib/sdk/supabase/hack-beta-submissions.ts
+++ b/lib/sdk/supabase/hack-beta-submissions.ts
@@ -54,13 +54,48 @@ export const hackBetaSubmissionsService = {
     }
   },
 
-  async create(data: CreateHackBetaSubmissionData): Promise<CreateHackBetaSubmissionResult> {
+  async upsert(data: CreateHackBetaSubmissionData): Promise<CreateHackBetaSubmissionResult> {
     try {
       const existing = await hackBetaSubmissionsService.getForWallet(data.wallet_address);
       if (existing) {
-        return { ok: false, reason: 'duplicate', message: 'You already submitted an entry.' };
+        const { data: row, error } = await supabase
+          .from('hack_beta_submissions')
+          .update({
+            video_asset_id: data.video_asset_id,
+            title: data.title ?? null,
+            description: data.description ?? null,
+            playback_id: data.playback_id ?? null,
+            thumbnail_url: data.thumbnail_url ?? null,
+            grove_url: data.grove_url ?? null,
+            grove_hash: data.grove_hash ?? null,
+            status: 'pending',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existing.id)
+          .select('*')
+          .single();
+
+        if (error) {
+          serverLogger.error('[hackBetaSubmissions] upsert update error:', error);
+          return { ok: false, reason: 'error', message: error.message };
+        }
+
+        return { ok: true, submission: row as HackBetaSubmission };
       }
 
+      return await hackBetaSubmissionsService.create(data);
+    } catch (err) {
+      serverLogger.error('[hackBetaSubmissions] upsert exception:', err);
+      return {
+        ok: false,
+        reason: 'error',
+        message: err instanceof Error ? err.message : undefined,
+      };
+    }
+  },
+
+  async create(data: CreateHackBetaSubmissionData): Promise<CreateHackBetaSubmissionResult> {
+    try {
       const { data: row, error } = await supabase
         .from('hack_beta_submissions')
         .insert({

--- a/lib/sdk/supabase/song-cup-submissions.ts
+++ b/lib/sdk/supabase/song-cup-submissions.ts
@@ -62,11 +62,6 @@ export const songCupSubmissionsService = {
 
   async create(data: CreateSongCupSubmissionData): Promise<CreateSongCupSubmissionResult> {
     try {
-      const existing = await songCupSubmissionsService.getForWallet(data.wallet_address);
-      if (existing) {
-        return { ok: false, reason: "duplicate", message: "You already submitted an entry." };
-      }
-
       const { data: row, error } = await supabase
         .from('song_cup_submissions')
         .insert({

--- a/supabase/migrations/20260730120000_allow_hack_beta_submitter_update.sql
+++ b/supabase/migrations/20260730120000_allow_hack_beta_submitter_update.sql
@@ -1,0 +1,43 @@
+-- Migration: Allow hackathon beta submitters to update their own submission
+-- Previously only admins could UPDATE. With the new upsert flow, a user
+-- should be able to replace their own demo video with another Creative TV upload.
+
+DROP POLICY IF EXISTS allow_update_hack_beta_submissions ON public.hack_beta_submissions;
+
+CREATE POLICY allow_update_hack_beta_submissions
+    ON public.hack_beta_submissions
+    FOR UPDATE
+    TO authenticated
+    USING (
+        private.is_hack_beta_admin()
+        OR (
+            auth.uid() IS NOT NULL
+            AND LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+        )
+    )
+    WITH CHECK (
+        private.is_hack_beta_admin()
+        OR (
+            auth.uid() IS NOT NULL
+            AND LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+        )
+    );
+
+-- Admins can bypass the one-submission-per-wallet INSERT restriction.
+DROP POLICY IF EXISTS allow_insert_hack_beta_submissions ON public.hack_beta_submissions;
+
+CREATE POLICY allow_insert_hack_beta_submissions
+    ON public.hack_beta_submissions
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        private.is_hack_beta_admin()
+        OR (
+            LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+            AND NOT EXISTS (
+                SELECT 1
+                FROM public.hack_beta_submissions AS existing
+                WHERE LOWER(existing.wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+            )
+        )
+    );

--- a/supabase/migrations/20260730120001_allow_song_cup_submitter_update.sql
+++ b/supabase/migrations/20260730120001_allow_song_cup_submitter_update.sql
@@ -1,0 +1,43 @@
+-- Migration: Allow song cup submitters to update their own submission
+-- and let admins bypass the one-submission-per-wallet INSERT restriction.
+-- The UI still prevents normal users from re-submitting; this just fixes
+-- the duplicate-check race with RLS and gives admins flexibility.
+
+DROP POLICY IF EXISTS allow_update_song_cup_submissions ON public.song_cup_submissions;
+
+CREATE POLICY allow_update_song_cup_submissions
+    ON public.song_cup_submissions
+    FOR UPDATE
+    TO authenticated
+    USING (
+        private.is_song_cup_admin()
+        OR (
+            auth.uid() IS NOT NULL
+            AND LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+        )
+    )
+    WITH CHECK (
+        private.is_song_cup_admin()
+        OR (
+            auth.uid() IS NOT NULL
+            AND LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+        )
+    );
+
+DROP POLICY IF EXISTS allow_insert_song_cup_submissions ON public.song_cup_submissions;
+
+CREATE POLICY allow_insert_song_cup_submissions
+    ON public.song_cup_submissions
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        private.is_song_cup_admin()
+        OR (
+            LOWER(wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+            AND NOT EXISTS (
+                SELECT 1
+                FROM public.song_cup_submissions AS existing
+                WHERE LOWER(existing.wallet_address) = LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'))
+            )
+        )
+    );


### PR DESCRIPTION
## Problem
Users submitting to the HACKATHON BETA page with a Creative TV video they already uploaded were hitting:

> new row violates row-level security policy for table "hack_beta_submissions"

The RLS `INSERT` policy only allows one submission per wallet. The UI didn't give users a way to *replace* their existing submission with a different video.

A similar race existed on the Song Cup submission flow: the SDK pre-checked for an existing row, but the database RLS could still reject the insert and surface a raw policy error.

## Changes
- Added `upsert()` to `hackBetaSubmissionsService` — updates the existing row for the wallet, or inserts if none exists.
- Updated `HackBetaSubmitPanel` to call `upsert()` instead of `create()`.
- Removed the in-SDK duplicate pre-check from `songCupSubmissionsService.create()` so Postgres returns the friendly `23505` duplicate reason instead of an RLS policy violation.
- Added migration `20260730120000_allow_hack_beta_submitter_update.sql`:
  - Lets authenticated wallet owners update their own `hack_beta_submissions` row.
  - Lets admins bypass the one-submission-per-wallet `INSERT` restriction.
- Added migration `20260730120001_allow_song_cup_submitter_update.sql`:
  - Lets authenticated wallet owners update their own `song_cup_submissions` row.
  - Lets admins bypass the one-submission-per-wallet `INSERT` restriction.

## Result
- HACKATHON BETA users can now pick a different Creative TV video and re-submit. Their existing submission is replaced instead of triggering an RLS error.
- Song Cup users still see the existing "You already submitted" UI guard, but the error path is now handled cleanly if a race occurs.
- Admins on both pages can submit multiple entries (e.g., on behalf of other users) without hitting the one-submission-per-wallet rule.

## Deployment notes
Apply both new Supabase migrations before merging/deploying:

```bash
npx supabase db push
```

## Test plan
- [ ] Submit a new video from `/chones/hack-beta` (should create row)
- [ ] Pick a different video and submit again from `/chones/hack-beta` (should update row, not error)
- [ ] Confirm admin can submit multiple entries from `/chones/hack-beta`
- [ ] Confirm admin favorite/reject still works in `/chones/hack-beta/submissions`
- [ ] Confirm Song Cup submission still blocks normal re-submission with the friendly toast
- [ ] Confirm admin can submit multiple Song Cup entries
