### PR TITLE
fix: admin submissions visible via service-role APIs

### DIFF
--- a/app/api/hack-beta/admin/settings/route.ts
+++ b/app/api/hack-beta/admin/settings/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireWalletAuth, WalletAuthError } from "@/lib/auth/require-wallet";
+import { isHackBetaAdminWallet } from "@/lib/chones/hack-beta/admin-config";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import { updateHackBetaMixtapeUrlAsAdmin } from "@/lib/sdk/supabase/hack-beta-admin";
+import { serverLogger } from "@/lib/utils/logger";
+
+const bodySchema = z.object({
+  mixtape_playlist_url: z.string().nullable(),
+});
+
+/**
+ * PATCH /api/hack-beta/admin/settings — update mixtape URL (admin + service role).
+ */
+export async function PATCH(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const { address } = await requireWalletAuth(req);
+    if (!isHackBetaAdminWallet(address)) {
+      return NextResponse.json({ error: "Admin wallet required" }, { status: 403 });
+    }
+
+    const json = await req.json();
+    const parsed = bodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const settings = await updateHackBetaMixtapeUrlAsAdmin(
+      parsed.data.mixtape_playlist_url,
+      address,
+    );
+    if (!settings) {
+      return NextResponse.json({ error: "Failed to save mixtape URL" }, { status: 500 });
+    }
+
+    return NextResponse.json({ settings });
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    serverLogger.error("[hack-beta/admin/settings] PATCH failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to update settings" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/hack-beta/admin/submissions/route.ts
+++ b/app/api/hack-beta/admin/submissions/route.ts
@@ -16,6 +16,10 @@ import { serverLogger } from "@/lib/utils/logger";
  * Wallet-auth + admin-list check; returns all statuses via service role.
  */
 export async function GET(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 

--- a/app/api/hack-beta/admin/submissions/route.ts
+++ b/app/api/hack-beta/admin/submissions/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireWalletAuth, WalletAuthError } from "@/lib/auth/require-wallet";
+import { isHackBetaAdminWallet } from "@/lib/chones/hack-beta/admin-config";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import {
+  listHackBetaSubmissionsAsAdmin,
+  setHackBetaSubmissionFavoriteAsAdmin,
+  updateHackBetaSubmissionStatusAsAdmin,
+} from "@/lib/sdk/supabase/hack-beta-admin";
+import { serverLogger } from "@/lib/utils/logger";
+
+/**
+ * GET /api/hack-beta/admin/submissions
+ * Wallet-auth + admin-list check; returns all statuses via service role.
+ */
+export async function GET(req: NextRequest) {
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const { address } = await requireWalletAuth(req);
+    if (!isHackBetaAdminWallet(address)) {
+      return NextResponse.json({ error: "Admin wallet required" }, { status: 403 });
+    }
+
+    const submissions = await listHackBetaSubmissionsAsAdmin();
+    return NextResponse.json({ submissions });
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    serverLogger.error("[hack-beta/admin/submissions] GET failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to list submissions" },
+      { status: 500 },
+    );
+  }
+}
+
+const patchSchema = z
+  .object({
+    id: z.string().uuid(),
+    status: z.enum(["pending", "approved", "rejected"]).optional(),
+    is_favorite: z.boolean().optional(),
+  })
+  .refine((b) => b.status !== undefined || b.is_favorite !== undefined, {
+    message: "Provide status and/or is_favorite",
+  });
+
+/**
+ * PATCH /api/hack-beta/admin/submissions
+ * Approve/reject or favorite a submission (service role after wallet admin check).
+ */
+export async function PATCH(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const { address } = await requireWalletAuth(req);
+    if (!isHackBetaAdminWallet(address)) {
+      return NextResponse.json({ error: "Admin wallet required" }, { status: 403 });
+    }
+
+    const json = await req.json();
+    const parsed = patchSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const { id, status, is_favorite } = parsed.data;
+
+    if (is_favorite !== undefined) {
+      const ok = await setHackBetaSubmissionFavoriteAsAdmin(id, is_favorite);
+      if (!ok) {
+        return NextResponse.json({ error: "Failed to update favorite" }, { status: 500 });
+      }
+    }
+
+    if (status !== undefined) {
+      const ok = await updateHackBetaSubmissionStatusAsAdmin(id, status);
+      if (!ok) {
+        return NextResponse.json({ error: "Failed to update status" }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    serverLogger.error("[hack-beta/admin/submissions] PATCH failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to update submission" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/song-cup/admin/submissions/route.ts
+++ b/app/api/song-cup/admin/submissions/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireWalletAuth, WalletAuthError } from "@/lib/auth/require-wallet";
+import { isSongCupAdminWallet } from "@/lib/songchain/song-cup/admin-config";
+import { checkBotIdDeep } from "@/lib/middleware/botIdGuard";
+import { rateLimiters } from "@/lib/middleware/rateLimit";
+import {
+  listSongCupSubmissionsAsAdmin,
+  setSongCupSubmissionFavoriteAsAdmin,
+  updateSongCupSubmissionStatusAsAdmin,
+} from "@/lib/sdk/supabase/song-cup-admin";
+import { serverLogger } from "@/lib/utils/logger";
+
+/**
+ * GET /api/song-cup/admin/submissions
+ * Wallet-auth + admin-list check; returns all statuses via service role.
+ */
+export async function GET(req: NextRequest) {
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const { address } = await requireWalletAuth(req);
+    if (!isSongCupAdminWallet(address)) {
+      return NextResponse.json({ error: "Admin wallet required" }, { status: 403 });
+    }
+
+    const submissions = await listSongCupSubmissionsAsAdmin();
+    return NextResponse.json({ submissions });
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    serverLogger.error("[song-cup/admin/submissions] GET failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to list submissions" },
+      { status: 500 },
+    );
+  }
+}
+
+const patchSchema = z
+  .object({
+    id: z.string().uuid(),
+    status: z.enum(["pending", "approved", "rejected"]).optional(),
+    is_favorite: z.boolean().optional(),
+  })
+  .refine((b) => b.status !== undefined || b.is_favorite !== undefined, {
+    message: "Provide status and/or is_favorite",
+  });
+
+/**
+ * PATCH /api/song-cup/admin/submissions
+ * Approve/reject or favorite a submission (service role after wallet admin check).
+ */
+export async function PATCH(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+  const rl = await rateLimiters.standard(req);
+  if (rl) return rl;
+
+  try {
+    const { address } = await requireWalletAuth(req);
+    if (!isSongCupAdminWallet(address)) {
+      return NextResponse.json({ error: "Admin wallet required" }, { status: 403 });
+    }
+
+    const json = await req.json();
+    const parsed = patchSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const { id, status, is_favorite } = parsed.data;
+
+    if (is_favorite !== undefined) {
+      const ok = await setSongCupSubmissionFavoriteAsAdmin(id, is_favorite);
+      if (!ok) {
+        return NextResponse.json({ error: "Failed to update favorite" }, { status: 500 });
+      }
+    }
+
+    if (status !== undefined) {
+      const ok = await updateSongCupSubmissionStatusAsAdmin(id, status);
+      if (!ok) {
+        return NextResponse.json({ error: "Failed to update status" }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (error instanceof WalletAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    serverLogger.error("[song-cup/admin/submissions] PATCH failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to update submission" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/song-cup/admin/submissions/route.ts
+++ b/app/api/song-cup/admin/submissions/route.ts
@@ -16,6 +16,10 @@ import { serverLogger } from "@/lib/utils/logger";
  * Wallet-auth + admin-list check; returns all statuses via service role.
  */
 export async function GET(req: NextRequest) {
+  const verification = await checkBotIdDeep();
+  if (verification.isBot) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
   const rl = await rateLimiters.standard(req);
   if (rl) return rl;
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -76,7 +76,10 @@ if (!botIdGlobal.__crtvBotIdInit) {
       botIdDeepAnalysisRoute('/api/stickers/record-claim', 'POST'),
       botIdDeepAnalysisRoute('/api/stickers/tips', 'POST'),
       botIdDeepAnalysisRoute('/api/hack-beta/submit', 'POST'),
+      botIdDeepAnalysisRoute('/api/hack-beta/admin/submissions', 'PATCH'),
+      botIdDeepAnalysisRoute('/api/hack-beta/admin/settings', 'PATCH'),
       botIdDeepAnalysisRoute('/api/song-cup/submit', 'POST'),
+      botIdDeepAnalysisRoute('/api/song-cup/admin/submissions', 'PATCH'),
       botIdDeepAnalysisRoute('/api/heartbit/mint', 'POST'),
       // claim-status omitted: read-only on-chain claim lookup; BotID 403 breaks list badges.
       botIdDeepAnalysisRoute('/api/search/videos', 'GET'),

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -76,9 +76,11 @@ if (!botIdGlobal.__crtvBotIdInit) {
       botIdDeepAnalysisRoute('/api/stickers/record-claim', 'POST'),
       botIdDeepAnalysisRoute('/api/stickers/tips', 'POST'),
       botIdDeepAnalysisRoute('/api/hack-beta/submit', 'POST'),
+      botIdDeepAnalysisRoute('/api/hack-beta/admin/submissions', 'GET'),
       botIdDeepAnalysisRoute('/api/hack-beta/admin/submissions', 'PATCH'),
       botIdDeepAnalysisRoute('/api/hack-beta/admin/settings', 'PATCH'),
       botIdDeepAnalysisRoute('/api/song-cup/submit', 'POST'),
+      botIdDeepAnalysisRoute('/api/song-cup/admin/submissions', 'GET'),
       botIdDeepAnalysisRoute('/api/song-cup/admin/submissions', 'PATCH'),
       botIdDeepAnalysisRoute('/api/heartbit/mint', 'POST'),
       // claim-status omitted: read-only on-chain claim lookup; BotID 403 breaks list badges.

--- a/lib/hooks/hack-beta/useHackBetaSettings.ts
+++ b/lib/hooks/hack-beta/useHackBetaSettings.ts
@@ -5,9 +5,11 @@ import {
   hackBetaSettingsService,
   type HackBetaSettings,
 } from "@/lib/sdk/supabase/hack-beta-settings";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { logger } from "@/lib/utils/logger";
 
 export function useHackBetaSettings() {
+  const { getAuthHeaders, isReady } = useWalletAuth();
   const [settings, setSettings] = useState<HackBetaSettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -29,12 +31,35 @@ export function useHackBetaSettings() {
   }, [refetch]);
 
   const updateMixtapeUrl = useCallback(
-    async (url: string | null, updatedBy?: string | null) => {
-      const row = await hackBetaSettingsService.updateMixtapeUrl(url, updatedBy);
-      if (row) setSettings(row);
-      return row;
+    async (url: string | null, _updatedBy?: string | null) => {
+      if (!isReady) {
+        logger.error("[useHackBetaSettings] wallet auth not ready");
+        return null;
+      }
+      try {
+        const authHeaders = await getAuthHeaders();
+        const res = await fetch("/api/hack-beta/admin/settings", {
+          method: "PATCH",
+          headers: {
+            ...authHeaders,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ mixtape_playlist_url: url }),
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { error?: string } | null;
+          logger.error("[useHackBetaSettings] update failed:", body ?? res.status);
+          return null;
+        }
+        const json = (await res.json()) as { settings?: HackBetaSettings };
+        if (json.settings) setSettings(json.settings);
+        return json.settings ?? null;
+      } catch (err) {
+        logger.error("[useHackBetaSettings] update exception:", err);
+        return null;
+      }
     },
-    [],
+    [getAuthHeaders, isReady],
   );
 
   return {

--- a/lib/hooks/hack-beta/useHackBetaSubmissions.ts
+++ b/lib/hooks/hack-beta/useHackBetaSubmissions.ts
@@ -52,23 +52,32 @@ export function useHackBetaSubmissions(enabled: boolean = true) {
       status?: HackBetaSubmission["status"];
       is_favorite?: boolean;
     }) => {
-      const authHeaders = await getAuthHeaders();
-      const res = await fetch("/api/hack-beta/admin/submissions", {
-        method: "PATCH",
-        headers: {
-          ...authHeaders,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
-        logger.error("[useHackBetaSubmissions] patch failed:", errBody ?? res.status);
+      if (!isReady) {
+        logger.error("[useHackBetaSubmissions] patch skipped: wallet auth not ready");
         return false;
       }
-      return true;
+      try {
+        const authHeaders = await getAuthHeaders();
+        const res = await fetch("/api/hack-beta/admin/submissions", {
+          method: "PATCH",
+          headers: {
+            ...authHeaders,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
+          logger.error("[useHackBetaSubmissions] patch failed:", errBody ?? res.status);
+          return false;
+        }
+        return true;
+      } catch (err) {
+        logger.error("[useHackBetaSubmissions] patch exception:", err);
+        return false;
+      }
     },
-    [getAuthHeaders],
+    [getAuthHeaders, isReady],
   );
 
   const updateStatus = useCallback(
@@ -110,7 +119,7 @@ export function useHackBetaSubmissions(enabled: boolean = true) {
 
   return {
     submissions,
-    isLoading: isLoading || isAdminLoading,
+    isLoading: isLoading || isAdminLoading || (isAdmin && !isReady),
     error,
     refetch: fetchRows,
     updateStatus,
@@ -118,5 +127,6 @@ export function useHackBetaSubmissions(enabled: boolean = true) {
     isAdmin,
     walletAddress,
     isAdminLoading,
+    isReady,
   };
 }

--- a/lib/hooks/hack-beta/useHackBetaSubmissions.ts
+++ b/lib/hooks/hack-beta/useHackBetaSubmissions.ts
@@ -1,44 +1,79 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import {
-  hackBetaSubmissionsService,
-  type HackBetaSubmission,
-} from "@/lib/sdk/supabase/hack-beta-submissions";
+import type { HackBetaSubmission } from "@/lib/sdk/supabase/hack-beta-submissions";
 import { useHackBetaAdmin } from "@/lib/hooks/hack-beta/useHackBetaAdmin";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { logger } from "@/lib/utils/logger";
 
 export function useHackBetaSubmissions(enabled: boolean = true) {
   const { isAdmin, walletAddress, isLoading: isAdminLoading } = useHackBetaAdmin();
+  const { getAuthHeaders, isReady } = useWalletAuth();
   const [submissions, setSubmissions] = useState<HackBetaSubmission[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchRows = useCallback(async () => {
-    if (!isAdmin || !enabled) {
+    if (!enabled || isAdminLoading) return;
+    if (!isAdmin || !isReady) {
       setSubmissions([]);
       return;
     }
     setIsLoading(true);
     setError(null);
     try {
-      const rows = await hackBetaSubmissionsService.list();
-      setSubmissions(rows);
+      const authHeaders = await getAuthHeaders();
+      const res = await fetch("/api/hack-beta/admin/submissions", {
+        method: "GET",
+        headers: authHeaders,
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || `Failed to load submissions (${res.status})`);
+      }
+      const json = (await res.json()) as { submissions?: HackBetaSubmission[] };
+      setSubmissions(json.submissions ?? []);
     } catch (err) {
       logger.error("[useHackBetaSubmissions] fetch failed:", err);
-      setError("Failed to load submissions");
+      setError(err instanceof Error ? err.message : "Failed to load submissions");
+      setSubmissions([]);
     } finally {
       setIsLoading(false);
     }
-  }, [isAdmin, enabled]);
+  }, [isAdmin, enabled, isAdminLoading, isReady, getAuthHeaders]);
 
   useEffect(() => {
     void fetchRows();
   }, [fetchRows]);
 
+  const patchSubmission = useCallback(
+    async (body: {
+      id: string;
+      status?: HackBetaSubmission["status"];
+      is_favorite?: boolean;
+    }) => {
+      const authHeaders = await getAuthHeaders();
+      const res = await fetch("/api/hack-beta/admin/submissions", {
+        method: "PATCH",
+        headers: {
+          ...authHeaders,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
+        logger.error("[useHackBetaSubmissions] patch failed:", errBody ?? res.status);
+        return false;
+      }
+      return true;
+    },
+    [getAuthHeaders],
+  );
+
   const updateStatus = useCallback(
     async (id: string, status: HackBetaSubmission["status"]) => {
-      const ok = await hackBetaSubmissionsService.updateStatus(id, status);
+      const ok = await patchSubmission({ id, status });
       if (ok) {
         setSubmissions((prev) =>
           prev.map((s) =>
@@ -48,31 +83,34 @@ export function useHackBetaSubmissions(enabled: boolean = true) {
       }
       return ok;
     },
-    [],
+    [patchSubmission],
   );
 
-  const setFavorite = useCallback(async (id: string, isFavorite: boolean) => {
-    const ok = await hackBetaSubmissionsService.setFavorite(id, isFavorite);
-    if (ok) {
-      setSubmissions((prev) =>
-        prev.map((s) =>
-          s.id === id
-            ? {
-                ...s,
-                is_favorite: isFavorite,
-                status: isFavorite ? "approved" : s.status,
-                updated_at: new Date().toISOString(),
-              }
-            : s,
-        ),
-      );
-    }
-    return ok;
-  }, []);
+  const setFavorite = useCallback(
+    async (id: string, isFavorite: boolean) => {
+      const ok = await patchSubmission({ id, is_favorite: isFavorite });
+      if (ok) {
+        setSubmissions((prev) =>
+          prev.map((s) =>
+            s.id === id
+              ? {
+                  ...s,
+                  is_favorite: isFavorite,
+                  status: isFavorite ? "approved" : s.status,
+                  updated_at: new Date().toISOString(),
+                }
+              : s,
+          ),
+        );
+      }
+      return ok;
+    },
+    [patchSubmission],
+  );
 
   return {
     submissions,
-    isLoading,
+    isLoading: isLoading || isAdminLoading,
     error,
     refetch: fetchRows,
     updateStatus,

--- a/lib/hooks/song-cup/useSongCupSubmissions.ts
+++ b/lib/hooks/song-cup/useSongCupSubmissions.ts
@@ -1,79 +1,122 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import {
-  songCupSubmissionsService,
-  type SongCupSubmission,
-} from "@/lib/sdk/supabase/song-cup-submissions";
+import type { SongCupSubmission } from "@/lib/sdk/supabase/song-cup-submissions";
 import { useSongCupAdmin } from "@/lib/hooks/song-cup/useSongCupAdmin";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { logger } from "@/lib/utils/logger";
 
 export function useSongCupSubmissions(enabled: boolean = true) {
   const { isAdmin, walletAddress, isLoading: isAdminLoading } = useSongCupAdmin();
+  const { getAuthHeaders, isReady } = useWalletAuth();
   const [submissions, setSubmissions] = useState<SongCupSubmission[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetch = useCallback(async () => {
-    if (!isAdmin || !enabled) {
+  const fetchRows = useCallback(async () => {
+    if (!enabled || isAdminLoading) return;
+    if (!isAdmin || !isReady) {
       setSubmissions([]);
       return;
     }
     setIsLoading(true);
     setError(null);
     try {
-      const rows = await songCupSubmissionsService.list();
-      setSubmissions(rows);
+      const authHeaders = await getAuthHeaders();
+      const res = await fetch("/api/song-cup/admin/submissions", {
+        method: "GET",
+        headers: authHeaders,
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || `Failed to load submissions (${res.status})`);
+      }
+      const json = (await res.json()) as { submissions?: SongCupSubmission[] };
+      setSubmissions(json.submissions ?? []);
     } catch (err) {
-      logger.error('[useSongCupSubmissions] fetch failed:', err);
-      setError('Failed to load submissions');
+      logger.error("[useSongCupSubmissions] fetch failed:", err);
+      setError(err instanceof Error ? err.message : "Failed to load submissions");
+      setSubmissions([]);
     } finally {
       setIsLoading(false);
     }
-  }, [isAdmin, enabled]);
+  }, [isAdmin, enabled, isAdminLoading, isReady, getAuthHeaders]);
 
   useEffect(() => {
-    fetch();
-  }, [fetch]);
+    void fetchRows();
+  }, [fetchRows]);
 
-  const updateStatus = useCallback(async (id: string, status: SongCupSubmission['status']) => {
-    const ok = await songCupSubmissionsService.updateStatus(id, status);
-    if (ok) {
-      setSubmissions((prev) =>
-        prev.map((s) => (s.id === id ? { ...s, status, updated_at: new Date().toISOString() } : s))
-      );
-    }
-    return ok;
-  }, []);
-
-  const setFavorite = useCallback(async (id: string, isFavorite: boolean) => {
-    const ok = await songCupSubmissionsService.setFavorite(id, isFavorite);
-    if (ok) {
-      setSubmissions((prev) => {
-        const next = prev.map((s) =>
-          s.id === id
-            ? {
-                ...s,
-                is_favorite: isFavorite,
-                status: isFavorite ? "approved" : s.status,
-                updated_at: new Date().toISOString(),
-              }
-            : s,
-        );
-        return [...next].sort((a, b) => {
-          if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;
-          return Date.parse(b.created_at) - Date.parse(a.created_at);
-        });
+  const patchSubmission = useCallback(
+    async (body: {
+      id: string;
+      status?: SongCupSubmission["status"];
+      is_favorite?: boolean;
+    }) => {
+      const authHeaders = await getAuthHeaders();
+      const res = await fetch("/api/song-cup/admin/submissions", {
+        method: "PATCH",
+        headers: {
+          ...authHeaders,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
       });
-    }
-    return ok;
-  }, []);
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
+        logger.error("[useSongCupSubmissions] patch failed:", errBody ?? res.status);
+        return false;
+      }
+      return true;
+    },
+    [getAuthHeaders],
+  );
+
+  const updateStatus = useCallback(
+    async (id: string, status: SongCupSubmission["status"]) => {
+      const ok = await patchSubmission({ id, status });
+      if (ok) {
+        setSubmissions((prev) =>
+          prev.map((s) =>
+            s.id === id ? { ...s, status, updated_at: new Date().toISOString() } : s,
+          ),
+        );
+      }
+      return ok;
+    },
+    [patchSubmission],
+  );
+
+  const setFavorite = useCallback(
+    async (id: string, isFavorite: boolean) => {
+      const ok = await patchSubmission({ id, is_favorite: isFavorite });
+      if (ok) {
+        setSubmissions((prev) => {
+          const next = prev.map((s) =>
+            s.id === id
+              ? {
+                  ...s,
+                  is_favorite: isFavorite,
+                  status: isFavorite ? "approved" : s.status,
+                  updated_at: new Date().toISOString(),
+                }
+              : s,
+          );
+          return [...next].sort((a, b) => {
+            if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;
+            return Date.parse(b.created_at) - Date.parse(a.created_at);
+          });
+        });
+      }
+      return ok;
+    },
+    [patchSubmission],
+  );
 
   return {
     submissions,
-    isLoading,
+    isLoading: isLoading || isAdminLoading,
     error,
-    refetch: fetch,
+    refetch: fetchRows,
     updateStatus,
     setFavorite,
     isAdmin,

--- a/lib/hooks/song-cup/useSongCupSubmissions.ts
+++ b/lib/hooks/song-cup/useSongCupSubmissions.ts
@@ -52,23 +52,32 @@ export function useSongCupSubmissions(enabled: boolean = true) {
       status?: SongCupSubmission["status"];
       is_favorite?: boolean;
     }) => {
-      const authHeaders = await getAuthHeaders();
-      const res = await fetch("/api/song-cup/admin/submissions", {
-        method: "PATCH",
-        headers: {
-          ...authHeaders,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
-        logger.error("[useSongCupSubmissions] patch failed:", errBody ?? res.status);
+      if (!isReady) {
+        logger.error("[useSongCupSubmissions] patch skipped: wallet auth not ready");
         return false;
       }
-      return true;
+      try {
+        const authHeaders = await getAuthHeaders();
+        const res = await fetch("/api/song-cup/admin/submissions", {
+          method: "PATCH",
+          headers: {
+            ...authHeaders,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const errBody = (await res.json().catch(() => null)) as { error?: string } | null;
+          logger.error("[useSongCupSubmissions] patch failed:", errBody ?? res.status);
+          return false;
+        }
+        return true;
+      } catch (err) {
+        logger.error("[useSongCupSubmissions] patch exception:", err);
+        return false;
+      }
     },
-    [getAuthHeaders],
+    [getAuthHeaders, isReady],
   );
 
   const updateStatus = useCallback(
@@ -114,7 +123,7 @@ export function useSongCupSubmissions(enabled: boolean = true) {
 
   return {
     submissions,
-    isLoading: isLoading || isAdminLoading,
+    isLoading: isLoading || isAdminLoading || (isAdmin && !isReady),
     error,
     refetch: fetchRows,
     updateStatus,
@@ -122,5 +131,6 @@ export function useSongCupSubmissions(enabled: boolean = true) {
     isAdmin,
     walletAddress,
     isAdminLoading,
+    isReady,
   };
 }

--- a/lib/sdk/supabase/hack-beta-admin.ts
+++ b/lib/sdk/supabase/hack-beta-admin.ts
@@ -1,0 +1,82 @@
+import { createServiceClient } from "@/lib/sdk/supabase/service";
+import type { HackBetaSubmission } from "@/lib/sdk/supabase/hack-beta-submissions";
+import type { HackBetaSettings } from "@/lib/sdk/supabase/hack-beta-settings";
+import { serverLogger } from "@/lib/utils/logger";
+
+/** Service-role list of all Hack Beta submissions (bypasses RLS). Server-only. */
+export async function listHackBetaSubmissionsAsAdmin(): Promise<HackBetaSubmission[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("hack_beta_submissions")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    serverLogger.error("[hackBetaAdmin] list error:", error);
+    throw new Error(error.message);
+  }
+  return (data ?? []) as HackBetaSubmission[];
+}
+
+export async function updateHackBetaSubmissionStatusAsAdmin(
+  id: string,
+  status: HackBetaSubmission["status"],
+): Promise<boolean> {
+  const supabase = createServiceClient();
+  const { error } = await supabase
+    .from("hack_beta_submissions")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    serverLogger.error("[hackBetaAdmin] updateStatus error:", error);
+    return false;
+  }
+  return true;
+}
+
+export async function setHackBetaSubmissionFavoriteAsAdmin(
+  id: string,
+  isFavorite: boolean,
+): Promise<boolean> {
+  const supabase = createServiceClient();
+  const updates: Record<string, unknown> = {
+    is_favorite: isFavorite,
+    updated_at: new Date().toISOString(),
+  };
+  if (isFavorite) updates.status = "approved";
+
+  const { error } = await supabase
+    .from("hack_beta_submissions")
+    .update(updates)
+    .eq("id", id);
+
+  if (error) {
+    serverLogger.error("[hackBetaAdmin] setFavorite error:", error);
+    return false;
+  }
+  return true;
+}
+
+export async function updateHackBetaMixtapeUrlAsAdmin(
+  url: string | null,
+  updatedBy: string,
+): Promise<HackBetaSettings | null> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("hack_beta_settings")
+    .update({
+      mixtape_playlist_url: url?.trim() || null,
+      updated_at: new Date().toISOString(),
+      updated_by: updatedBy.toLowerCase(),
+    })
+    .eq("id", "default")
+    .select("*")
+    .single();
+
+  if (error) {
+    serverLogger.error("[hackBetaAdmin] updateMixtapeUrl error:", error);
+    return null;
+  }
+  return data as HackBetaSettings;
+}

--- a/lib/sdk/supabase/song-cup-admin.ts
+++ b/lib/sdk/supabase/song-cup-admin.ts
@@ -1,0 +1,59 @@
+import { createServiceClient } from "@/lib/sdk/supabase/service";
+import type { SongCupSubmission } from "@/lib/sdk/supabase/song-cup-submissions";
+import { serverLogger } from "@/lib/utils/logger";
+
+/** Service-role list of all Song Cup submissions (bypasses RLS). Server-only. */
+export async function listSongCupSubmissionsAsAdmin(): Promise<SongCupSubmission[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("song_cup_submissions")
+    .select("*")
+    .order("is_favorite", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    serverLogger.error("[songCupAdmin] list error:", error);
+    throw new Error(error.message);
+  }
+  return (data ?? []) as SongCupSubmission[];
+}
+
+export async function updateSongCupSubmissionStatusAsAdmin(
+  id: string,
+  status: SongCupSubmission["status"],
+): Promise<boolean> {
+  const supabase = createServiceClient();
+  const { error } = await supabase
+    .from("song_cup_submissions")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    serverLogger.error("[songCupAdmin] updateStatus error:", error);
+    return false;
+  }
+  return true;
+}
+
+export async function setSongCupSubmissionFavoriteAsAdmin(
+  id: string,
+  isFavorite: boolean,
+): Promise<boolean> {
+  const supabase = createServiceClient();
+  const updates: Record<string, unknown> = {
+    is_favorite: isFavorite,
+    updated_at: new Date().toISOString(),
+  };
+  if (isFavorite) updates.status = "approved";
+
+  const { error } = await supabase
+    .from("song_cup_submissions")
+    .update(updates)
+    .eq("id", id);
+
+  if (error) {
+    serverLogger.error("[songCupAdmin] setFavorite error:", error);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Admin Hack Beta / Song Cup submission pages could unlock the UI but showed **no pending rows** because browser Supabase (anon) RLS only exposes `approved` without a Supabase JWT `app_metadata.wallet_address` (Privy auth never sets that).
- Added wallet-auth admin APIs that verify the signer, check the TS admin wallet list, and read/update via the service role.
- Wired admin hooks (list / approve-reject / favorite) and Hack Beta mixtape settings update to those APIs.
- Registered BotID deep analysis on admin PATCH routes.

## Test plan
- [ ] As admin SCA, open `/chones/hack-beta/submissions` → sign auth prompt if asked → pending demos appear.
- [ ] Approve / Reject / favorite a Hack Beta submission and confirm it updates.
- [ ] Save mixtape playlist URL as admin and confirm it persists.
- [ ] As admin, open `/songchain/song-cup/submissions` → pending entries appear; approve/reject/favorite works.
- [ ] Non-admin wallet still gets 403 from admin APIs / no review UI.


Made with [Cursor](https://cursor.com)