### PR TITLE
fix: watch gate copy, Nearchos handle, and SCA admin checks

### DIFF
--- a/app/chones/hack-beta/submissions/page.tsx
+++ b/app/chones/hack-beta/submissions/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { useUser } from "@/lib/wallet/react";
 import { useHackBetaSubmissions } from "@/lib/hooks/hack-beta/useHackBetaSubmissions";
 import { useHackBetaSettings } from "@/lib/hooks/hack-beta/useHackBetaSettings";
 import { Card, CardContent } from "@/components/ui/card";
@@ -23,10 +22,18 @@ import {
 import { toast } from "sonner";
 
 export default function HackBetaSubmissionsPage() {
-  const user = useUser();
   const [statusFilter, setStatusFilter] = useState<HackBetaSubmissionStatusFilter>("pending");
-  const { submissions, isLoading, error, refetch, updateStatus, setFavorite, isAdmin } =
-    useHackBetaSubmissions(true);
+  const {
+    submissions,
+    isLoading,
+    error,
+    refetch,
+    updateStatus,
+    setFavorite,
+    isAdmin,
+    walletAddress,
+    isAdminLoading,
+  } = useHackBetaSubmissions(true);
   const { mixtapePlaylistUrl, updateMixtapeUrl, isLoading: settingsLoading } =
     useHackBetaSettings();
   const [mixtapeDraft, setMixtapeDraft] = useState<string | null>(null);
@@ -48,7 +55,7 @@ export default function HackBetaSubmissionsPage() {
     if (!isAdmin) return;
     setSavingMixtape(true);
     try {
-      const row = await updateMixtapeUrl(mixtapeValue.trim() || null, user?.address);
+      const row = await updateMixtapeUrl(mixtapeValue.trim() || null, walletAddress);
       if (!row) {
         toast.error("Failed to save mixtape URL");
         return;
@@ -101,7 +108,15 @@ export default function HackBetaSubmissionsPage() {
           </Button>
         </div>
 
-        {!user?.address && (
+        {isAdminLoading && (
+          <Card>
+            <CardContent className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              Resolving smart wallet…
+            </CardContent>
+          </Card>
+        )}
+
+        {!isAdminLoading && !walletAddress && (
           <Card>
             <CardContent className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
               <AlertCircle className="h-4 w-4" />
@@ -110,12 +125,12 @@ export default function HackBetaSubmissionsPage() {
           </Card>
         )}
 
-        {user?.address && !isAdmin && (
+        {!isAdminLoading && walletAddress && !isAdmin && (
           <Card>
             <CardContent className="space-y-2 p-4 text-sm">
               <p className="flex items-center gap-2 text-muted-foreground">
                 <AlertCircle className="h-4 w-4" />
-                {truncateWalletAddress(user.address)} is not an admin wallet.
+                {truncateWalletAddress(walletAddress)} is not an admin wallet.
               </p>
               <p className="text-xs text-muted-foreground">
                 Admins:{" "}

--- a/app/songchain/song-cup/submissions/page.tsx
+++ b/app/songchain/song-cup/submissions/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useUser } from "@/lib/wallet/react";
 import { useSongCupSubmissions } from "@/lib/hooks/song-cup/useSongCupSubmissions";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -19,11 +18,19 @@ import {
 } from "@/lib/songchain/song-cup/admin-config";
 
 export default function SongCupSubmissionsPage() {
-  const user = useUser();
   const [statusFilter, setStatusFilter] = useState<SongCupSubmissionStatusFilter>("pending");
 
-  const { submissions, isLoading, error, refetch, updateStatus, setFavorite, isAdmin } =
-    useSongCupSubmissions(true);
+  const {
+    submissions,
+    isLoading,
+    error,
+    refetch,
+    updateStatus,
+    setFavorite,
+    isAdmin,
+    walletAddress,
+    isAdminLoading,
+  } = useSongCupSubmissions(true);
 
   const filtered = useMemo(
     () => filterSubmissionsByStatus(submissions, statusFilter),
@@ -62,7 +69,15 @@ export default function SongCupSubmissionsPage() {
           </Button>
         </div>
 
-        {!isAdmin && (
+        {isAdminLoading && (
+          <Card>
+            <CardContent className="py-4 text-sm text-muted-foreground">
+              Resolving smart wallet…
+            </CardContent>
+          </Card>
+        )}
+
+        {!isAdminLoading && !isAdmin && (
           <Card className="border-yellow-500/30 bg-yellow-950/20">
             <CardContent className="flex items-start gap-3 py-4">
               <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-500" />
@@ -129,9 +144,9 @@ export default function SongCupSubmissionsPage() {
           </div>
         )}
 
-        {isAdmin && user?.address && (
+        {isAdmin && walletAddress && (
           <p className="text-center text-xs text-muted-foreground">
-            Signed in as {truncateWalletAddress(user.address)}
+            Signed in as {truncateWalletAddress(walletAddress)}
           </p>
         )}
       </div>

--- a/components/User/MembershipVerifiedBadge.tsx
+++ b/components/User/MembershipVerifiedBadge.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useAddressHasMembership } from "@/lib/hooks/unlock/useAddressHasMembership";
+
+type MembershipVerifiedBadgeProps = {
+  address?: string | null;
+  /**
+   * Force show/hide when membership is already known by the parent.
+   * When omitted, membership is looked up for `address`.
+   */
+  show?: boolean;
+  className?: string;
+  title?: string;
+  size?: "sm" | "md";
+};
+
+const sizeClass = {
+  sm: "h-3.5 w-3.5",
+  md: "h-4 w-4",
+} as const;
+
+/**
+ * Twitter/Instagram-style verified badge for Unlock Creative Pass holders.
+ */
+export function MembershipVerifiedBadge({
+  address,
+  show,
+  className,
+  title = "Creative member",
+  size = "sm",
+}: MembershipVerifiedBadgeProps) {
+  const { hasMembership, isLoading } = useAddressHasMembership(
+    show === undefined ? address : null,
+  );
+
+  const visible = show ?? (!isLoading && hasMembership);
+  if (!visible) return null;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center text-[#1D9BF0]",
+        sizeClass[size],
+        className,
+      )}
+      title={title}
+      aria-label={title}
+    >
+      <svg
+        viewBox="0 0 22 22"
+        className="h-full w-full"
+        aria-hidden
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M11 0L13.59 2.06 16.79 1.44 17.76 4.56 20.88 5.53 20.26 8.73 22.32 11.32 20.26 13.91 20.88 17.11 17.76 18.08 16.79 21.2 13.59 20.58 11 22.64 8.41 20.58 5.21 21.2 4.24 18.08 1.12 17.11 1.74 13.91 0 11.32 1.74 8.73 1.12 5.53 4.24 4.56 5.21 1.44 8.41 2.06 11 0z"
+        />
+        <path
+          fill="#fff"
+          d="M9.55 14.9l-3.1-3.1 1.25-1.25 1.85 1.85 4.75-4.75 1.25 1.25-6 6z"
+        />
+      </svg>
+    </span>
+  );
+}

--- a/components/User/MembershipVerifiedBadge.tsx
+++ b/components/User/MembershipVerifiedBadge.tsx
@@ -23,7 +23,7 @@ const sizeClass = {
 
 /**
  * Twitter/Instagram-style verified badge for Unlock Creative Pass holders.
- * Brand Plus members get a gold badge; other members get blue.
+ * Brand Pass members get a gold badge; other members get blue.
  */
 export function MembershipVerifiedBadge({
   address,
@@ -39,7 +39,7 @@ export function MembershipVerifiedBadge({
   if (!visible) return null;
 
   const isBrand = brand ?? hasBrandMembership;
-  const title = isBrand ? "Creative Brand member" : "Creative member";
+  const title = isBrand ? "Creative Brand Pass" : "Creative member";
 
   return (
     <span

--- a/components/User/MembershipVerifiedBadge.tsx
+++ b/components/User/MembershipVerifiedBadge.tsx
@@ -10,8 +10,9 @@ type MembershipVerifiedBadgeProps = {
    * When omitted, membership is looked up for `address`.
    */
   show?: boolean;
+  /** Force brand (gold) vs standard (blue) when parent already knows the tier. */
+  brand?: boolean;
   className?: string;
-  title?: string;
   size?: "sm" | "md";
 };
 
@@ -22,25 +23,29 @@ const sizeClass = {
 
 /**
  * Twitter/Instagram-style verified badge for Unlock Creative Pass holders.
+ * Brand Plus members get a gold badge; other members get blue.
  */
 export function MembershipVerifiedBadge({
   address,
   show,
+  brand,
   className,
-  title = "Creative member",
   size = "sm",
 }: MembershipVerifiedBadgeProps) {
-  const { hasMembership, isLoading } = useAddressHasMembership(
-    show === undefined ? address : null,
-  );
+  const { hasMembership, hasBrandMembership, isLoading } =
+    useAddressHasMembership(show === undefined ? address : null);
 
   const visible = show ?? (!isLoading && hasMembership);
   if (!visible) return null;
 
+  const isBrand = brand ?? hasBrandMembership;
+  const title = isBrand ? "Creative Brand member" : "Creative member";
+
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-center justify-center text-[#1D9BF0]",
+        "inline-flex shrink-0 items-center justify-center",
+        isBrand ? "text-[#EAB308]" : "text-[#1D9BF0]",
         sizeClass[size],
         className,
       )}

--- a/components/User/UserDisplay.tsx
+++ b/components/User/UserDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { MembershipVerifiedBadge } from "@/components/User/MembershipVerifiedBadge";
 import { useMeTokenByOwner } from "@/lib/hooks/metokens/useMeTokenByOwner";
 import { useCreatorProfile } from "@/lib/hooks/metokens/useCreatorProfile";
 import { formatAddress } from "@/lib/helpers";
@@ -55,10 +56,8 @@ export function UserDisplay({
   className,
   variant = "inline",
 }: UserDisplayProps) {
-  const { meToken, loading: meTokenLoading } = useMeTokenByOwner(address);
-  const { profile, loading: profileLoading } = useCreatorProfile(address);
-
-  const isLoading = meTokenLoading || profileLoading;
+  const { meToken } = useMeTokenByOwner(address);
+  const { profile } = useCreatorProfile(address);
 
   // Determine what to display
   const displayName = profile?.username || meToken?.name || null;
@@ -89,18 +88,33 @@ export function UserDisplay({
       </Avatar>
       <div className={cn("flex flex-col", variant === "vertical" && "items-start")}>
         {displayName && (
-          <span className={cn("font-medium", textSizes[avatarSize])}>
+          <span className={cn("inline-flex items-center gap-1 font-medium", textSizes[avatarSize])}>
             {displayName}
+            <MembershipVerifiedBadge
+              address={address}
+              size={avatarSize === "lg" ? "md" : "sm"}
+            />
           </span>
         )}
         {displaySymbol && (
-          <span className={cn("text-muted-foreground", textSizes[avatarSize === "sm" ? "sm" : "xs"])}>
+          <span
+            className={cn(
+              "text-muted-foreground",
+              textSizes[avatarSize === "sm" ? "sm" : "xs"],
+            )}
+          >
             {displaySymbol}
           </span>
         )}
         {showAddress && (!displayName || !displaySymbol) && (
-          <span className={cn("text-muted-foreground font-mono", textSizes[avatarSize === "sm" ? "sm" : "xs"])}>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 font-mono text-muted-foreground",
+              textSizes[avatarSize === "sm" ? "sm" : "xs"],
+            )}
+          >
             {shortenAddress(address)}
+            {!displayName && <MembershipVerifiedBadge address={address} />}
           </span>
         )}
       </div>
@@ -109,7 +123,7 @@ export function UserDisplay({
 
   if (clickable) {
     return (
-      <Link href={`/profile/${address}`} className="hover:opacity-80 transition-opacity">
+      <Link href={`/profile/${address}`} className="transition-opacity hover:opacity-80">
         {content}
       </Link>
     );
@@ -150,11 +164,19 @@ export function UserDisplayCompact({
           {avatarFallback}
         </AvatarFallback>
       </Avatar>
-      <span className={cn("font-medium", textSizes[avatarSize])}>
-        {displayName || displaySymbol || (showAddress ? shortenAddress(address) : formatAddress(address))}
+      <span className={cn("inline-flex items-center gap-1 font-medium", textSizes[avatarSize])}>
+        {displayName ||
+          displaySymbol ||
+          (showAddress ? shortenAddress(address) : formatAddress(address))}
+        <MembershipVerifiedBadge address={address} />
       </span>
       {displaySymbol && displayName && (
-        <span className={cn("text-muted-foreground", textSizes[avatarSize === "sm" ? "sm" : "xs"])}>
+        <span
+          className={cn(
+            "text-muted-foreground",
+            textSizes[avatarSize === "sm" ? "sm" : "xs"],
+          )}
+        >
           ({displaySymbol})
         </span>
       )}
@@ -183,14 +205,21 @@ export function UserNameDisplay({
   const displaySymbol = meToken?.symbol || null;
 
   return (
-    <span className={cn("font-medium", textSizes[size], className)}>
-      {displayName || displaySymbol || (showAddress ? shortenAddress(address) : formatAddress(address))}
+    <span className={cn("inline-flex items-center gap-1 font-medium", textSizes[size], className)}>
+      {displayName ||
+        displaySymbol ||
+        (showAddress ? shortenAddress(address) : formatAddress(address))}
+      <MembershipVerifiedBadge address={address} size={size === "lg" ? "md" : "sm"} />
       {displaySymbol && displayName && (
-        <span className={cn("text-muted-foreground ml-1", textSizes[size === "sm" ? "sm" : "xs"])}>
+        <span
+          className={cn(
+            "ml-0.5 text-muted-foreground",
+            textSizes[size === "sm" ? "sm" : "xs"],
+          )}
+        >
           ({displaySymbol})
         </span>
       )}
     </span>
   );
 }
-

--- a/components/Videos/VideoCard.tsx
+++ b/components/Videos/VideoCard.tsx
@@ -22,6 +22,7 @@ import { fetchVideoAssetByPlaybackId } from "@/lib/utils/video-assets-client";
 import VideoThumbnail from "./VideoThumbnail";
 import { ShareDialog } from "./ShareDialog";
 import { useCreatorProfile } from "@/lib/hooks/metokens/useCreatorProfile";
+import { MembershipVerifiedBadge } from "@/components/User/MembershipVerifiedBadge";
 import { VideoBuyButton } from "./VideoBuyButton";
 import { logger } from "@/lib/utils/logger";
 import { useIsVideoAdmin } from "@/hooks/useIsVideoAdmin";
@@ -296,8 +297,9 @@ const VideoCard: React.FC<VideoCardProps> = ({
                 </AvatarFallback>
               </Avatar>
               <div className="flex flex-col">
-                <span className="text-sm font-medium">
+                <span className="inline-flex items-center gap-1 text-sm font-medium">
                   {creatorProfile?.username || shortenAddress(address)}
+                  <MembershipVerifiedBadge address={address} />
                 </span>
               </div>
             </Link>

--- a/components/Videos/VideoDetails.tsx
+++ b/components/Videos/VideoDetails.tsx
@@ -713,10 +713,10 @@ export default function VideoDetails({
                 <div className="flex flex-col items-center gap-6 p-8 max-w-md text-center">
                   <div className="flex flex-col gap-2">
                     <h2 className="text-2xl font-bold text-white">
-                      Connect Your Wallet
+                      Connect Your Account
                     </h2>
                     <p className="text-gray-300">
-                      Please connect your wallet to watch this video.
+                      Please select &quot;Get Started&quot; to watch this video.
                     </p>
                   </div>
                   <Button

--- a/components/chones/ChonesXFollowStrip.tsx
+++ b/components/chones/ChonesXFollowStrip.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Twitter } from "lucide-react";
-import { CHONES_X_HANDLE, CHONES_X_URL } from "@/lib/chones/social";
+import {
+  CHONES_X_HANDLE,
+  CHONES_X_URL,
+  NEARCHOS_X_HANDLE,
+  NEARCHOS_X_URL,
+} from "@/lib/chones/social";
 import { cn } from "@/lib/utils";
 
 type ChonesXFollowStripProps = {
@@ -32,12 +37,12 @@ export function ChonesXFollowStrip({ className }: ChonesXFollowStripProps) {
         ·
       </span>
       <a
-        href="https://x.com/trigs_0"
+        href={NEARCHOS_X_URL}
         target="_blank"
         rel="noopener noreferrer"
         className="rounded-md px-2 py-1 text-amber-600 transition hover:bg-amber-500/10 hover:text-amber-500 dark:text-amber-300"
       >
-        @trigs_0
+        @{NEARCHOS_X_HANDLE}
       </a>
     </div>
   );

--- a/components/songchain/SongchainPostCard.tsx
+++ b/components/songchain/SongchainPostCard.tsx
@@ -38,6 +38,7 @@ import { useLensOrbWrite } from "@/hooks/useLensOrbWrite";
 import { groveService } from "@/lib/sdk/grove/service";
 import { clearStaleOrbSessionIfNeeded } from "@/lib/sdk/orb/session-errors";
 import { SongchainAuthorTimeline } from "@/components/songchain/SongchainAuthorTimeline";
+import { MembershipVerifiedBadge } from "@/components/User/MembershipVerifiedBadge";
 import { SongchainQuotedPostEmbed } from "@/components/songchain/SongchainQuotedPostEmbed";
 import { SongchainPostContent } from "@/components/songchain/SongchainPostContent";
 import { SongchainFollowButton } from "@/components/songchain/SongchainGraphPanel";
@@ -331,12 +332,19 @@ export function SongchainPostCard({
             <button
               type="button"
               className={cn(
-                "text-left hover:text-violet-400 w-fit",
+                "inline-flex w-fit items-center gap-1 text-left hover:text-violet-400",
                 variant === "song-cup" ? cn("text-xs", songCupMuted) : "text-xs text-muted-foreground",
               )}
               onClick={() => setTimelineOpen(true)}
             >
               {authorLabel(isQuote ? post : content)}
+              <MembershipVerifiedBadge
+                address={
+                  isQuote
+                    ? post.author.address
+                    : content?.author.address ?? post.author.address
+                }
+              />
             </button>
             {content && variant !== "song-cup" && (
               <SongchainFollowButton

--- a/lib/chones/social.ts
+++ b/lib/chones/social.ts
@@ -1,8 +1,10 @@
 export const CHONES_X_HANDLE = "ChonesWeaving";
 export const CREATIVE_TV_X_HANDLE = "CreativeCrtv";
+export const NEARCHOS_X_HANDLE = "Nearchos_xyz";
 
 export const CHONES_X_URL = `https://x.com/${CHONES_X_HANDLE}`;
 export const CREATIVE_TV_X_URL = `https://x.com/${CREATIVE_TV_X_HANDLE}`;
+export const NEARCHOS_X_URL = `https://x.com/${NEARCHOS_X_HANDLE}`;
 
 export const HACK_BETA_HASHTAG = "ChonesHackBeta";
 
@@ -16,7 +18,7 @@ export function buildHackBetaShareText(opts?: {
     title
       ? `Check out my HACKATHON BETA demo: ${title}`
       : "Check out Chones HACKATHON BETA on Creative TV",
-    `@${CHONES_X_HANDLE} @${CREATIVE_TV_X_HANDLE} #${HACK_BETA_HASHTAG}`,
+    `@${CHONES_X_HANDLE} @${CREATIVE_TV_X_HANDLE} @${NEARCHOS_X_HANDLE} #${HACK_BETA_HASHTAG}`,
   ];
   if (pageUrl) lines.push(pageUrl);
   return lines.join("\n\n");

--- a/lib/hooks/hack-beta/useHackBetaAdmin.ts
+++ b/lib/hooks/hack-beta/useHackBetaAdmin.ts
@@ -1,16 +1,24 @@
 "use client";
 
 import { useMemo } from "react";
-import { useUser } from "@/lib/wallet/react";
+import { useCreatorWalletAddress } from "@/lib/hooks/accountkit/useCreatorWalletAddress";
 import { isHackBetaAdminWallet } from "@/lib/chones/hack-beta/admin-config";
 
 export function useHackBetaAdmin() {
-  const user = useUser();
+  const { creatorAddress, smartAccountAddress, eoaAddress, isLoading } =
+    useCreatorWalletAddress();
 
+  // Admin lists store smart-wallet addresses; also accept EOA if listed.
   const isAdmin = useMemo(
-    () => isHackBetaAdminWallet(user?.address),
-    [user?.address],
+    () =>
+      isHackBetaAdminWallet(smartAccountAddress) ||
+      isHackBetaAdminWallet(eoaAddress),
+    [smartAccountAddress, eoaAddress],
   );
 
-  return { isAdmin, walletAddress: user?.address ?? null };
+  return {
+    isAdmin,
+    walletAddress: creatorAddress,
+    isLoading,
+  };
 }

--- a/lib/hooks/hack-beta/useHackBetaSubmissions.ts
+++ b/lib/hooks/hack-beta/useHackBetaSubmissions.ts
@@ -1,24 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { useUser } from "@/lib/wallet/react";
+import { useState, useEffect, useCallback } from "react";
 import {
   hackBetaSubmissionsService,
   type HackBetaSubmission,
 } from "@/lib/sdk/supabase/hack-beta-submissions";
-import { isHackBetaAdminWallet } from "@/lib/chones/hack-beta/admin-config";
+import { useHackBetaAdmin } from "@/lib/hooks/hack-beta/useHackBetaAdmin";
 import { logger } from "@/lib/utils/logger";
 
 export function useHackBetaSubmissions(enabled: boolean = true) {
-  const user = useUser();
+  const { isAdmin, walletAddress, isLoading: isAdminLoading } = useHackBetaAdmin();
   const [submissions, setSubmissions] = useState<HackBetaSubmission[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const isAdmin = useMemo(
-    () => isHackBetaAdminWallet(user?.address),
-    [user?.address],
-  );
 
   const fetchRows = useCallback(async () => {
     if (!isAdmin || !enabled) {
@@ -84,5 +78,7 @@ export function useHackBetaSubmissions(enabled: boolean = true) {
     updateStatus,
     setFavorite,
     isAdmin,
+    walletAddress,
+    isAdminLoading,
   };
 }

--- a/lib/hooks/song-cup/useSongCupAdmin.ts
+++ b/lib/hooks/song-cup/useSongCupAdmin.ts
@@ -1,16 +1,24 @@
 "use client";
 
 import { useMemo } from "react";
-import { useUser } from "@/lib/wallet/react";
+import { useCreatorWalletAddress } from "@/lib/hooks/accountkit/useCreatorWalletAddress";
 import { isSongCupAdminWallet } from "@/lib/songchain/song-cup/admin-config";
 
 export function useSongCupAdmin() {
-  const user = useUser();
+  const { creatorAddress, smartAccountAddress, eoaAddress, isLoading } =
+    useCreatorWalletAddress();
 
+  // Admin lists store smart-wallet addresses; also accept EOA if listed.
   const isAdmin = useMemo(
-    () => isSongCupAdminWallet(user?.address),
-    [user?.address],
+    () =>
+      isSongCupAdminWallet(smartAccountAddress) ||
+      isSongCupAdminWallet(eoaAddress),
+    [smartAccountAddress, eoaAddress],
   );
 
-  return { isAdmin, walletAddress: user?.address ?? null };
+  return {
+    isAdmin,
+    walletAddress: creatorAddress,
+    isLoading,
+  };
 }

--- a/lib/hooks/song-cup/useSongCupSubmissions.ts
+++ b/lib/hooks/song-cup/useSongCupSubmissions.ts
@@ -1,24 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { useUser } from "@/lib/wallet/react";
+import { useState, useEffect, useCallback } from "react";
 import {
   songCupSubmissionsService,
   type SongCupSubmission,
 } from "@/lib/sdk/supabase/song-cup-submissions";
-import { isSongCupAdminWallet } from "@/lib/songchain/song-cup/admin-config";
+import { useSongCupAdmin } from "@/lib/hooks/song-cup/useSongCupAdmin";
 import { logger } from "@/lib/utils/logger";
 
 export function useSongCupSubmissions(enabled: boolean = true) {
-  const user = useUser();
+  const { isAdmin, walletAddress, isLoading: isAdminLoading } = useSongCupAdmin();
   const [submissions, setSubmissions] = useState<SongCupSubmission[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const isAdmin = useMemo(
-    () => isSongCupAdminWallet(user?.address),
-    [user?.address],
-  );
 
   const fetch = useCallback(async () => {
     if (!isAdmin || !enabled) {
@@ -75,5 +69,15 @@ export function useSongCupSubmissions(enabled: boolean = true) {
     return ok;
   }, []);
 
-  return { submissions, isLoading, error, refetch: fetch, updateStatus, setFavorite, isAdmin };
+  return {
+    submissions,
+    isLoading,
+    error,
+    refetch: fetch,
+    updateStatus,
+    setFavorite,
+    isAdmin,
+    walletAddress,
+    isAdminLoading,
+  };
 }

--- a/lib/hooks/unlock/useAddressHasMembership.ts
+++ b/lib/hooks/unlock/useAddressHasMembership.ts
@@ -2,9 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { isAddress } from "viem";
+import { hasValidBrandPass } from "@/lib/access/creator-membership";
 
 type MembershipApiItem = {
   name?: string;
+  address?: string;
   isValid?: boolean;
 };
 
@@ -15,7 +17,7 @@ type MembershipApiResponse = {
 
 export type AddressMembershipStatus = {
   hasMembership: boolean;
-  /** Valid Creative Brand Plus lock. */
+  /** Valid Creative Brand Pass (or legacy Brand Plus). */
   hasBrandMembership: boolean;
 };
 
@@ -30,12 +32,15 @@ const inflight = new Map<string, Promise<AddressMembershipStatus>>();
 function summarizeMemberships(
   memberships: MembershipApiItem[] | undefined,
 ): AddressMembershipStatus {
-  const valid = memberships?.filter((m) => m.isValid === true) ?? [];
-  const hasBrandMembership = valid.some(
-    (m) => m.name === "BASE_CREATIVE_BRAND_PLUS",
-  );
+  const withAddress =
+    memberships?.filter(
+      (m): m is MembershipApiItem & { address: string } =>
+        typeof m.address === "string" && m.address.length > 0,
+    ) ?? [];
+  const hasMembership = withAddress.some((m) => m.isValid === true);
+  const hasBrandMembership = hasValidBrandPass(withAddress);
   return {
-    hasMembership: valid.length > 0,
+    hasMembership,
     hasBrandMembership,
   };
 }
@@ -79,7 +84,7 @@ async function fetchMembershipStatus(
 
 /**
  * Whether `address` holds a valid Unlock Creative membership (any lock),
- * and whether Brand Plus specifically is held (gold badge).
+ * and whether Brand Pass specifically is held (gold badge).
  * Results are cached in-memory for the session.
  */
 export function useAddressHasMembership(address?: string | null) {

--- a/lib/hooks/unlock/useAddressHasMembership.ts
+++ b/lib/hooks/unlock/useAddressHasMembership.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isAddress } from "viem";
+
+type MembershipApiResponse = {
+  memberships?: Array<{ isValid?: boolean }>;
+  error?: string;
+};
+
+const cache = new Map<string, boolean>();
+const inflight = new Map<string, Promise<boolean>>();
+
+async function fetchHasMembership(address: string): Promise<boolean> {
+  const key = address.toLowerCase();
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const res = await fetch("/api/membership", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ address: key }),
+      });
+      if (!res.ok) {
+        cache.set(key, false);
+        return false;
+      }
+      const data = (await res.json()) as MembershipApiResponse;
+      const hasMembership = Boolean(
+        data.memberships?.some((m) => m.isValid === true),
+      );
+      cache.set(key, hasMembership);
+      return hasMembership;
+    } catch {
+      cache.set(key, false);
+      return false;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Whether `address` holds a valid Unlock Creative membership (any lock).
+ * Results are cached in-memory for the session to avoid repeat RPC lookups.
+ */
+export function useAddressHasMembership(address?: string | null) {
+  const normalized =
+    address && isAddress(address) ? address.toLowerCase() : null;
+  const [hasMembership, setHasMembership] = useState(() =>
+    normalized ? (cache.get(normalized) ?? false) : false,
+  );
+  const [isLoading, setIsLoading] = useState(() =>
+    normalized ? !cache.has(normalized) : false,
+  );
+
+  useEffect(() => {
+    if (!normalized) {
+      setHasMembership(false);
+      setIsLoading(false);
+      return;
+    }
+
+    if (cache.has(normalized)) {
+      setHasMembership(cache.get(normalized) ?? false);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    void fetchHasMembership(normalized).then((value) => {
+      if (cancelled) return;
+      setHasMembership(value);
+      setIsLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalized]);
+
+  return { hasMembership, isLoading };
+}

--- a/lib/hooks/unlock/useAddressHasMembership.ts
+++ b/lib/hooks/unlock/useAddressHasMembership.ts
@@ -3,15 +3,46 @@
 import { useEffect, useState } from "react";
 import { isAddress } from "viem";
 
+type MembershipApiItem = {
+  name?: string;
+  isValid?: boolean;
+};
+
 type MembershipApiResponse = {
-  memberships?: Array<{ isValid?: boolean }>;
+  memberships?: MembershipApiItem[];
   error?: string;
 };
 
-const cache = new Map<string, boolean>();
-const inflight = new Map<string, Promise<boolean>>();
+export type AddressMembershipStatus = {
+  hasMembership: boolean;
+  /** Valid Creative Brand Plus lock. */
+  hasBrandMembership: boolean;
+};
 
-async function fetchHasMembership(address: string): Promise<boolean> {
+const EMPTY_STATUS: AddressMembershipStatus = {
+  hasMembership: false,
+  hasBrandMembership: false,
+};
+
+const cache = new Map<string, AddressMembershipStatus>();
+const inflight = new Map<string, Promise<AddressMembershipStatus>>();
+
+function summarizeMemberships(
+  memberships: MembershipApiItem[] | undefined,
+): AddressMembershipStatus {
+  const valid = memberships?.filter((m) => m.isValid === true) ?? [];
+  const hasBrandMembership = valid.some(
+    (m) => m.name === "BASE_CREATIVE_BRAND_PLUS",
+  );
+  return {
+    hasMembership: valid.length > 0,
+    hasBrandMembership,
+  };
+}
+
+async function fetchMembershipStatus(
+  address: string,
+): Promise<AddressMembershipStatus> {
   const key = address.toLowerCase();
   const cached = cache.get(key);
   if (cached !== undefined) return cached;
@@ -27,18 +58,16 @@ async function fetchHasMembership(address: string): Promise<boolean> {
         body: JSON.stringify({ address: key }),
       });
       if (!res.ok) {
-        cache.set(key, false);
-        return false;
+        cache.set(key, EMPTY_STATUS);
+        return EMPTY_STATUS;
       }
       const data = (await res.json()) as MembershipApiResponse;
-      const hasMembership = Boolean(
-        data.memberships?.some((m) => m.isValid === true),
-      );
-      cache.set(key, hasMembership);
-      return hasMembership;
+      const status = summarizeMemberships(data.memberships);
+      cache.set(key, status);
+      return status;
     } catch {
-      cache.set(key, false);
-      return false;
+      cache.set(key, EMPTY_STATUS);
+      return EMPTY_STATUS;
     } finally {
       inflight.delete(key);
     }
@@ -49,14 +78,15 @@ async function fetchHasMembership(address: string): Promise<boolean> {
 }
 
 /**
- * Whether `address` holds a valid Unlock Creative membership (any lock).
- * Results are cached in-memory for the session to avoid repeat RPC lookups.
+ * Whether `address` holds a valid Unlock Creative membership (any lock),
+ * and whether Brand Plus specifically is held (gold badge).
+ * Results are cached in-memory for the session.
  */
 export function useAddressHasMembership(address?: string | null) {
   const normalized =
     address && isAddress(address) ? address.toLowerCase() : null;
-  const [hasMembership, setHasMembership] = useState(() =>
-    normalized ? (cache.get(normalized) ?? false) : false,
+  const [status, setStatus] = useState<AddressMembershipStatus>(() =>
+    normalized ? (cache.get(normalized) ?? EMPTY_STATUS) : EMPTY_STATUS,
   );
   const [isLoading, setIsLoading] = useState(() =>
     normalized ? !cache.has(normalized) : false,
@@ -64,22 +94,22 @@ export function useAddressHasMembership(address?: string | null) {
 
   useEffect(() => {
     if (!normalized) {
-      setHasMembership(false);
+      setStatus(EMPTY_STATUS);
       setIsLoading(false);
       return;
     }
 
     if (cache.has(normalized)) {
-      setHasMembership(cache.get(normalized) ?? false);
+      setStatus(cache.get(normalized) ?? EMPTY_STATUS);
       setIsLoading(false);
       return;
     }
 
     let cancelled = false;
     setIsLoading(true);
-    void fetchHasMembership(normalized).then((value) => {
+    void fetchMembershipStatus(normalized).then((value) => {
       if (cancelled) return;
-      setHasMembership(value);
+      setStatus(value);
       setIsLoading(false);
     });
 
@@ -88,5 +118,9 @@ export function useAddressHasMembership(address?: string | null) {
     };
   }, [normalized]);
 
-  return { hasMembership, isLoading };
+  return {
+    hasMembership: status.hasMembership,
+    hasBrandMembership: status.hasBrandMembership,
+    isLoading,
+  };
 }


### PR DESCRIPTION
## Summary
- Soften unsigned video overlay copy to “Connect Your Account” / select Get Started (no wallet jargon).
- Replace `@trigs_0` with `@Nearchos_xyz` in the Chones follow strip and Hack Beta predefined share tweet.
- Fix Hack Beta / Song Cup admin detection to prefer smart-wallet (SCA) addresses so listed admins can open submission review.
- Show a Twitter-style Unlock membership verified badge next to usernames (UserDisplay, discover VideoCard, Songchain posts):
  - **Blue** for Creative Pass members (Creator / Investor)
  - **Gold** for Creative Brand Pass members (legacy Brand Plus still recognized)

## Test plan
- [ ] Open a discover video while signed out → overlay shows new copy and Get Started still opens auth.
- [ ] On `/chones/hack-beta`, follow strip links to `@Nearchos_xyz`; Share on X includes `@Nearchos_xyz`.
- [ ] Sign in with admin SCA `0xdE4b…1734` → “Admin submissions” appears; `/chones/hack-beta/submissions` unlocks Approve/Reject.
- [ ] Same SCA admin check works on Song Cup submissions page.
- [ ] Non-admin wallet still sees the not-admin message after smart wallet resolves.
- [ ] Standard Creator/Investor Pass address shows **blue** verified badge.
- [ ] Creative Brand Pass address shows **gold** verified badge.
- [ ] Non-member address shows no badge.