### PR TITLE
fix(submissions): atomic RPC upsert for hack-beta and song-cup

### DIFF
--- a/components/songchain/SongchainComposePost.tsx
+++ b/components/songchain/SongchainComposePost.tsx
@@ -78,9 +78,8 @@ export function SongchainComposePost({
           post_id: created.postId,
         });
         if (!submissionResult.ok) {
-          if (submissionResult.reason === "duplicate") {
-            // Feed post succeeded; submission row already exists for this wallet.
-          } else {
+          // The RPC upsert path now handles existing rows silently on the server.
+          if (submissionResult.reason === "error") {
             logger.error(
               "[SongchainComposePost] Song Cup submission failed:",
               submissionResult.message,

--- a/lib/sdk/supabase/hack-beta-submissions.ts
+++ b/lib/sdk/supabase/hack-beta-submissions.ts
@@ -56,34 +56,24 @@ export const hackBetaSubmissionsService = {
 
   async upsert(data: CreateHackBetaSubmissionData): Promise<CreateHackBetaSubmissionResult> {
     try {
-      const existing = await hackBetaSubmissionsService.getForWallet(data.wallet_address);
-      if (existing) {
-        const { data: row, error } = await supabase
-          .from('hack_beta_submissions')
-          .update({
-            video_asset_id: data.video_asset_id,
-            title: data.title ?? null,
-            description: data.description ?? null,
-            playback_id: data.playback_id ?? null,
-            thumbnail_url: data.thumbnail_url ?? null,
-            grove_url: data.grove_url ?? null,
-            grove_hash: data.grove_hash ?? null,
-            status: 'pending',
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', existing.id)
-          .select('*')
-          .single();
+      const { data: row, error } = await supabase
+        .rpc('upsert_hack_beta_submission', {
+          p_video_asset_id: data.video_asset_id,
+          p_title: data.title ?? null,
+          p_description: data.description ?? null,
+          p_playback_id: data.playback_id ?? null,
+          p_thumbnail_url: data.thumbnail_url ?? null,
+          p_grove_url: data.grove_url ?? null,
+          p_grove_hash: data.grove_hash ?? null,
+        })
+        .single();
 
-        if (error) {
-          serverLogger.error('[hackBetaSubmissions] upsert update error:', error);
-          return { ok: false, reason: 'error', message: error.message };
-        }
-
-        return { ok: true, submission: row as HackBetaSubmission };
+      if (error) {
+        serverLogger.error('[hackBetaSubmissions] rpc upsert error:', error);
+        return { ok: false, reason: 'error', message: error.message };
       }
 
-      return await hackBetaSubmissionsService.create(data);
+      return { ok: true, submission: row as HackBetaSubmission };
     } catch (err) {
       serverLogger.error('[hackBetaSubmissions] upsert exception:', err);
       return {

--- a/lib/sdk/supabase/migrations/00009_atomic_submission_upserts.sql
+++ b/lib/sdk/supabase/migrations/00009_atomic_submission_upserts.sql
@@ -1,0 +1,241 @@
+-- Migration 00009: atomic upsert RPC for hack beta and song cup submissions
+-- Replaces the client-side SELECT / UPDATE / INSERT race with a single Postgres
+-- call. The real logic lives in private.* (SECURITY DEFINER) and is exposed via
+-- thin public.* wrappers (SECURITY INVOKER) so PostgREST can reach them without
+-- leaving a privileged function in the exposed public schema.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+-- Real upsert logic for hack beta submissions (private, SECURITY DEFINER).
+CREATE OR REPLACE FUNCTION private.upsert_hack_beta_submission(
+    p_video_asset_id TEXT,
+    p_title TEXT DEFAULT NULL,
+    p_description TEXT DEFAULT NULL,
+    p_playback_id TEXT DEFAULT NULL,
+    p_thumbnail_url TEXT DEFAULT NULL,
+    p_grove_url TEXT DEFAULT NULL,
+    p_grove_hash TEXT DEFAULT NULL
+)
+RETURNS public.hack_beta_submissions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, private
+AS $$
+DECLARE
+    v_wallet_address TEXT;
+    v_result public.hack_beta_submissions;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Unauthorized';
+    END IF;
+
+    v_wallet_address := LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'));
+
+    IF v_wallet_address IS NULL OR v_wallet_address = '' THEN
+        RAISE EXCEPTION 'Wallet address not found in JWT app_metadata';
+    END IF;
+
+    UPDATE public.hack_beta_submissions
+    SET
+        video_asset_id = p_video_asset_id,
+        title = p_title,
+        description = p_description,
+        playback_id = p_playback_id,
+        thumbnail_url = p_thumbnail_url,
+        grove_url = p_grove_url,
+        grove_hash = p_grove_hash,
+        status = 'pending',
+        updated_at = now()
+    WHERE LOWER(wallet_address) = v_wallet_address
+    RETURNING * INTO v_result;
+
+    IF FOUND THEN
+        RETURN v_result;
+    END IF;
+
+    INSERT INTO public.hack_beta_submissions (
+        wallet_address,
+        video_asset_id,
+        title,
+        description,
+        playback_id,
+        thumbnail_url,
+        grove_url,
+        grove_hash,
+        status,
+        is_favorite
+    ) VALUES (
+        v_wallet_address,
+        p_video_asset_id,
+        p_title,
+        p_description,
+        p_playback_id,
+        p_thumbnail_url,
+        p_grove_url,
+        p_grove_hash,
+        'pending',
+        false
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION private.upsert_hack_beta_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION private.upsert_hack_beta_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO authenticated;
+
+-- Thin public wrapper exposed to PostgREST / supabase-js.
+CREATE OR REPLACE FUNCTION public.upsert_hack_beta_submission(
+    p_video_asset_id TEXT,
+    p_title TEXT DEFAULT NULL,
+    p_description TEXT DEFAULT NULL,
+    p_playback_id TEXT DEFAULT NULL,
+    p_thumbnail_url TEXT DEFAULT NULL,
+    p_grove_url TEXT DEFAULT NULL,
+    p_grove_hash TEXT DEFAULT NULL
+)
+RETURNS public.hack_beta_submissions
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = private
+AS $$
+    SELECT private.upsert_hack_beta_submission(
+        p_video_asset_id,
+        p_title,
+        p_description,
+        p_playback_id,
+        p_thumbnail_url,
+        p_grove_url,
+        p_grove_hash
+    );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.upsert_hack_beta_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.upsert_hack_beta_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO authenticated;
+
+-- Real upsert logic for song cup submissions (private, SECURITY DEFINER).
+CREATE OR REPLACE FUNCTION private.upsert_song_cup_submission(
+    p_grove_url TEXT,
+    p_grove_hash TEXT DEFAULT NULL,
+    p_title TEXT DEFAULT NULL,
+    p_description TEXT DEFAULT NULL,
+    p_artist_handle TEXT DEFAULT NULL,
+    p_email TEXT DEFAULT NULL,
+    p_cover_url TEXT DEFAULT NULL,
+    p_cover_hash TEXT DEFAULT NULL,
+    p_attestation_uid TEXT DEFAULT NULL,
+    p_post_id TEXT DEFAULT NULL
+)
+RETURNS public.song_cup_submissions
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, private
+AS $$
+DECLARE
+    v_wallet_address TEXT;
+    v_result public.song_cup_submissions;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Unauthorized';
+    END IF;
+
+    v_wallet_address := LOWER((auth.jwt() -> 'app_metadata' ->> 'wallet_address'));
+
+    IF v_wallet_address IS NULL OR v_wallet_address = '' THEN
+        RAISE EXCEPTION 'Wallet address not found in JWT app_metadata';
+    END IF;
+
+    UPDATE public.song_cup_submissions
+    SET
+        grove_url = p_grove_url,
+        grove_hash = p_grove_hash,
+        title = p_title,
+        description = p_description,
+        artist_handle = p_artist_handle,
+        email = p_email,
+        cover_url = p_cover_url,
+        cover_hash = p_cover_hash,
+        attestation_uid = p_attestation_uid,
+        post_id = p_post_id,
+        status = 'pending',
+        updated_at = now()
+    WHERE LOWER(wallet_address) = v_wallet_address
+    RETURNING * INTO v_result;
+
+    IF FOUND THEN
+        RETURN v_result;
+    END IF;
+
+    INSERT INTO public.song_cup_submissions (
+        wallet_address,
+        grove_url,
+        grove_hash,
+        title,
+        description,
+        artist_handle,
+        email,
+        cover_url,
+        cover_hash,
+        attestation_uid,
+        post_id,
+        status,
+        is_favorite
+    ) VALUES (
+        v_wallet_address,
+        p_grove_url,
+        p_grove_hash,
+        p_title,
+        p_description,
+        p_artist_handle,
+        p_email,
+        p_cover_url,
+        p_cover_hash,
+        p_attestation_uid,
+        p_post_id,
+        'pending',
+        false
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION private.upsert_song_cup_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION private.upsert_song_cup_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO authenticated;
+
+-- Thin public wrapper exposed to PostgREST / supabase-js.
+CREATE OR REPLACE FUNCTION public.upsert_song_cup_submission(
+    p_grove_url TEXT,
+    p_grove_hash TEXT DEFAULT NULL,
+    p_title TEXT DEFAULT NULL,
+    p_description TEXT DEFAULT NULL,
+    p_artist_handle TEXT DEFAULT NULL,
+    p_email TEXT DEFAULT NULL,
+    p_cover_url TEXT DEFAULT NULL,
+    p_cover_hash TEXT DEFAULT NULL,
+    p_attestation_uid TEXT DEFAULT NULL,
+    p_post_id TEXT DEFAULT NULL
+)
+RETURNS public.song_cup_submissions
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = private
+AS $$
+    SELECT private.upsert_song_cup_submission(
+        p_grove_url,
+        p_grove_hash,
+        p_title,
+        p_description,
+        p_artist_handle,
+        p_email,
+        p_cover_url,
+        p_cover_hash,
+        p_attestation_uid,
+        p_post_id
+    );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.upsert_song_cup_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.upsert_song_cup_submission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO authenticated;

--- a/lib/sdk/supabase/song-cup-submissions.ts
+++ b/lib/sdk/supabase/song-cup-submissions.ts
@@ -63,31 +63,23 @@ export const songCupSubmissionsService = {
   async create(data: CreateSongCupSubmissionData): Promise<CreateSongCupSubmissionResult> {
     try {
       const { data: row, error } = await supabase
-        .from('song_cup_submissions')
-        .insert({
-          wallet_address: data.wallet_address.toLowerCase(),
-          grove_url: data.grove_url,
-          grove_hash: data.grove_hash ?? null,
-          title: data.title ?? null,
-          description: data.description ?? null,
-          artist_handle: data.artist_handle ?? null,
-          email: data.email ?? null,
-          cover_url: data.cover_url ?? null,
-          cover_hash: data.cover_hash ?? null,
-          attestation_uid: data.attestation_uid ?? null,
-          post_id: data.post_id ?? null,
-          status: 'pending',
-          is_favorite: false,
+        .rpc('upsert_song_cup_submission', {
+          p_grove_url: data.grove_url,
+          p_grove_hash: data.grove_hash ?? null,
+          p_title: data.title ?? null,
+          p_description: data.description ?? null,
+          p_artist_handle: data.artist_handle ?? null,
+          p_email: data.email ?? null,
+          p_cover_url: data.cover_url ?? null,
+          p_cover_hash: data.cover_hash ?? null,
+          p_attestation_uid: data.attestation_uid ?? null,
+          p_post_id: data.post_id ?? null,
         })
-        .select('*')
         .single();
 
       if (error) {
-        if (error.code === "23505") {
-          return { ok: false, reason: "duplicate", message: "You already submitted an entry." };
-        }
-        serverLogger.error('[songCupSubmissions] insert error:', error);
-        return { ok: false, reason: "error", message: error.message };
+        serverLogger.error('[songCupSubmissions] rpc create/upsert error:', error);
+        return { ok: false, reason: 'error', message: error.message };
       }
 
       return { ok: true, submission: row as SongCupSubmission };
@@ -95,7 +87,7 @@ export const songCupSubmissionsService = {
       serverLogger.error('[songCupSubmissions] create exception:', err);
       return {
         ok: false,
-        reason: "error",
+        reason: 'error',
         message: err instanceof Error ? err.message : undefined,
       };
     }


### PR DESCRIPTION
## Problem
The first fix (PR #294) updated RLS policies so wallet owners can update their own submission rows, but the SDK still performs a client-side `SELECT -> UPDATE/INSERT`. That sequence still races, and users continue seeing:

> new row violates row-level security policy for table "hack_beta_submissions"

## Solution
Replace the client-side upsert with atomic Postgres RPC functions that handle `UPDATE`-or-`INSERT` in a single call.

## Changes
- Added `lib/sdk/supabase/migrations/00009_atomic_submission_upserts.sql`:
  - `private.upsert_hack_beta_submission()` / `private.upsert_song_cup_submission()` — real logic, `SECURITY DEFINER`, with `auth.uid()` check.
  - `public.upsert_hack_beta_submission()` / `public.upsert_song_cup_submission()` — thin `SECURITY INVOKER` wrappers so PostgREST / `supabase-js` can call them without exposing a privileged function in the public schema.
- Updated `hackBetaSubmissionsService.upsert()` to call `supabase.rpc('upsert_hack_beta_submission', ...)`
- Updated `songCupSubmissionsService.create()` to call `supabase.rpc('upsert_song_cup_submission', ...)`
- Updated `SongchainComposePost` since the RPC path no longer returns a separate `"duplicate"` reason

## Concurrency safety
Both tables already have unique indexes on `LOWER(wallet_address)`, so concurrent RPC calls cannot create duplicate rows. If two calls both see "no row", one `INSERT` succeeds and the other hits the unique index.

## Required before testing
Apply the migration to your live Supabase project:

```bash
cd /Users/sirgawain/Developer/crtv3
npx supabase db push
```

Or run the contents of `lib/sdk/supabase/migrations/00009_atomic_submission_upserts.sql` in the Supabase SQL editor.

## Test plan
- [ ] Submit a new video from `/chones/hack-beta`
- [ ] Submit again from `/chones/hack-beta` with a different video (should update, not error)
- [ ] Submit a Song Cup entry from the Song Cup page
- [ ] Verify `SongchainComposePost` still creates a Song Cup submission when uploading a video
- [ ] Confirm no raw RLS errors appear in either flow
- [ ] Run the Supabase Security Advisor and confirm no `SECURITY DEFINER` in public-schema warnings for these functions
