### PR TITLE
fix: stop MeToken success effect from looping during video upload

### DIFF
--- a/components/UserProfile/RobustMeTokenCreator.tsx
+++ b/components/UserProfile/RobustMeTokenCreator.tsx
@@ -10,7 +10,7 @@
  * 4. Better UX for long blockchain transactions
  */
 
-import { useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -84,6 +84,14 @@ export function RobustMeTokenCreator({ onMeTokenCreated, onClose }: RobustMeToke
   const [assetsDeposited, setAssetsDeposited] = useState('');
   const [assetBalances, setAssetBalances] = useState<Record<string, bigint>>({});
   const [showPendingTransactions, setShowPendingTransactions] = useState(false);
+
+  // Keep the latest callback in a ref so the success effect below can depend on
+  // a stable value instead of re-firing every time the parent re-renders with a
+  // new inline `onMeTokenCreated` reference (React error #185 loop).
+  const onMeTokenCreatedRef = useRef(onMeTokenCreated);
+  useEffect(() => {
+    onMeTokenCreatedRef.current = onMeTokenCreated;
+  }, [onMeTokenCreated]);
 
   const { client } = useSmartAccountClient({});
   const { toast } = useToast();
@@ -169,7 +177,7 @@ export function RobustMeTokenCreator({ onMeTokenCreated, onClose }: RobustMeToke
         description: `Your MeToken "${tokenName}" (${tokenSymbol}) is ready for trading.`,
       });
 
-      onMeTokenCreated?.(state.meTokenAddress, state.txHash, state.meTokenId);
+      onMeTokenCreatedRef.current?.(state.meTokenAddress, state.txHash, state.meTokenId);
 
       // Reset form
       setName('');
@@ -188,7 +196,6 @@ export function RobustMeTokenCreator({ onMeTokenCreated, onClose }: RobustMeToke
     name,
     symbol,
     toast,
-    onMeTokenCreated,
     fetchBalances,
     defaultHub,
     fallbackHubId,


### PR DESCRIPTION
## Summary

Fixes a **React error #185 ("Maximum update depth exceeded")** that crashed the video upload form when a creator created a MeToken mid-upload, wiping the in-progress video and firing the "MeToken created successfully" toast multiple times.

## Root cause

`RobustMeTokenCreator` has a success `useEffect` that calls `onMeTokenCreated(...)`. In `CreateThumbnailForm`, that prop is passed as an **inline arrow function** — a new reference on every render. The inline callback calls `checkUserMeToken()`, which sets state → re-render → new callback identity → the effect's dependency array (which included `onMeTokenCreated`) changed → effect re-fired → toast + `checkUserMeToken()` again → infinite loop.

The MeToken itself was never lost (it's on-chain and synced to Supabase); the crash just unmounted the upload form, which holds all its state in component-local `useState`.

## Fix

In `components/UserProfile/RobustMeTokenCreator.tsx`:

1. Store `onMeTokenCreated` in a `useRef` so the effect reads the latest callback without depending on its identity.
2. Remove `onMeTokenCreated` from the effect's dependency array — the effect now depends only on stable state values and fires **exactly once** per successful creation.

## Test plan

- [ ] Create a MeToken during the video upload flow → success toast appears once, form does not crash, upload state is preserved
- [ ] Typecheck passes for the touched file

## Notes

The upload form's state (`activeStep`, `livepeerAsset`, `videoAsset`, `metadata`) is still component-local, so a hard refresh or unrelated remount can still lose an in-progress upload. That's a separate, larger change (persisting upload state) and is intentionally out of scope here.
