### PR TITLE
fix: narrow membership API types for Brand Pass badge

### DIFF
--- a/lib/hooks/unlock/useAddressHasMembership.ts
+++ b/lib/hooks/unlock/useAddressHasMembership.ts
@@ -32,13 +32,17 @@ const inflight = new Map<string, Promise<AddressMembershipStatus>>();
 function summarizeMemberships(
   memberships: MembershipApiItem[] | undefined,
 ): AddressMembershipStatus {
-  const withAddress =
-    memberships?.filter(
-      (m): m is MembershipApiItem & { address: string } =>
-        typeof m.address === "string" && m.address.length > 0,
-    ) ?? [];
-  const hasMembership = withAddress.some((m) => m.isValid === true);
-  const hasBrandMembership = hasValidBrandPass(withAddress);
+  const normalized =
+    memberships
+      ?.filter(
+        (m): m is MembershipApiItem & { address: string; isValid: boolean } =>
+          typeof m.address === "string" &&
+          m.address.length > 0 &&
+          typeof m.isValid === "boolean",
+      )
+      .map((m) => ({ address: m.address, isValid: m.isValid })) ?? [];
+  const hasMembership = normalized.some((m) => m.isValid);
+  const hasBrandMembership = hasValidBrandPass(normalized);
   return {
     hasMembership,
     hasBrandMembership,


### PR DESCRIPTION
## Summary
- Fixes the production TypeScript build failure from #299 where `isValid` was `boolean | undefined` but `hasValidBrandPass` expects `MembershipLike` with `isValid: boolean`.
- Narrows membership API items before the Brand Pass gold-badge check.

## Test plan
- [ ] Vercel / `yarn run build` TypeScript step passes.
- [ ] Brand Pass holders still show gold verified badge.
- [ ] Other Creative Pass holders still show blue badge.


Made with [Cursor](https://cursor.com)