### PR TITLE
fix: Hack Beta media thumbnails on admin + gallery

### DIFF
--- a/components/chones/hack-beta/HackBetaGallery.tsx
+++ b/components/chones/hack-beta/HackBetaGallery.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Film, Loader2, Star } from "lucide-react";
 import { HackBetaShareToXButton } from "@/components/chones/hack-beta/HackBetaShareToXButton";
+import { HackBetaSubmissionThumbnail } from "@/components/chones/hack-beta/HackBetaSubmissionThumbnail";
 import { useHackBetaApprovedSubmissions } from "@/lib/hooks/hack-beta/useHackBetaApprovedSubmissions";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -48,18 +49,12 @@ export function HackBetaGallery({ className }: HackBetaGalleryProps) {
             className="overflow-hidden rounded-xl border border-border/60 bg-card/40"
           >
             <Link href={`/discover/${s.video_asset_id}`} className="block">
-              {s.thumbnail_url ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={s.thumbnail_url}
-                  alt={s.title || "Demo"}
-                  className="aspect-video w-full bg-black object-cover"
-                />
-              ) : (
-                <div className="flex aspect-video items-center justify-center bg-muted/40">
-                  <Film className="h-8 w-8 text-muted-foreground" />
-                </div>
-              )}
+              <HackBetaSubmissionThumbnail
+                playbackId={s.playback_id}
+                thumbnailUrl={s.thumbnail_url}
+                title={s.title}
+                assetId={s.video_asset_id}
+              />
             </Link>
             <div className="space-y-2 p-3">
               <div className="flex items-start justify-between gap-2">

--- a/components/chones/hack-beta/HackBetaSubmissionReviewCard.tsx
+++ b/components/chones/hack-beta/HackBetaSubmissionReviewCard.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { formatDistanceToNow } from "date-fns";
-import { CheckCircle, ExternalLink, Film, Star, XCircle } from "lucide-react";
+import { CheckCircle, ExternalLink, Star, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { HackBetaSubmissionThumbnail } from "@/components/chones/hack-beta/HackBetaSubmissionThumbnail";
 import type { HackBetaSubmission } from "@/lib/sdk/supabase/hack-beta-submissions";
 import { truncateWalletAddress } from "@/lib/chones/hack-beta/admin-config";
-import { getThumbnailUrl } from "@/lib/utils/thumbnail";
 import { cn } from "@/lib/utils";
 
 type HackBetaSubmissionReviewCardProps = {
@@ -20,42 +18,6 @@ type HackBetaSubmissionReviewCardProps = {
   className?: string;
 };
 
-function useSubmissionThumbnail(
-  thumbnailUrl?: string | null,
-  playbackId?: string | null,
-) {
-  const stored = thumbnailUrl?.trim() || null;
-  const [url, setUrl] = useState<string | null>(stored);
-  const [isLoading, setIsLoading] = useState(!stored && Boolean(playbackId));
-
-  useEffect(() => {
-    if (stored) {
-      setUrl(stored);
-      setIsLoading(false);
-      return;
-    }
-    if (!playbackId) {
-      setUrl(null);
-      setIsLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setIsLoading(true);
-    void getThumbnailUrl(playbackId).then((resolved) => {
-      if (cancelled) return;
-      setUrl(resolved);
-      setIsLoading(false);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [stored, playbackId]);
-
-  return { url, isLoading };
-}
-
 export function HackBetaSubmissionReviewCard({
   submission,
   onApprove,
@@ -63,11 +25,6 @@ export function HackBetaSubmissionReviewCard({
   onReject,
   className,
 }: HackBetaSubmissionReviewCardProps) {
-  const { url: thumbnailSrc, isLoading: thumbnailLoading } = useSubmissionThumbnail(
-    submission.thumbnail_url,
-    submission.playback_id,
-  );
-
   return (
     <article
       className={cn(
@@ -75,20 +32,12 @@ export function HackBetaSubmissionReviewCard({
         className,
       )}
     >
-      {thumbnailSrc ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={thumbnailSrc}
-          alt=""
-          className="aspect-video w-full bg-black object-cover"
-        />
-      ) : thumbnailLoading ? (
-        <Skeleton className="aspect-video w-full rounded-none" />
-      ) : (
-        <div className="flex aspect-video items-center justify-center bg-muted/40">
-          <Film className="h-8 w-8 text-muted-foreground" />
-        </div>
-      )}
+      <HackBetaSubmissionThumbnail
+        playbackId={submission.playback_id}
+        thumbnailUrl={submission.thumbnail_url}
+        title={submission.title}
+        assetId={submission.video_asset_id}
+      />
 
       <div className="flex flex-1 flex-col gap-2 p-3">
         <h4 className="line-clamp-1 text-sm font-semibold">

--- a/components/chones/hack-beta/HackBetaSubmissionThumbnail.tsx
+++ b/components/chones/hack-beta/HackBetaSubmissionThumbnail.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Film } from "lucide-react";
+import VideoThumbnail from "@/components/Videos/VideoThumbnail";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchVideoAssetByAssetId } from "@/lib/utils/video-assets-client";
+import { cn } from "@/lib/utils";
+
+type HackBetaSubmissionThumbnailProps = {
+  playbackId?: string | null;
+  thumbnailUrl?: string | null;
+  title?: string | null;
+  assetId?: string | null;
+  className?: string;
+};
+
+type ResolvedMedia = {
+  playbackId: string | null;
+  thumbnailUrl: string | null;
+};
+
+/**
+ * Resolves submission media the same way Discover / upload history do:
+ * stored thumbnail → video_assets by playback/asset id → Livepeer VTT → brand fallback.
+ */
+export function HackBetaSubmissionThumbnail({
+  playbackId,
+  thumbnailUrl,
+  title,
+  assetId,
+  className,
+}: HackBetaSubmissionThumbnailProps) {
+  const [resolved, setResolved] = useState<ResolvedMedia>({
+    playbackId: playbackId?.trim() || null,
+    thumbnailUrl: thumbnailUrl?.trim() || null,
+  });
+  const [isResolving, setIsResolving] = useState(
+    !playbackId?.trim() && Boolean(assetId?.trim()),
+  );
+
+  useEffect(() => {
+    const storedPlayback = playbackId?.trim() || null;
+    const storedThumb = thumbnailUrl?.trim() || null;
+
+    if (storedPlayback) {
+      setResolved({ playbackId: storedPlayback, thumbnailUrl: storedThumb });
+      setIsResolving(false);
+      return;
+    }
+
+    const id = assetId?.trim();
+    if (!id) {
+      setResolved({ playbackId: null, thumbnailUrl: storedThumb });
+      setIsResolving(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolving(true);
+
+    void fetchVideoAssetByAssetId(id)
+      .then((asset) => {
+        if (cancelled) return;
+        const fromAsset =
+          (asset as { playback_id?: string } | null)?.playback_id?.trim() || null;
+        const thumbFromAsset =
+          storedThumb ||
+          (asset as { thumbnail_url?: string } | null)?.thumbnail_url?.trim() ||
+          (asset as { thumbnailUri?: string } | null)?.thumbnailUri?.trim() ||
+          null;
+        setResolved({ playbackId: fromAsset, thumbnailUrl: thumbFromAsset });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResolved({ playbackId: null, thumbnailUrl: storedThumb });
+      })
+      .finally(() => {
+        if (!cancelled) setIsResolving(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [playbackId, thumbnailUrl, assetId]);
+
+  if (isResolving) {
+    return <Skeleton className={cn("aspect-video w-full rounded-none", className)} />;
+  }
+
+  if (!resolved.playbackId) {
+    return (
+      <div
+        className={cn(
+          "flex aspect-video w-full items-center justify-center bg-muted/40",
+          className,
+        )}
+      >
+        <Film className="h-8 w-8 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("aspect-video w-full overflow-hidden bg-black", className)}>
+      <VideoThumbnail
+        playbackId={resolved.playbackId}
+        src={null}
+        title={title || "Hack Beta demo"}
+        assetId={assetId || undefined}
+        initialThumbnailUrl={resolved.thumbnailUrl || undefined}
+        className="h-full w-full"
+        hidePlayOverlay
+      />
+    </div>
+  );
+}

--- a/components/chones/hack-beta/HackBetaSubmitPanel.tsx
+++ b/components/chones/hack-beta/HackBetaSubmitPanel.tsx
@@ -78,7 +78,10 @@ export function HackBetaSubmitPanel({ className }: HackBetaSubmitPanelProps) {
           title: selected.title,
           description: notes.trim() || selected.description || undefined,
           playback_id: selected.playback_id,
-          thumbnail_url: selected.thumbnailUri || undefined,
+          thumbnail_url:
+            selected.thumbnailUri ||
+            (selected as { thumbnail_url?: string }).thumbnail_url ||
+            undefined,
           grove_url: grove.url,
           grove_hash: grove.hash,
         },


### PR DESCRIPTION
## Summary
- #302 shipped but production still showed Film icons because Livepeer VTT thumbnails often are not available for these assets.
- Admin review cards and the public Hack Beta gallery now use the same `VideoThumbnail` path as Discover (stored URL → video_assets DB → Livepeer → brand fallback), including resolving `playback_id` from `video_asset_id` when needed.
- Submit also persists `thumbnail_url` from `thumbnailUri` or `thumbnail_url` on the selected video.

## Test plan
- [ ] Hard-refresh `/chones/hack-beta/submissions` as admin — pending cards show real video thumbs (or Creative TV fallback), not Film icons.
- [ ] Approve a submission, open `/chones/hack-beta` gallery — approved card shows the same thumbnail and links to `/discover/{assetId}`.
- [ ] New submit still saves and stores a thumbnail when the library video has one.


Made with [Cursor](https://cursor.com)