### PR TITLE
fix(livestream): stop tearing down HLS before it can start

### DIFF
--- a/app/api/livepeer/webhook/route.ts
+++ b/app/api/livepeer/webhook/route.ts
@@ -11,7 +11,10 @@ import {
   finalizeStreamRecordings,
   persistRecordingAsset,
 } from "@/services/livestream-recordings";
-import { markStreamOfflineByStreamId } from "@/services/streams";
+import {
+  markStreamLiveByStreamId,
+  markStreamOfflineByStreamId,
+} from "@/services/streams";
 import { serverLogger } from "@/lib/utils/logger";
 
 export async function POST(request: NextRequest) {
@@ -43,6 +46,11 @@ export async function POST(request: NextRequest) {
       }
       if (asset?.id) {
         await persistRecordingAsset(asset, { streamId });
+      }
+    } else if (event === "stream.started") {
+      if (streamId) {
+        await markStreamLiveByStreamId(streamId);
+        serverLogger.info("Marked stream live from stream.started webhook", { streamId });
       }
     } else if (event === "recording.ready" || event === "stream.idle") {
       if (streamId) {

--- a/app/watch/[playbackId]/WatchClient.tsx
+++ b/app/watch/[playbackId]/WatchClient.tsx
@@ -125,9 +125,10 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
     ok: boolean;
     token?: string;
     gate?: LiveStreamGateInfo;
+    errorMessage?: string;
   }> => {
     if (!playbackId) {
-      return { ok: false };
+      return { ok: false, errorMessage: "No playback ID provided." };
     }
 
     const gateActive = isGateLikelyActive();
@@ -194,7 +195,7 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
 
     const parseJwtResult = async (res: Response): Promise<
       | { ok: true; token: string }
-      | { ok: false; gate?: LiveStreamGateInfo }
+      | { ok: false; gate?: LiveStreamGateInfo; errorMessage?: string }
     > => {
       if (res.ok) {
         const { token } = await res.json();
@@ -221,7 +222,13 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
       }
 
       logger.warn("Failed to sign JWT for stream:", errData);
-      return { ok: false };
+      const message =
+        typeof errData.message === "string" && errData.message.trim()
+          ? errData.message
+          : res.status === 500
+            ? "Playback authorization is misconfigured. Please try again later."
+            : "Unable to authorize playback for this private stream.";
+      return { ok: false, errorMessage: message };
     };
 
     if (jwtRes.status === 404) {
@@ -278,23 +285,44 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         setStreamData(streamRecord as import("@/services/streams").Stream);
       }
 
-      // Happy path — stream is live; JWT required for playback.
+      // Happy path — stream has sources; JWT is required for jwt playbackPolicy streams.
       if (sources && sources.length > 0) {
+        logger.info("[WatchClient] Playback sources ready", {
+          playbackId,
+          sourceCount: sources.length,
+          sourceTypes: sources.map((s) => s.type),
+        });
         try {
           const jwtResult = await requestStreamJwt();
           if (jwtResult.ok && jwtResult.token) {
+            logger.info("[WatchClient] JWT issued for playback", { playbackId });
             setJwt(jwtResult.token);
             setStatus({ kind: "live", sources });
           } else if (jwtResult.gate) {
             setJwt(undefined);
             setStatus({ kind: "metoken-gated", gate: jwtResult.gate, sources });
           } else {
+            // JWT-gated livestreams cannot play without a token — do not mount a black player.
             setJwt(undefined);
-            setStatus({ kind: "live", sources });
+            logger.error("[WatchClient] JWT missing for gated stream; blocking live render", {
+              playbackId,
+              errorMessage: jwtResult.errorMessage,
+            });
+            setStatus({
+              kind: "error",
+              userMessage:
+                jwtResult.errorMessage ??
+                "This stream is private and we couldn't issue a playback token. Please refresh and try again.",
+            });
           }
         } catch (jwtErr) {
           logger.error("Error signing JWT:", jwtErr);
-          setStatus({ kind: "live", sources });
+          setJwt(undefined);
+          setStatus({
+            kind: "error",
+            userMessage:
+              "Unable to authorize playback for this private stream. Please try again.",
+          });
         }
         return;
       }
@@ -349,6 +377,13 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
         setStatus({ kind: "live", sources: status.sources });
       } else if (jwtResult.gate) {
         setStatus({ kind: "metoken-gated", gate: jwtResult.gate, sources: status.sources });
+      } else {
+        setJwt(undefined);
+        setStatus({
+          kind: "error",
+          userMessage:
+            "This stream is private and we couldn't issue a playback token. Please refresh and try again.",
+        });
       }
     } finally {
       setIsChecking(false);
@@ -527,7 +562,10 @@ export default function WatchClient({ initialMarketData, tokenInfo, videoTitle, 
                     jwt={jwt}
                     lowLatency={false}
                     onStalled={() => {
-                      // Stream went idle after we entered live state.
+                      // Only fires after HLS warm-up budget with no playable media.
+                      logger.warn("[WatchClient] Player reported stall; returning to offline poll", {
+                        playbackId,
+                      });
                       setStatus({ kind: "offline-temporary", attempts: 0 });
                     }}
                   />

--- a/components/Live/Broadcast.tsx
+++ b/components/Live/Broadcast.tsx
@@ -36,6 +36,7 @@ import { updateStream } from "@/services/streams";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { walletAuthHeadersToArgs } from "@/lib/auth/require-wallet";
 import { parseStreamProxyFailure } from "@/lib/livepeer/stream-proxy-errors";
+import { getDetailPlaybackSource } from "@/lib/hooks/livepeer/useDetailPlaybackSources";
 import { CreativeBrandOverlay } from "@/components/Player/CreativeBrandOverlay";
 import { FloatingTipHearts } from "@/components/Live/FloatingTipHearts";
 
@@ -146,6 +147,44 @@ async function finalizeStreamRecordings(streamId: string) {
   }
 }
 
+/** Poll until Livepeer reports playable sources (HLS warm-up), or give up. */
+async function waitForPlaybackSources(
+  playbackId: string,
+  opts?: { signal?: AbortSignal; maxAttempts?: number; intervalMs?: number },
+): Promise<boolean> {
+  const maxAttempts = opts?.maxAttempts ?? 15;
+  const intervalMs = opts?.intervalMs ?? 2_000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (opts?.signal?.aborted) return false;
+    try {
+      const sources = await getDetailPlaybackSource(playbackId, {
+        signal: opts?.signal,
+      });
+      if (sources && sources.length > 0) {
+        logger.info("Playback sources ready after WHIP live", {
+          playbackId,
+          attempt,
+          sourceCount: sources.length,
+        });
+        return true;
+      }
+    } catch (err) {
+      if (opts?.signal?.aborted) return false;
+      logger.debug("Playback readiness poll failed:", err);
+    }
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  logger.warn("Playback sources not ready before is_live timeout; marking live anyway", {
+    playbackId,
+    maxAttempts,
+  });
+  return false;
+}
+
 function BroadcastWithControls({
   streamKey,
   streamId: propStreamId,
@@ -185,20 +224,30 @@ function BroadcastWithControls({
 
   const finalizeTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
-  // Sync is_live status with DB; finalize recordings when broadcast ends
+  // Sync is_live with DB only after Livepeer playback is ready (or warm-up budget expires).
+  // Finalize recordings when broadcast ends.
   useEffect(() => {
     if (!creatorAddress) return;
+
+    const abort = new AbortController();
 
     const syncStatus = async () => {
       try {
         const auth = walletAuthHeadersToArgs(await getAuthHeaders());
         if (status === 'live') {
+          if (playbackId) {
+            await waitForPlaybackSources(playbackId, { signal: abort.signal });
+            if (abort.signal.aborted) return;
+          }
+          if (abort.signal.aborted) return;
           await updateStream(
             creatorAddress,
             { is_live: true, last_live_at: new Date().toISOString() },
             auth,
           );
-          logger.info("Stream marked as live in DB");
+          logger.info("Stream marked as live in DB (playback-ready gated)", {
+            playbackId,
+          });
         } else if (status === 'idle' || status === 'error') {
           await updateStream(creatorAddress, { is_live: false, last_live_at: new Date().toISOString() }, auth);
           logger.info("Stream marked as offline in DB");
@@ -211,6 +260,7 @@ function BroadcastWithControls({
           }
         }
       } catch (err) {
+        if (abort.signal.aborted) return;
         logger.error("Failed to sync stream status:", err);
       }
     };
@@ -218,10 +268,11 @@ function BroadcastWithControls({
     void syncStatus();
 
     return () => {
+      abort.abort();
       finalizeTimeoutsRef.current.forEach(clearTimeout);
       finalizeTimeoutsRef.current = [];
     };
-  }, [status, creatorAddress, propStreamId, getAuthHeaders, saveRecording]);
+  }, [status, creatorAddress, propStreamId, playbackId, getAuthHeaders, saveRecording]);
 
   const [isFullscreen, setIsFullscreen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -45,6 +45,9 @@ interface PlayerProps {
   onStalled?: () => void;
 }
 
+/** HLS live warm-up can take ~10–20s; allow headroom before declaring a stall. */
+const HLS_WARMUP_MS = 45_000;
+
 export function Player(props: PlayerProps) {
   const { src, title, playbackId, assetId, jwt, onPlay, onStalled, autoPlay = true, lowLatency = true } = props;
 
@@ -55,36 +58,70 @@ export function Player(props: PlayerProps) {
   const playerId = useRef(Math.random().toString(36).substring(7)).current;
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const stalledTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const hasPlayedRef = useRef(false);
 
-  // Cap livestream manifest loading at 10s and surface stalls to the parent.
+  const clearStalledTimer = useCallback(() => {
+    if (stalledTimerRef.current) {
+      clearTimeout(stalledTimerRef.current);
+      stalledTimerRef.current = null;
+    }
+  }, []);
+
+  const markPlaybackStarted = useCallback(() => {
+    if (hasPlayedRef.current) return;
+    hasPlayedRef.current = true;
+    clearStalledTimer();
+    logger.debug("[Player] Playback started; cleared stall warm-up timer", {
+      playbackId,
+    });
+  }, [clearStalledTimer, playbackId]);
+
+  // Only report a stall if we never reached playable media within the HLS warm-up budget.
   useEffect(() => {
+    hasPlayedRef.current = false;
     if (!onStalled) return;
-    const timer = setTimeout(() => {
-      onStalled();
-    }, 10_000);
-    stalledTimerRef.current = timer;
 
-    return () => {
-      if (stalledTimerRef.current) {
-        clearTimeout(stalledTimerRef.current);
-        stalledTimerRef.current = null;
-      }
-    };
-  }, [src, onStalled]);
+    clearStalledTimer();
+    stalledTimerRef.current = setTimeout(() => {
+      if (hasPlayedRef.current) return;
+      logger.warn("[Player] HLS warm-up exceeded without playback; reporting stall", {
+        playbackId,
+        budgetMs: HLS_WARMUP_MS,
+        hasJwt: Boolean(jwt),
+      });
+      onStalled();
+    }, HLS_WARMUP_MS);
+
+    return () => clearStalledTimer();
+  }, [src, onStalled, playbackId, jwt, clearStalledTimer]);
 
   useEffect(() => {
     const video = containerRef.current?.querySelector("video");
     if (video) {
       videoRef.current = video;
     }
-  }, []);
+  }, [src]);
 
   useEffect(() => {
-    if (!videoRef.current) return;
+    const video = videoRef.current ?? containerRef.current?.querySelector("video");
+    if (!video) return;
+    videoRef.current = video;
 
     const handlePlay = () => {
+      markPlaybackStarted();
       setCurrentPlayingId(assetId || playerId);
       onPlay?.();
+    };
+
+    const handlePlaying = () => {
+      markPlaybackStarted();
+    };
+
+    const handleLoadedData = () => {
+      // First frame / segment available — treat as successful warm-up.
+      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        markPlaybackStarted();
+      }
     };
 
     const handlePause = () => {
@@ -93,16 +130,18 @@ export function Player(props: PlayerProps) {
       }
     };
 
-    videoRef.current.addEventListener("play", handlePlay);
-    videoRef.current.addEventListener("pause", handlePause);
+    video.addEventListener("play", handlePlay);
+    video.addEventListener("playing", handlePlaying);
+    video.addEventListener("loadeddata", handleLoadedData);
+    video.addEventListener("pause", handlePause);
 
     return () => {
-      if (videoRef.current) {
-        videoRef.current.removeEventListener("play", handlePlay);
-        videoRef.current.removeEventListener("pause", handlePause);
-      }
+      video.removeEventListener("play", handlePlay);
+      video.removeEventListener("playing", handlePlaying);
+      video.removeEventListener("loadeddata", handleLoadedData);
+      video.removeEventListener("pause", handlePause);
     };
-  }, [playerId, currentPlayingId, setCurrentPlayingId, assetId, onPlay]);
+  }, [playerId, currentPlayingId, setCurrentPlayingId, assetId, onPlay, src, markPlaybackStarted]);
 
   const safelyPauseCurrentVideo = useCallback(async () => {
     if (videoRef.current) {
@@ -175,11 +214,11 @@ export function Player(props: PlayerProps) {
           playsInline
           controls={false}
           hlsConfig={{
-            manifestLoadingTimeOut: 10_000,
-            manifestLoadingMaxRetry: 2,
-            manifestLoadingRetryDelay: 1_000,
-            levelLoadingTimeOut: 10_000,
-            fragLoadingTimeOut: 10_000,
+            manifestLoadingTimeOut: HLS_WARMUP_MS,
+            manifestLoadingMaxRetry: 6,
+            manifestLoadingRetryDelay: 1_500,
+            levelLoadingTimeOut: 20_000,
+            fragLoadingTimeOut: 20_000,
           }}
         />
 

--- a/lib/hooks/livepeer/useDetailPlaybackSources.ts
+++ b/lib/hooks/livepeer/useDetailPlaybackSources.ts
@@ -87,14 +87,24 @@ export const getDetailPlaybackSource = async (
     }
 
     const res = await response.json();
-    logger.debug("[getDetailPlaybackSource] Playback info:", res);
+    const meta = res?.meta as
+      | { live?: number; source?: Array<{ hrn?: string; type?: string }> }
+      | undefined;
+    logger.info("[getDetailPlaybackSource] Playback info received", {
+      id,
+      type: res?.type,
+      live: meta?.live,
+      sourceCount: meta?.source?.length ?? 0,
+      sourceTypes: meta?.source?.map((s) => s.hrn ?? s.type) ?? [],
+    });
 
     const src = getSrc(res) as Src[];
     logger.debug("[getDetailPlaybackSource] Generated sources:", src);
     if (!src?.length) {
-      logger.error(
-        "[getDetailPlaybackSource] No valid sources generated for ID:",
-        id
+      logger.warn(
+        "[getDetailPlaybackSource] No playable sources yet for ID (stream may still be warming up):",
+        id,
+        { live: meta?.live, sourceCount: meta?.source?.length ?? 0 },
       );
       return null;
     }

--- a/services/streams.ts
+++ b/services/streams.ts
@@ -387,6 +387,30 @@ export interface ActiveStream {
 }
 
 /**
+ * Server-side helper to mark a stream live by Livepeer stream ID.
+ * Used by webhooks when Livepeer reports stream.started; bypasses wallet-auth
+ * because the caller is Livepeer, not an end user.
+ */
+export async function markStreamLiveByStreamId(streamId: string) {
+    const supabase = await createServiceClient();
+    const now = new Date().toISOString();
+
+    const { error } = await supabase
+        .from("streams")
+        .update({
+            is_live: true,
+            last_live_at: now,
+            updated_at: now,
+        })
+        .ilike("stream_id", streamId);
+
+    if (error) {
+        serverLogger.error("Error marking stream live by stream ID:", error);
+        throw new Error(`Failed to mark stream live: ${error.message}`);
+    }
+}
+
+/**
  * Server-side helper to mark a stream offline by Livepeer stream ID.
  * Used by webhooks when Livepeer reports stream.idle; bypasses wallet-auth
  * because the caller is Livepeer, not an end user.


### PR DESCRIPTION
## Summary
- Raise the watch-page stall budget to 45s and clear it on first playable frame so HLS warm-up is not torn down as offline
- Require a JWT before mounting JWT-gated livestream players, and surface clear auth/config errors instead of a black player
- Delay `is_live` until Livepeer playback sources exist, and sync live state from `stream.started` webhooks (keeping `stream.idle` offline)

## Test plan
- [ ] Go live from `/live/[address]` and confirm creator broadcast still connects (WHIP)
- [ ] Open `/watch/[playbackId]` in a second browser and confirm video appears (not offline after ~10s)
- [ ] Viewer DevTools: `/api/internal/playback-info` returns sources; `/api/internal/sign-jwt` returns a token; HLS `index.m3u8` is 200 with `Livepeer-Jwt`
- [ ] Confirm Discover / Live Now only shows the stream after playback sources are ready
- [ ] Confirm MeToken-gated streams still show the gate UI when balance is insufficient
- [ ] Confirm ending the broadcast marks the stream offline (`stream.idle` / stop broadcast)


Made with [Cursor](https://cursor.com)